### PR TITLE
Log non fetal issues in snowflake usage crawler [sc-3635]

### DIFF
--- a/metaphor/bigquery/extractor.py
+++ b/metaphor/bigquery/extractor.py
@@ -31,7 +31,7 @@ from metaphor.models.metadata_change_event import (
 from metaphor.common.event_util import EventUtil
 from metaphor.common.extractor import BaseExtractor, RunConfig
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 

--- a/metaphor/common/api_sink.py
+++ b/metaphor/common/api_sink.py
@@ -8,7 +8,7 @@ from serde import deserialize
 
 from .sink import Sink
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 

--- a/metaphor/common/event_util.py
+++ b/metaphor/common/event_util.py
@@ -15,7 +15,7 @@ from metaphor.models.metadata_change_event import (
 
 from metaphor import models
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 

--- a/metaphor/common/extractor.py
+++ b/metaphor/common/extractor.py
@@ -13,7 +13,7 @@ from smart_open import open
 from .api_sink import ApiSink, ApiSinkConfig
 from .file_sink import FileSink, FileSinkConfig
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 

--- a/metaphor/common/file_sink.py
+++ b/metaphor/common/file_sink.py
@@ -10,7 +10,7 @@ from serde import deserialize
 from .s3 import write_file
 from .sink import Sink
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 

--- a/metaphor/common/sink.py
+++ b/metaphor/common/sink.py
@@ -7,7 +7,7 @@ from metaphor.models.metadata_change_event import MetadataChangeEvent
 
 from .event_util import EventUtil
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 

--- a/metaphor/dbt/extractor.py
+++ b/metaphor/dbt/extractor.py
@@ -34,7 +34,7 @@ from .dbt_model import (
     ManifestTestMetadata,
 )
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 

--- a/metaphor/google_directory/extractor.py
+++ b/metaphor/google_directory/extractor.py
@@ -21,7 +21,7 @@ from smart_open import open
 from metaphor.common.event_util import EventUtil
 from metaphor.common.extractor import BaseExtractor, RunConfig
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 # If modifying these scopes, delete the file token.json.

--- a/metaphor/looker/extractor.py
+++ b/metaphor/looker/extractor.py
@@ -28,7 +28,7 @@ from metaphor.common.event_util import EventUtil
 from metaphor.common.extractor import BaseExtractor, RunConfig
 from metaphor.looker.lookml_parser import Connection, Model, parse_models
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 

--- a/metaphor/looker/lookml_parser.py
+++ b/metaphor/looker/lookml_parser.py
@@ -15,7 +15,7 @@ from metaphor.models.metadata_change_event import DataPlatform, DatasetLogicalID
 
 from metaphor.common.entity_id import EntityId, EntityType
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 

--- a/metaphor/postgresql/extractor.py
+++ b/metaphor/postgresql/extractor.py
@@ -28,7 +28,7 @@ from metaphor.models.metadata_change_event import (
 
 from metaphor.common.extractor import BaseExtractor, RunConfig
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 _ignored_dbs = ["template0", "template1", "rdsadmin"]

--- a/metaphor/slack_directory/extractor.py
+++ b/metaphor/slack_directory/extractor.py
@@ -21,7 +21,7 @@ from metaphor.common.extractor import BaseExtractor, RunConfig
 
 logging.basicConfig(level=logging.INFO)
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 

--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -30,7 +30,7 @@ from serde import deserialize
 
 from metaphor.common.extractor import BaseExtractor, RunConfig
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.4.27"
+version = "0.4.28"
 description = ""
 authors = ["Metaphor <dev@metaphor.io>"]
 packages = [


### PR DESCRIPTION
### Why?

To avoid flooding the log with error and causing confusion https://app.shortcut.com/metaphor-data/story/3635/log-non-fetal-issues-in-snowflake-usage-crawler-as-warning-instead-of-error

### What?

- Adopt best practice to getLogger with module name, instead of getting the root logger
- Disable the error logging from sql_metadata, replace with own logging

### Checklist

- [x] I have tested that the changes in this PR work as expected
- [ ] I have added/updated tests that exercise the critical code paths in this diff
