### PR TITLE
Use default placeholder value when column native type is not set

### DIFF
--- a/metaphor/dbt/extractor.py
+++ b/metaphor/dbt/extractor.py
@@ -143,7 +143,7 @@ class DbtExtractor(BaseExtractor):
             column_name = col.name.lower()
             field = self._init_field(dataset, column_name)
             field.description = col.description
-            field.native_type = col.data_type
+            field.native_type = "Not Set" if col.data_type is None else col.data_type
 
             field_doc = self._init_field_doc(dataset, column_name)
             field_doc.documentation = col.description
@@ -209,7 +209,7 @@ class DbtExtractor(BaseExtractor):
             column_name = col.name.lower()
             field = self._init_field(dataset, column_name)
             field.description = col.comment
-            field.native_type = col.type
+            field.native_type = "Not Set" if col.type is None else col.type
 
             field_doc = self._init_field_doc(dataset, column_name)
             field_doc.documentation = col.comment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.4.25"
+version = "0.4.26"
 description = ""
 authors = ["Metaphor <dev@metaphor.io>"]
 packages = [

--- a/tests/dbt/data/catalog.json
+++ b/tests/dbt/data/catalog.json
@@ -18,7 +18,7 @@
       },
       "columns": {
         "ID": {
-          "type": "NUMBER",
+          "type": null,
           "comment": null,
           "index": 1,
           "name": "ID"

--- a/tests/dbt/data/expected_results.json
+++ b/tests/dbt/data/expected_results.json
@@ -36,7 +36,7 @@
         "fields": [
           {
             "fieldPath": "id",
-            "nativeType": "NUMBER"
+            "nativeType": "Not Set"
           }
         ],
         "schemaType": "SQL",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- ☝️ give your PR a short, but descriptive title. -->

### Why?

dbt's catalog may sometimes contain `null` as column type. This causes an issue when ingesting the MCEs which expects `nativeType` to be an non-empty string.

### What?

As titled.

### Checklist

- [x] I have tested that the changes in this PR work as expected
- [ ] I have added/updated tests that exercise the critical code paths in this diff
