### PR TITLE
Limit Snowflake connector to extract metadata only from the database specified in the config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.5.0"
+version = "0.5.1"
 description = ""
 authors = ["Metaphor <dev@metaphor.io>"]
 packages = [


### PR DESCRIPTION


<!-- markdownlint-disable MD041 -->
<!-- ☝️ give your PR a short, but descriptive title. -->

### Why?

Snowflake connector currently will scan all tables/views from all databases regardless what's specified in the config.

### What?

As titled. We can introduce a list of allowed databases in the config file as a breaking change in 0.6:  https://github.com/MetaphorData/connectors/issues/13

Note: While the behavior is backward incompatible, it's considered as a bug fix. 

Verified by running it locally:
```
$ python -m metaphor.snowflake ~/Desktop/local/snowflake.yml
2021-10-04 21:18:57,948 INFO - query: [USE ACME]
...
2021-10-04 21:19:31,522 INFO - Fetched 43 entities
```

### Checklist

- [x] I have tested that the changes in this PR work as expected
- [ ] I have added/updated tests that exercise the critical code paths in this diff
