### PR TITLE
Add quotes to pip package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ This repository contains a collection of Python-based "connectors" that extract 
 This package requires Python 3.7+ installed. You can verify the version on your system by running the following command,
 
 ```shell
-python -V  # or python3 -V on some systems
+python -V  # or python3 on some systems
 ```
 
 Once verified, you can install the package using [pip](https://docs.python.org/3/installing/index.html),
 
 ```shell
-pip install "metaphor-connectors[all]"
+pip install "metaphor-connectors[all]"  # or pip3 on some systems
 ```
 
-This will install all the connectors and required dependencies. You can also choose to install only a subset of the dependencies by installing specific [extra](https://packaging.python.org/tutorials/installing-packages/#installing-setuptools-extras), e.g.
+This will install all the connectors and required dependencies. You can also choose to install only a subset of the dependencies by installing the specific [extra](https://packaging.python.org/tutorials/installing-packages/#installing-setuptools-extras), e.g.
 
 ```shell
 pip install "metaphor-connectors[snowflake]"
@@ -31,7 +31,7 @@ Similary, you can also install the package using `requirements.txt` or `pyprojec
 
 ## Connectors
 
-Each connector is placed under its own directory under `metaphor` and extends the `metaphor.common.BaseExtractor` class.
+Each connector is placed under its own directory under [metaphor](./metaphor) and extends the `metaphor.common.BaseExtractor` class.
 
 | Connector | Metadata  |
 | --------- | --------- |  

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ python -V  # or python3 -V on some systems
 Once verified, you can install the package using [pip](https://docs.python.org/3/installing/index.html),
 
 ```shell
-pip install metaphor-connectors[all]
+pip install "metaphor-connectors[all]"
 ```
 
 This will install all the connectors and required dependencies. You can also choose to install only a subset of the dependencies by installing specific [extra](https://packaging.python.org/tutorials/installing-packages/#installing-setuptools-extras), e.g.
 
 ```shell
-pip install metaphor-connectors[snowflake]
+pip install "metaphor-connectors[snowflake]"
 ```
 
 Similary, you can also install the package using `requirements.txt` or `pyproject.toml`.


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Users encounter the following error on zsh:

```
% pip install metaphor-connectors[all]
zsh: no matches found: metaphor-connectors[all]
```

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As square brackets have special meaning in zsh, we need to put the package name in quotes to make it work on both bash & zsh.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

```
% pip install "metaphor-connectors[all]"
...
Successfully installed metaphor-connectors-0.6.1
```
