### PR TITLE
Fix Looker crawler lineage dataset ID [sc-3553]

### DIFF
--- a/metaphor/dbt/extractor.py
+++ b/metaphor/dbt/extractor.py
@@ -146,7 +146,7 @@ class DbtExtractor(BaseExtractor):
             dataset.upstream = DatasetUpstream()
             dataset.upstream.source_code_url = model.original_file_path
             dataset.upstream.source_datasets = [
-                self._get_upstream(n, platform, datasets)
+                self._get_upstream(n, datasets, platform, self.account)
                 for n in model.depends_on.nodes
             ]
 
@@ -296,9 +296,14 @@ class DbtExtractor(BaseExtractor):
 
     @staticmethod
     def _get_upstream(
-        node: str, platform: str, datasets: Dict[str, DbtManifestNode]
+        node: str,
+        datasets: Dict[str, DbtManifestNode],
+        platform: str,
+        account: Optional[str],
     ) -> str:
-        dataset_id = DatasetLogicalID()
-        dataset_id.platform = DataPlatform[platform]
-        dataset_id.name = DbtExtractor._get_dataset_name(datasets[node])
+        dataset_id = DatasetLogicalID(
+            platform=DataPlatform[platform],
+            account=account,
+            name=DbtExtractor._get_dataset_name(datasets[node]),
+        )
         return str(EntityId(EntityType.DATASET, dataset_id))

--- a/metaphor/looker/extractor.py
+++ b/metaphor/looker/extractor.py
@@ -136,7 +136,7 @@ class LookerExtractor(BaseExtractor):
             # Snowflake host <account_name>.snowflakecomputing.com
             # see https://docs.looker.com/setup-and-management/database-config/snowflake
             return host.split(".")[0]
-        return
+        return None
 
     def _fetch_dashboards(
         self, config: LookerRunConfig, sdk: Looker31SDK, model_map: Dict[str, Model]

--- a/metaphor/looker/extractor.py
+++ b/metaphor/looker/extractor.py
@@ -131,12 +131,12 @@ class LookerExtractor(BaseExtractor):
         return connection_map
 
     @staticmethod
-    def parse_account(host: str, platform: DataPlatform) -> Optional[str]:
-        if platform == DataPlatform.SNOWFLAKE:
+    def parse_account(host: Optional[str], platform: DataPlatform) -> Optional[str]:
+        if platform == DataPlatform.SNOWFLAKE and host:
             # Snowflake host <account_name>.snowflakecomputing.com
             # see https://docs.looker.com/setup-and-management/database-config/snowflake
             return host.split(".")[0]
-        return None
+        return
 
     def _fetch_dashboards(
         self, config: LookerRunConfig, sdk: Looker31SDK, model_map: Dict[str, Model]

--- a/metaphor/looker/lookml_parser.py
+++ b/metaphor/looker/lookml_parser.py
@@ -24,6 +24,7 @@ class Connection:
     name: str
     platform: DataPlatform
     database: str
+    account: Optional[str]
     default_schema: Optional[str]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.4.17"
+version = "0.4.18"
 description = ""
 authors = ["Metaphor <dev@metaphor.io>"]
 packages = [

--- a/tests/dbt/data/expected_results.json
+++ b/tests/dbt/data/expected_results.json
@@ -79,7 +79,7 @@
       "upstream": {
         "sourceCodeUrl": "models/example/my_second_dbt_model.sql",
         "sourceDatasets": [
-          "DATASET~82D1C5DCAC9512AF99F49318FDC8EAE0"
+          "DATASET~AF64AB4122CD383EA8360D20965ABB67"
         ]
       }
     },
@@ -169,7 +169,7 @@
       "upstream": {
         "sourceCodeUrl": "models/example/trial_model_1.sql",
         "sourceDatasets": [
-          "DATASET~77A301EF532BCAF1F679E5979AE70974"
+          "DATASET~BDB320613577550E8EE6BE295054A8A0"
         ]
       }
     },
@@ -258,7 +258,7 @@
       "upstream": {
         "sourceCodeUrl": "models/example/trial_model_2.sql",
         "sourceDatasets": [
-          "DATASET~4DED9233C6796641B5625158719C55CD"
+          "DATASET~88E2F99BE08491C03619AC3FF0FF07BC"
         ]
       }
     },

--- a/tests/looker/test_extractor.py
+++ b/tests/looker/test_extractor.py
@@ -1,0 +1,15 @@
+from metaphor.models.metadata_change_event import DataPlatform
+
+from metaphor.looker.extractor import LookerExtractor, LookerRunConfig
+
+
+def test_parse_account(test_root_dir):
+    assert (
+        LookerExtractor.parse_account(
+            "account.snowflakecomputing.com", DataPlatform.SNOWFLAKE
+        )
+        == "account"
+    )
+
+    assert LookerExtractor.parse_account("account", DataPlatform.SNOWFLAKE) == "account"
+    assert LookerExtractor.parse_account("account", DataPlatform.POSTGRESQL) is None

--- a/tests/looker/test_extractor.py
+++ b/tests/looker/test_extractor.py
@@ -1,6 +1,6 @@
 from metaphor.models.metadata_change_event import DataPlatform
 
-from metaphor.looker.extractor import LookerExtractor, LookerRunConfig
+from metaphor.looker.extractor import LookerExtractor
 
 
 def test_parse_account(test_root_dir):

--- a/tests/looker/test_lookml_parser.py
+++ b/tests/looker/test_lookml_parser.py
@@ -12,6 +12,7 @@ connection_map = {
         name="snowflake",
         platform=DataPlatform.SNOWFLAKE,
         database="db",
+        account="account",
         default_schema="schema",
     )
 }


### PR DESCRIPTION
### Why?

Since we added "account" to Snowflake DatasetID, we need to also update the lineage references to add account info

### What?

- Update lineage reference  in DBT and LOOKER to add "account"  to DatasetID

### Checklist

- [ ] I have tested that the changes in this PR work as expected
- [x] I have added/updated tests that exercise the critical code paths in this diff
