### PR TITLE
Add missing __init__.py & __main__.py for redshift connector

### DIFF
--- a/metaphor/redshift/__main__.py
+++ b/metaphor/redshift/__main__.py
@@ -1,0 +1,7 @@
+from metaphor.common.cli import cli_main
+
+from .config import RedshiftRunConfig
+from .extractor import RedshiftExtractor
+
+if __name__ == "__main__":
+    cli_main("Redshift metadata extractor", RedshiftRunConfig, RedshiftExtractor)

--- a/metaphor/redshift/config.py
+++ b/metaphor/redshift/config.py
@@ -7,5 +7,5 @@ from metaphor.postgresql.config import PostgreSQLRunConfig
 
 @deserialize
 @dataclass
-class RedshiftSQLRunConfig(PostgreSQLRunConfig):
+class RedshiftRunConfig(PostgreSQLRunConfig):
     port: int = 5439

--- a/metaphor/redshift/extractor.py
+++ b/metaphor/redshift/extractor.py
@@ -3,11 +3,15 @@ from typing import List
 from metaphor.models.metadata_change_event import MetadataChangeEvent
 
 from metaphor.postgresql.extractor import PostgreSQLExtractor
-from metaphor.redshift.config import RedshiftSQLRunConfig
+from metaphor.redshift.config import RedshiftRunConfig
 
 
-class RedshiftSQLExtractor(PostgreSQLExtractor):
+class RedshiftExtractor(PostgreSQLExtractor):
     """Redshift metadata extractor"""
 
-    async def extract(self, config: RedshiftSQLRunConfig) -> List[MetadataChangeEvent]:
-        return self._extract(config, True)
+    @staticmethod
+    def config_class():
+        return RedshiftRunConfig
+
+    async def extract(self, config: RedshiftRunConfig) -> List[MetadataChangeEvent]:
+        return await self._extract(config, True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.8.0"
+version = "0.8.1"
 description = ""
 authors = ["Metaphor <dev@metaphor.io>"]
 packages = [

--- a/tests/redshift/test_config.py
+++ b/tests/redshift/test_config.py
@@ -1,12 +1,10 @@
-from metaphor.redshift.config import RedshiftSQLRunConfig
+from metaphor.redshift.config import RedshiftRunConfig
 
 
 def test_json_config(test_root_dir):
-    config = RedshiftSQLRunConfig.from_json_file(
-        f"{test_root_dir}/redshift/config.json"
-    )
+    config = RedshiftRunConfig.from_json_file(f"{test_root_dir}/redshift/config.json")
 
-    assert config == RedshiftSQLRunConfig(
+    assert config == RedshiftRunConfig(
         host="host",
         database="database",
         user="user",
@@ -17,9 +15,9 @@ def test_json_config(test_root_dir):
 
 
 def test_yaml_config(test_root_dir):
-    config = RedshiftSQLRunConfig.from_yaml_file(f"{test_root_dir}/redshift/config.yml")
+    config = RedshiftRunConfig.from_yaml_file(f"{test_root_dir}/redshift/config.yml")
 
-    assert config == RedshiftSQLRunConfig(
+    assert config == RedshiftRunConfig(
         host="host",
         database="database",
         user="user",


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

https://github.com/MetaphorData/connectors/pull/92 missed adding the required files to make redshift connector a proper python module.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled. Also fixed the naming of the extractor and config classes.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

```
$ python -m metaphor.redshift ~/Desktop/local/redshift.yml
Log file: /var/folders/mj/nctx1fsn2cg7rdssx505z4pr0000gn/T/tmp9ztonis2.log
**** <class 'metaphor.redshift.config.RedshiftRunConfig'>, {'host': 'localhost', 'database': 'metaphor', 'user': 'root', 'password': 'uG9n_UELKPY83PB-PKF7Ey.A', 'output': {'file': {'path': '~/Desktop/local/mce/redshift.json'}}}
Starting extractor RedshiftExtractor
Fetching metadata from DataPlatform.REDSHIFT host localhost
Connecting to DB metaphor
Databases: ['metaphor', 'dev', 'padb_harvest']
Connecting to DB metaphor
DB metaphor has tables [('public', 'customer', 'metaphor.public.customer'), ('public', 'dwdate', 'metaphor.public.dwdate'), ('public', 'lineorder', 'metaphor.public.lineorder'), ('public', 'part', 'metaphor.public.part'), ('public', 'supplier', 'metaphor.public.supplier')]
Connecting to DB dev
DB dev has tables []
Connecting to DB padb_harvest
DB padb_harvest has tables []
Fetched 5 entities
Extractor ended successfully
```
