### PR TITLE
Use falsy instead of None when building url

### DIFF
--- a/metaphor/looker/lookml_parser.py
+++ b/metaphor/looker/lookml_parser.py
@@ -268,7 +268,7 @@ def _build_looker_explore(
 def _get_entity_url(
     path: str, base_dir: str, projectSourceUrl: Optional[str]
 ) -> Optional[str]:
-    if projectSourceUrl is None:
+    if not projectSourceUrl:
         return None
 
     relative_path = os.path.relpath(path, base_dir)

--- a/tests/looker/test_lookml_parser.py
+++ b/tests/looker/test_lookml_parser.py
@@ -97,7 +97,7 @@ def test_basic(test_root_dir):
 
 def test_join(test_root_dir):
     models_map, virtual_views = parse_project(
-        test_root_dir + "/looker/join", connection_map
+        test_root_dir + "/looker/join", connection_map, ""
     )
 
     dataset_id1 = EntityId(


### PR DESCRIPTION
### Why?

If strictly checking `None` value, then the default value `""` passed in by the looker-action won't be treated as falsy and will generate invalid URL. 

### 🤓 What?

- Use falsy check to replace none check. 

### 🧪 Tested?

Unit test
