### PR TITLE
Fix DBT manifest test metadata parsing error

### DIFF
--- a/metaphor/dbt/dbt_model.py
+++ b/metaphor/dbt/dbt_model.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 from serde import deserialize
 from serde.json import from_json
@@ -19,12 +19,18 @@ class ManifestMetadata:
 class ManifestTestMetadata:
     @deserialize
     @dataclass
-    class Kwargs:
+    class KwargsColumn:
         column_name: str
         model: str
 
+    @deserialize
+    @dataclass
+    class KwargsColumns:
+        combination_of_columns: List[str]
+        model: str
+
     name: str
-    kwargs: Kwargs
+    kwargs: Union[KwargsColumn, KwargsColumns]
 
 
 @deserialize

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.4.24"
+version = "0.4.25"
 description = ""
 authors = ["Metaphor <dev@metaphor.io>"]
 packages = [

--- a/tests/dbt/data/expected_results.json
+++ b/tests/dbt/data/expected_results.json
@@ -9,7 +9,18 @@
           {
             "fieldPath": "id",
             "tests": [
-              "unique",
+              "unique"
+            ]
+          },
+          {
+            "fieldPath": "f1",
+            "tests": [
+              "not_null"
+            ]
+          },
+          {
+            "fieldPath": "f2",
+            "tests": [
               "not_null"
             ]
           }

--- a/tests/dbt/data/manifest.json
+++ b/tests/dbt/data/manifest.json
@@ -480,7 +480,10 @@
         "namespace": null,
         "name": "not_null",
         "kwargs": {
-          "column_name": "id",
+          "combination_of_columns": [
+            "f1",
+            "f2"
+          ],
           "model": "{{ ref('my_first_dbt_model') }}"
         }
       },


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- ☝️ give your PR a short, but descriptive title. -->

### Why?

dbt crawler is failing to parse the output of the newly added shopify dbt project: https://github.com/MetaphorData/dbt/pull/19
```
2021-09-28 06:07:22,736 ERROR - Read manifest json error: 'column_name'
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/***/dbt/extractor.py", line 66, in extract
    self._manifest = DbtManifest.from_json_file(config.manifest)
  File "/usr/local/lib/python3.7/site-packages/***/dbt/dbt_model.py", line 71, in from_json_file
    return from_json(cls, fin.read())  # type: ignore
  File "/usr/local/lib/python3.7/site-packages/serde/json.py", line 29, in from_json
    return from_dict(c, de.deserialize(s, **opts), reuse_instances=False)
  File "/usr/local/lib/python3.7/site-packages/serde/de.py", line 311, in from_dict
    return from_obj(cls, o, named=True, reuse_instances=reuse_instances)
  File "/usr/local/lib/python3.7/site-packages/serde/de.py", line 248, in from_obj
    return serde_scope.funcs[FROM_DICT](o, reuse_instances=reuse_instances)
  File "<string>", line 28, in from_dict
  File "<string>", line 28, in <dictcomp>
  File "<string>", line 40, in from_dict
  File "<string>", line 18, in from_dict
  File "<string>", line 14, in from_dict
KeyError: 'column_name'
```

### What?

Change the model for `test_metadata.kwargs` to a union to accept both single- & multi-column format.

Tested locally:
```
$ python -m metaphor.dbt ~/Desktop/local/dbt.yml 
2021-09-28 06:16:57,677 INFO - Starting extractor DbtExtractor
2021-09-28 06:16:57,678 INFO - Fetching metadata from DBT repo
2021-09-28 06:16:57,702 INFO - Fetched 28 entities
```

### Checklist

- [x] I have tested that the changes in this PR work as expected
- [ ] I have added/updated tests that exercise the critical code paths in this diff
