### PR TITLE
Redshift crawler privilege error [sc-3633]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.4.23"
+version = "0.4.24"
 description = ""
 authors = ["Metaphor <dev@metaphor.io>"]
 packages = [


### PR DESCRIPTION
### Why?

`InsufficientPrivilegeError: Operation not allowed on schema "pg_internal"` .
pg_internal can't be accessed by user account, and we shouldn't crawl its metadata anyway. 

### What?

- Exclude postgres internal schemas from crawler.

### Checklist

- [x] I have tested that the changes in this PR work as expected
- [ ] I have added/updated tests that exercise the critical code paths in this diff
