### PR TITLE
Crawl unique column constraint for Datasets [sc-4137]

### DIFF
--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -182,16 +182,12 @@ class SnowflakeExtractor(BaseExtractor):
         cursor.execute(f"SHOW UNIQUE KEYS IN DATABASE {database}")
 
         for entry in cursor:
-            (
-                create_time,
-                db,
-                schema,
-                table_name,
-                column,
-                order,
-                constraint_name,
-                *_rest,
-            ) = entry
+            schema, table_name, column, constraint_name = (
+                entry[2],
+                entry[3],
+                entry[4],
+                entry[6],
+            )
             table = self.table_fullname(database, schema, table_name)
 
             dataset = self._datasets.get(table)
@@ -201,7 +197,6 @@ class SnowflakeExtractor(BaseExtractor):
                 )
                 continue
 
-            column = entry[4]
             field = next(
                 (f for f in dataset.schema.fields if f.field_path == column),
                 None,
@@ -218,16 +213,12 @@ class SnowflakeExtractor(BaseExtractor):
         cursor.execute(f"SHOW PRIMARY KEYS IN DATABASE {database}")
 
         for entry in cursor:
-            (
-                create_time,
-                db,
-                schema,
-                table_name,
-                column,
-                order,
-                constraint_name,
-                *_rest,
-            ) = entry
+            schema, table_name, column, constraint_name = (
+                entry[2],
+                entry[3],
+                entry[4],
+                entry[6],
+            )
             table = self.table_fullname(database, schema, table_name)
 
             dataset = self._datasets.get(table)
@@ -242,7 +233,7 @@ class SnowflakeExtractor(BaseExtractor):
 
             if sql_schema.primary_key is None:
                 sql_schema.primary_key = []
-            sql_schema.primary_key.append(entry[4])
+            sql_schema.primary_key.append(column)
 
     def _init_dataset(
         self,

--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -182,8 +182,17 @@ class SnowflakeExtractor(BaseExtractor):
         cursor.execute(f"SHOW UNIQUE KEYS IN DATABASE {database}")
 
         for entry in cursor:
-            table = self.table_fullname(database, entry[2], entry[3])
-            constraint_name = entry[6]
+            (
+                create_time,
+                db,
+                schema,
+                table_name,
+                column,
+                order,
+                constraint_name,
+                *_rest,
+            ) = entry
+            table = self.table_fullname(database, schema, table_name)
 
             dataset = self._datasets.get(table)
             if dataset is None or dataset.schema is None:
@@ -209,8 +218,17 @@ class SnowflakeExtractor(BaseExtractor):
         cursor.execute(f"SHOW PRIMARY KEYS IN DATABASE {database}")
 
         for entry in cursor:
-            table = self.table_fullname(database, entry[2], entry[3])
-            constraint_name = entry[6]
+            (
+                create_time,
+                db,
+                schema,
+                table_name,
+                column,
+                order,
+                constraint_name,
+                *_rest,
+            ) = entry
+            table = self.table_fullname(database, schema, table_name)
 
             dataset = self._datasets.get(table)
             if dataset is None or dataset.schema is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.6.6"
+version = "0.6.7"
 description = ""
 authors = ["Metaphor <dev@metaphor.io>"]
 packages = [


### PR DESCRIPTION
### Why?

To show unique and PK constraint on UI

### 🤓 What?

- fetch unique constraints and PK columns and attach to corresponding table

### 🧪 Tested?

local runCrawler
```
[
  {
    "dataset": {
      "entityType": "DATASET",
      "logicalId": {
        "account": "ooa97392",
        "name": "demo_db.metaphor.cycle_hire",
        "platform": "SNOWFLAKE"
      },
      "schema": {
        "aspectType": "DATASET_SCHEMA",
        "fields": [
          {
            "fieldPath": "RENTAL_ID",
            "nativeType": "NUMBER",
            "nullable": false,
            "precision": 38.0
          },
          ...
        ],
        "schemaType": "SQL",
        "sqlSchema": {
          "materialization": "TABLE",
          "primaryKey": [
            "BIKE_ID",
            "RENTAL_ID"
          ],
        },
        "entityId": "",
        "latest": false
      },
      ...
  },
  {
    "dataset": {
      "entityType": "DATASET",
      "logicalId": {
        "account": "ooa97392",
        "name": "demo_db.dbt_dev.netflix",
        "platform": "SNOWFLAKE"
      },
      "schema": {
        "aspectType": "DATASET_SCHEMA",
        "fields": [
          {
            "description": "SHOW_ID. SALES_RECORDS Jibber Jabber Jibber Jabber Jibber Jabber Jibber Jabber Jibber Jabber Jibber Jabber Jibber Jabber Jibber Jabber Jibber Jabber Jibber Jabber Jibber Jabber Jibber Jabber Jibber Jabber Jibber Jabber Jibber Jabber Jibber Jabber Jibber Jabber Jibber Jabber Jibber Jabber Jibber Jabber Jibber Jabber Jibber Jabber Jibber Jabber",
            "fieldPath": "SHOW_ID",
            "isUnique": true,
            "maxLength": 16777216.0,
            "nativeType": "TEXT",
            "nullable": false
          },
          ...
        ],
        "schemaType": "SQL",
        "sqlSchema": {
          "materialization": "TABLE",
        },
      ...
  }
]
```
