### PR TITLE
bump version for dbt crawler

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.5.1"
+version = "0.5.2"
 description = ""
 authors = ["Metaphor <dev@metaphor.io>"]
 packages = [


### PR DESCRIPTION
### Why?

Forgot to bump version 😞  in https://github.com/MetaphorData/connectors/pull/47

### What?

Bump version to 0.5.2

### Checklist

- [ ] I have tested that the changes in this PR work as expected
- [ ] I have added/updated tests that exercise the critical code paths in this diff
