### PR TITLE
Rename postgres crawler [sc-3946]

### DIFF
--- a/metaphor/bigquery/extractor.py
+++ b/metaphor/bigquery/extractor.py
@@ -70,7 +70,7 @@ class BigQueryExtractor(BaseExtractor):
 
     BYTES_PER_MEGABYTES = 1024 * 1024
 
-    async def extract(self, config: RunConfig) -> List[MetadataChangeEvent]:
+    async def extract(self, config: BigQueryRunConfig) -> List[MetadataChangeEvent]:
         assert isinstance(config, BigQueryExtractor.config_class())
 
         logger.info("Fetching metadata from BigQuery")

--- a/metaphor/postgresql/__main__.py
+++ b/metaphor/postgresql/__main__.py
@@ -1,6 +1,6 @@
 from metaphor.common.cli import cli_main
 
-from .extractor import PostgresqlExtractor, PostgresqlRunConfig
+from .extractor import PostgreSQLExtractor, PostgreSQLRunConfig
 
 if __name__ == "__main__":
-    cli_main("PostgreSQL metadata extractor", PostgresqlRunConfig, PostgresqlExtractor)
+    cli_main("PostgreSQL metadata extractor", PostgreSQLRunConfig, PostgreSQLExtractor)

--- a/metaphor/postgresql/extractor.py
+++ b/metaphor/postgresql/extractor.py
@@ -42,7 +42,7 @@ _ignored_schemas = [
 
 @deserialize
 @dataclass
-class PostgresqlRunConfig(RunConfig):
+class PostgreSQLRunConfig(RunConfig):
     host: str
     database: str
     user: str
@@ -52,18 +52,18 @@ class PostgresqlRunConfig(RunConfig):
     redshift: bool = False  # whether the target is redshift or postgresql
 
 
-class PostgresqlExtractor(BaseExtractor):
+class PostgreSQLExtractor(BaseExtractor):
     """PostgreSQL metadata extractor"""
 
     @staticmethod
     def config_class():
-        return PostgresqlRunConfig
+        return PostgreSQLRunConfig
 
     def __init__(self):
         self._datasets: Dict[str, Dataset] = {}
 
-    async def extract(self, config: PostgresqlRunConfig) -> List[MetadataChangeEvent]:
-        assert isinstance(config, PostgresqlExtractor.config_class())
+    async def extract(self, config: PostgreSQLRunConfig) -> List[MetadataChangeEvent]:
+        assert isinstance(config, PostgreSQLExtractor.config_class())
 
         platform = DataPlatform.REDSHIFT if config.redshift else DataPlatform.POSTGRESQL
         logger.info(f"Fetching metadata from {platform} host {config.host}")
@@ -100,7 +100,7 @@ class PostgresqlExtractor(BaseExtractor):
         return f"{db}.{schema}.{table}".lower()
 
     @staticmethod
-    async def _connect_database(config: PostgresqlRunConfig, database: str):
+    async def _connect_database(config: PostgreSQLRunConfig, database: str):
         logger.info(f"Connecting to DB {database}")
         return await asyncpg.connect(
             host=config.host,
@@ -181,7 +181,7 @@ class PostgresqlExtractor(BaseExtractor):
             name,
         )
         for column in results:
-            dataset.schema.fields.append(PostgresqlExtractor._build_field(column))
+            dataset.schema.fields.append(PostgreSQLExtractor._build_field(column))
 
     @staticmethod
     async def _fetch_constraints(conn, schema: str, name: str, dataset: Dataset):
@@ -210,7 +210,7 @@ class PostgresqlExtractor(BaseExtractor):
         )
         if results:
             for constraint in results:
-                PostgresqlExtractor._build_constraint(
+                PostgreSQLExtractor._build_constraint(
                     constraint, dataset.schema.sql_schema
                 )
 
@@ -264,7 +264,7 @@ class PostgresqlExtractor(BaseExtractor):
             foreign_key = ForeignKey()
             foreign_key.field_path = constraint["key_columns"]
             foreign_key.parent = DatasetLogicalID()
-            foreign_key.parent.name = PostgresqlExtractor._dataset_name(
+            foreign_key.parent.name = PostgreSQLExtractor._dataset_name(
                 constraint["constraint_db"],
                 constraint["constraint_schema"],
                 constraint["constraint_table"],

--- a/metaphor/slack_directory/extractor.py
+++ b/metaphor/slack_directory/extractor.py
@@ -40,7 +40,7 @@ class SlackRunConfig(RunConfig):
     include_restricted: bool = False
 
     # Exclude the default Slack bot, which is weirdly not marked as "is_bot".
-    excluded_ids: Set[str] = field(default_factory=lambda: set(["USLACKBOT"]))
+    excluded_ids: Set[str] = field(default_factory=lambda: {"USLACKBOT"})
 
 
 def list_all_users(config: SlackRunConfig) -> List[Dict]:
@@ -62,7 +62,7 @@ class SlackExtractor(BaseExtractor):
     def config_class():
         return SlackRunConfig
 
-    async def extract(self, config: RunConfig) -> List[MetadataChangeEvent]:
+    async def extract(self, config: SlackRunConfig) -> List[MetadataChangeEvent]:
         assert isinstance(config, SlackExtractor.config_class())
 
         logger.info("Fetching directory data from Slack")

--- a/tests/postgresql/test_config.py
+++ b/tests/postgresql/test_config.py
@@ -1,12 +1,12 @@
-from metaphor.postgresql.extractor import PostgresqlRunConfig
+from metaphor.postgresql.extractor import PostgreSQLRunConfig
 
 
 def test_json_config(test_root_dir):
-    config = PostgresqlRunConfig.from_json_file(
+    config = PostgreSQLRunConfig.from_json_file(
         f"{test_root_dir}/postgresql/config.json"
     )
 
-    assert config == PostgresqlRunConfig(
+    assert config == PostgreSQLRunConfig(
         host="host",
         database="database",
         user="user",
@@ -18,11 +18,11 @@ def test_json_config(test_root_dir):
 
 
 def test_yaml_config(test_root_dir):
-    config = PostgresqlRunConfig.from_yaml_file(
+    config = PostgreSQLRunConfig.from_yaml_file(
         f"{test_root_dir}/postgresql/config.yml"
     )
 
-    assert config == PostgresqlRunConfig(
+    assert config == PostgreSQLRunConfig(
         host="host",
         database="database",
         user="user",


### PR DESCRIPTION
### Why?

Better naming, https://github.com/MetaphorData/connectors/issues/13

### What?

- Rename `PostgresqlExtractor` & `PostgresqlRunConfig` to `PostgreSQLExtractor` & `PostgreSQLRunConfig`

### Checklist

- [x] I have tested that the changes in this PR work as expected
- [ ] I have added/updated tests that exercise the critical code paths in this diff
