### PR TITLE
bump version to 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.5.3"
+version = "0.6.0"
 description = ""
 authors = ["Metaphor <dev@metaphor.io>"]
 packages = [


### PR DESCRIPTION
### Why?

After https://github.com/MetaphorData/connectors/pull/55 is checked in, the tasks in https://github.com/MetaphorData/connectors/issues/13 are completed.

### What?

- bump version 0.6.0

### Checklist

- [ ] I have tested that the changes in this PR work as expected
- [ ] I have added/updated tests that exercise the critical code paths in this diff
