### PR TITLE
Add source code URL for Looker Explore [sc-3892]

### DIFF
--- a/metaphor/looker/extractor.py
+++ b/metaphor/looker/extractor.py
@@ -41,7 +41,11 @@ class LookerRunConfig(RunConfig):
     client_id: str
     client_secret: str
 
+    # file path to LookerML project directory
     lookml_dir: str
+
+    # the source code URL for the project directory
+    projectSourceUrl: Optional[str] = None
 
     verify_ssl: bool = True
     timeout: int = 120
@@ -101,7 +105,9 @@ class LookerExtractor(BaseExtractor):
 
         connections = self._fetch_connections(sdk)
 
-        model_map, virtual_views = parse_project(config.lookml_dir, connections)
+        model_map, virtual_views = parse_project(
+            config.lookml_dir, connections, config.projectSourceUrl
+        )
 
         dashboards = self._fetch_dashboards(config, sdk, model_map)
 

--- a/metaphor/looker/lookml_parser.py
+++ b/metaphor/looker/lookml_parser.py
@@ -156,11 +156,16 @@ def fullname(model: str, name: str) -> str:
 
 
 def _build_looker_view(
-    model: str, raw_view: Dict, raw_views: Dict[str, Dict], connection: Connection
+    model: str,
+    raw_view: Dict,
+    raw_views: Dict[str, Dict],
+    connection: Connection,
+    url: Optional[str],
 ) -> VirtualView:
     name = raw_view["name"]
     view = LookerView(
         label=raw_view.get("label"),
+        url=url,
         source_datasets=[
             str(ds) for ds in _get_upstream_datasets(name, raw_views, connection)
         ],
@@ -202,7 +207,9 @@ def _build_looker_view(
     )
 
 
-def _build_looker_explore(model: str, raw_explore: Dict) -> VirtualView:
+def _build_looker_explore(
+    model: str, raw_explore: Dict, url: Optional[str]
+) -> VirtualView:
     name = raw_explore["name"]
     base_view_name = raw_explore.get("from", raw_explore.get("view_name", name))
 
@@ -211,6 +218,7 @@ def _build_looker_explore(model: str, raw_explore: Dict) -> VirtualView:
         description=raw_explore.get("description"),
         label=raw_explore.get("label"),
         tags=raw_explore.get("tags"),
+        url=url,
         fields=raw_explore.get("fields"),
         base_view=str(
             to_virtual_view_entity_id(
@@ -257,30 +265,48 @@ def _build_looker_explore(model: str, raw_explore: Dict) -> VirtualView:
     )
 
 
+def _get_entity_url(
+    path: str, base_dir: str, projectSourceUrl: Optional[str]
+) -> Optional[str]:
+    if projectSourceUrl is None:
+        return None
+
+    relative_path = os.path.relpath(path, base_dir)
+    return f"{projectSourceUrl}/{relative_path}"
+
+
 def _load_included_file(
-    include_path: str, base_dir: str
-) -> Tuple[Dict[str, Dict], Dict[str, Dict]]:
+    include_path: str, base_dir: str, projectSourceUrl: Optional[str]
+) -> Tuple[Dict[str, Dict], Dict[str, Dict], Dict[str, str]]:
     glob_pattern = f"{base_dir}/{include_path}"
     if not glob_pattern.endswith(".lkml"):
         glob_pattern = glob_pattern + ".lkml"
 
     raw_views = {}
     raw_explores = {}
+    entity_urls = {}
+
     for path in glob.glob(glob_pattern, recursive=True):
+        url = _get_entity_url(path, base_dir, projectSourceUrl)
         with open(path) as f:
             root = lkml.load(f)
             for view in root.get("views", []):
                 raw_views[view["name"]] = view
+                entity_urls[view["name"]] = url
 
             for explore in root.get("explores", []):
                 raw_explores[explore["name"]] = explore
+                entity_urls[explore["name"]] = url
 
-    return raw_views, raw_explores
+    return raw_views, raw_explores, entity_urls
 
 
 def _load_model(
-    model_path: str, base_dir: str, connections: Dict[str, Connection]
-) -> Tuple[Dict[str, Dict], Dict[str, Dict], Connection]:
+    model_path: str,
+    base_dir: str,
+    connections: Dict[str, Connection],
+    projectSourceUrl: Optional[str],
+) -> Tuple[Dict[str, Dict], Dict[str, Dict], Dict[str, str], Connection]:
     """
     Loads model file and extract raw Views and Explores
     """
@@ -289,29 +315,39 @@ def _load_model(
 
     raw_views = {}
     raw_explores = {}
+    entity_urls = {}
 
     # Add explores & views defined in included files
     for include_path in model.get("includes", []):
-        views, explores = _load_included_file(include_path, base_dir)
+        views, explores, urls = _load_included_file(
+            include_path, base_dir, projectSourceUrl
+        )
         raw_views.update(views)
         raw_explores.update(explores)
+        entity_urls.update(urls)
+
+    url = _get_entity_url(model_path, base_dir, projectSourceUrl)
 
     # Add explores & views defined in model
     for explore in model.get("explores", []):
         raw_explores[explore["name"]] = explore
+        entity_urls[explore["name"]] = url
 
     for view in model.get("views", []):
         raw_views[view["name"]] = view
+        entity_urls[view["name"]] = url
 
     connection = connections.get(model.get("connection", ""), None)
     if connection is None:
         raise ValueError(f"Model ${model_path} has an invalid connection")
 
-    return raw_views, raw_explores, connection
+    return raw_views, raw_explores, entity_urls, connection
 
 
 def parse_project(
-    base_dir: str, connections: Dict[str, Connection]
+    base_dir: str,
+    connections: Dict[str, Connection],
+    projectSourceUrl: Optional[str] = None,
 ) -> Tuple[Dict[str, Model], List[VirtualView]]:
     """
     parse the project under base_dir, returning a Model map and a list of virtual views including
@@ -323,19 +359,27 @@ def parse_project(
 
     for model_path in glob.glob(f"{base_dir}/**/*.model.lkml", recursive=True):
         model_name = os.path.basename(model_path)[0 : -len(".model.lkml")]
-        raw_views, raw_explores, connection = _load_model(
-            model_path, base_dir, connections
+        raw_views, raw_explores, entity_urls, connection = _load_model(
+            model_path, base_dir, connections, projectSourceUrl
         )
 
         virtual_views.extend(
             [
-                _build_looker_view(model_name, view, raw_views, connection)
+                _build_looker_view(
+                    model_name,
+                    view,
+                    raw_views,
+                    connection,
+                    entity_urls.get(view["name"]),
+                )
                 for view in raw_views.values()
             ]
         )
         virtual_views.extend(
             [
-                _build_looker_explore(model_name, explore)
+                _build_looker_explore(
+                    model_name, explore, entity_urls.get(explore["name"])
+                )
                 for explore in raw_explores.values()
             ]
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.6.7"
+version = "0.6.8"
 description = ""
 authors = ["Metaphor <dev@metaphor.io>"]
 packages = [

--- a/tests/looker/test_lookml_parser.py
+++ b/tests/looker/test_lookml_parser.py
@@ -39,7 +39,7 @@ def test_empty_model(test_root_dir):
 
 def test_basic(test_root_dir):
     models_map, virtual_views = parse_project(
-        test_root_dir + "/looker/basic", connection_map
+        test_root_dir + "/looker/basic", connection_map, "http://foo/files"
     )
 
     dataset_id = EntityId(
@@ -56,7 +56,7 @@ def test_basic(test_root_dir):
         VirtualViewLogicalID(name="model1.view1", type=VirtualViewType.LOOKER_VIEW),
     )
 
-    expected = {
+    assert models_map == {
         "model1": Model(
             explores={
                 "explore1": Explore(
@@ -65,7 +65,6 @@ def test_basic(test_root_dir):
             }
         )
     }
-    assert models_map == expected
 
     assert virtual_views == [
         VirtualView(
@@ -78,6 +77,7 @@ def test_basic(test_root_dir):
                     LookerViewMeasure(field="average_measurement", type="average")
                 ],
                 source_datasets=[str(dataset_id)],
+                url="http://foo/files/view1.view.lkml",
             ),
         ),
         VirtualView(
@@ -89,6 +89,7 @@ def test_basic(test_root_dir):
                 base_view=str(virtual_view_id),
                 description="description",
                 label="label",
+                url="http://foo/files/model1.model.lkml",
             ),
         ),
     ]


### PR DESCRIPTION
### Why?

To show links to looker view/explore source code

### 🤓 What?

Fill in url for looker view and explore

### 🧪 Tested?

Unit tests
local crawler run:
```
[
{
    "virtualView": {
      "logicalId": {
        "name": "acme.historic_rideshare",
        "type": "LOOKER_EXPLORE"
      },
      "lookerExplore": {
        "baseView": "VIRTUAL_VIEW~E25B180C821D8761013C9D28A88A65BF",
        "description": "Historic ride sharing data created by combining shopify orders and cleaned bike rides",
        "fields": [
          "cleaned_bike_rides.start_station_name",
          "shopify__orders.app_id",
          "shopify__orders.billing_address_city"
        ],
        "joins": [
          {
            "onClause": "${cleaned_bike_rides.start_station_name} = ${shopify__orders.billing_address_city}",
            "relationship": "many_to_one",
            "type": "left_outer",
            "view": "VIRTUAL_VIEW~2B22A3D2B91A6FB3066195364A5B7100"
          }
        ],
        "modelName": "acme",
        "url": "https://metaphordata.cloud.looker.com/projects/metaphor/files//models/acme.model.lkml",
        "entityId": "",
        "latest": false
      }
    }
   ...
]
```
