### PR TITLE
Fix crashing when assume_role_arn is not specified

### DIFF
--- a/metaphor/common/s3.py
+++ b/metaphor/common/s3.py
@@ -22,7 +22,7 @@ def write_file(
             **OWNER_FULL_CONTROL_ACL,
             # Use supplied credentials
             # See https://github.com/RaRe-Technologies/smart_open#s3-credentials
-            "client": s3_session.client("s3"),
+            "client": None if s3_session is None else s3_session.client("s3"),
         }
 
     mode = "wb" if binary_mode else "w"


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

https://github.com/MetaphorData/connectors/pull/89 that causes the connector to crash with the following error when `assume_role_arn` is not specified:

```
[ERROR] AttributeError: 'NoneType' object has no attribute 'client'
Traceback (most recent call last):
  File "/var/task/functions/bigquery/handler.py", line 12, in handle
    return handle_api(event, context, BigQueryExtractor)
  File "/var/task/common/handler.py", line 32, in handle_api
    events = actor.run(config=run_config)
  File "/tmp/sls-py-req/metaphor/common/extractor.py", line 72, in run
    file_sink.sink(events)
  File "/tmp/sls-py-req/metaphor/common/sink.py", line 25, in sink
    return self._sink(valid_records)
  File "/tmp/sls-py-req/metaphor/common/file_sink.py", line 63, in _sink
    s3_session=self.s3_session,
  File "/tmp/sls-py-req/metaphor/common/s3.py", line 25, in write_file
    "client": s3_session.client("s3"),
```

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Make sure to test if the client is None or not before dereferencing.

Purposely didn't bump the PyPI version as we've already introduced breaking changes as part of https://github.com/MetaphorData/connectors/issues/76

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Tested locally with `assume_role_arn` not set.
