### PR TITLE
Fix datasetID account

### DIFF
--- a/metaphor/looker/lookml_parser.py
+++ b/metaphor/looker/lookml_parser.py
@@ -92,7 +92,9 @@ class Explore:
 
         return EntityId(
             EntityType.DATASET,
-            DatasetLogicalID(name=full_name, platform=connection.platform),
+            DatasetLogicalID(
+                name=full_name, platform=connection.platform, account=connection.account
+            ),
         )
 
     @staticmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.4.18"
+version = "0.4.19"
 description = ""
 authors = ["Metaphor <dev@metaphor.io>"]
 packages = [

--- a/tests/looker/test_lookml_parser.py
+++ b/tests/looker/test_lookml_parser.py
@@ -41,7 +41,9 @@ def test_basic(test_root_dir):
                         EntityId(
                             EntityType.DATASET,
                             DatasetLogicalID(
-                                name="db.schema.view1", platform=DataPlatform.SNOWFLAKE
+                                name="db.schema.view1",
+                                platform=DataPlatform.SNOWFLAKE,
+                                account="account",
                             ),
                         )
                     },
@@ -67,13 +69,17 @@ def test_join(test_root_dir):
                         EntityId(
                             EntityType.DATASET,
                             DatasetLogicalID(
-                                name="db.schema.view1", platform=DataPlatform.SNOWFLAKE
+                                name="db.schema.view1",
+                                platform=DataPlatform.SNOWFLAKE,
+                                account="account",
                             ),
                         ),
                         EntityId(
                             EntityType.DATASET,
                             DatasetLogicalID(
-                                name="db.schema2.view2", platform=DataPlatform.SNOWFLAKE
+                                name="db.schema2.view2",
+                                platform=DataPlatform.SNOWFLAKE,
+                                account="account",
                             ),
                         ),
                     },
@@ -99,7 +105,9 @@ def test_explore_in_view(test_root_dir):
                         EntityId(
                             EntityType.DATASET,
                             DatasetLogicalID(
-                                name="db.schema.view1", platform=DataPlatform.SNOWFLAKE
+                                name="db.schema.view1",
+                                platform=DataPlatform.SNOWFLAKE,
+                                account="account",
                             ),
                         )
                     },
@@ -125,7 +133,9 @@ def test_derived_table(test_root_dir):
                         EntityId(
                             EntityType.DATASET,
                             DatasetLogicalID(
-                                name="db.schema.table1", platform=DataPlatform.SNOWFLAKE
+                                name="db.schema.table1",
+                                platform=DataPlatform.SNOWFLAKE,
+                                account="account",
                             ),
                         )
                     },
@@ -138,7 +148,9 @@ def test_derived_table(test_root_dir):
                         EntityId(
                             EntityType.DATASET,
                             DatasetLogicalID(
-                                name="db.schema.table1", platform=DataPlatform.SNOWFLAKE
+                                name="db.schema.table1",
+                                platform=DataPlatform.SNOWFLAKE,
+                                account="account",
                             ),
                         )
                     },


### PR DESCRIPTION
### Why?

Previous fix https://github.com/MetaphorData/connectors/pull/30 didn't actually filled the account in DatasetId, fixed it here

### What?

- Add account in DatasetId 
- Test run crawler locally, verify the generated dataset ID matches snowflake crawler

### Checklist

- [x] I have tested that the changes in this PR work as expected
- [x] I have added/updated tests that exercise the critical code paths in this diff
