### PR TITLE
Drop dataset virtual view dual writing in [sc-3948]

### DIFF
--- a/tests/looker/test_lookml_parser.py
+++ b/tests/looker/test_lookml_parser.py
@@ -61,9 +61,6 @@ def test_basic(test_root_dir):
             explores={
                 "explore1": Explore(
                     name="explore1",
-                    description="description",
-                    label="label",
-                    upstream_datasets={dataset_id},
                 )
             }
         )
@@ -135,9 +132,6 @@ def test_join(test_root_dir):
             explores={
                 "explore1": Explore(
                     name="explore1",
-                    description="description",
-                    label="label",
-                    upstream_datasets={dataset_id1, dataset_id2},
                 )
             }
         )
@@ -228,9 +222,6 @@ def test_explore_in_view(test_root_dir):
             explores={
                 "explore1": Explore(
                     name="explore1",
-                    description="description",
-                    label="label",
-                    upstream_datasets={dataset_id},
                 )
             }
         )
@@ -303,48 +294,12 @@ def test_derived_table(test_root_dir):
             explores={
                 "explore1": Explore(
                     name="explore1",
-                    upstream_datasets={
-                        EntityId(
-                            type=EntityType.DATASET,
-                            logicalId=DatasetLogicalID(
-                                account="account",
-                                name="db.schema.table1",
-                                platform=DataPlatform.SNOWFLAKE,
-                            ),
-                        )
-                    },
-                    description="description",
-                    label="label",
                 ),
                 "explore2": Explore(
                     name="explore2",
-                    upstream_datasets={
-                        EntityId(
-                            type=EntityType.DATASET,
-                            logicalId=DatasetLogicalID(
-                                account="account",
-                                name="db.schema.table1",
-                                platform=DataPlatform.SNOWFLAKE,
-                            ),
-                        )
-                    },
-                    description="description",
-                    label="label",
                 ),
                 "explore3": Explore(
                     name="explore3",
-                    upstream_datasets={
-                        EntityId(
-                            type=EntityType.DATASET,
-                            logicalId=DatasetLogicalID(
-                                account="account",
-                                name="db.schema.table1",
-                                platform=DataPlatform.SNOWFLAKE,
-                            ),
-                        )
-                    },
-                    description="description3",
-                    label="label3",
                 ),
             }
         )


### PR DESCRIPTION
### Why?

Dashboard upstream should only point to looker explore, not directly to dataset anymore, this can cause confusion to user.
Part of https://github.com/MetaphorData/connectors/issues/13

### What?

- remove the `upstreamDatasets` in DashboardLineage
- Fix `upstreamVirtualView` ids with full qualified name

Generated MCE, previous:
```
      "upstream": {
        "sourceDatasets": [
          "DATASET~181EB317DD87BD5543C8A97135ACB5DF",
          "DATASET~A34DC6FC69D7DFD3DF8285D8DF783F41",
          "DATASET~A2A14D0D4832E92DEEAB2F956F663CA4",
          "DATASET~061D5F960D9BA1F5924A79D02F97FC74",
          "DATASET~C16EEFC9FD8BC362B0845968CB507915",
          "DATASET~5BEED87BC99D8304FA8001DFC1886AC7",
          "DATASET~02B06B1D7327E2EACAE839C29A4F6199"
        ],
        "sourceVirtualViews": [
          "VIRTUAL_VIEW~0E01187CB192E747D521A3FC30F68DDD",
          "VIRTUAL_VIEW~777C53F683F220F1835C683CEF5670EC",
          "VIRTUAL_VIEW~34829670517B5422F060A1323D5A54F9",
          "VIRTUAL_VIEW~B50D0F05C9910B51CC4194EDEC227D9D"
        ],
        "entityId": "",
        "latest": false
      }
```
after
```
      "upstream": {
        "sourceVirtualViews": [
          "VIRTUAL_VIEW~EEE538A6D6F5FBDC18713D2B0071FF71",
          "VIRTUAL_VIEW~71690A21DFFCA0844309C56F6186358C",
          "VIRTUAL_VIEW~68DEDA3264854978801F078CBBFBC23A"
        ],
        "entityId": "",
        "latest": false
      }
```
Verified the virtual view ids are real 


### Checklist

- [x] I have tested that the changes in this PR work as expected
- [ ] I have added/updated tests that exercise the critical code paths in this diff
