### PR TITLE
snowflake crawler should add query tag in [sc-4105]

### DIFF
--- a/metaphor/snowflake/README.md
+++ b/metaphor/snowflake/README.md
@@ -123,6 +123,14 @@ The max number of concurrent queries to the snowflake database can be configured
 max_concurrency: <max_number_of_queries> # Default to 10
 ```
 
+#### Query Tag
+
+Each query issued by snowflake connectors can be tagged with a query tag. It can be configured as follows,
+
+```yaml
+query_tag: <query_taqg> # Default to 'MetaphorData'
+```
+
 ## Testing
 
 Follow the [Installation](../../README.md) instructions to install `metaphor-connectors` in your environment (or virtualenv). Make sure to include either `all` or `snowflake` extra.

--- a/metaphor/snowflake/auth.py
+++ b/metaphor/snowflake/auth.py
@@ -41,6 +41,9 @@ class SnowflakeAuthConfig(RunConfig):
     # database context when opening a connection
     default_database: Optional[str] = None
 
+    # the query tags for each snowflake query the connector issues
+    query_tag: Optional[str] = "MetaphorData"
+
 
 def connect(config: SnowflakeAuthConfig) -> snowflake.connector.SnowflakeConnection:
     if config.password is None and config.private_key is None:
@@ -55,6 +58,9 @@ def connect(config: SnowflakeAuthConfig) -> snowflake.connector.SnowflakeConnect
             user=config.user,
             password=config.password,
             database=config.default_database,
+            session_parameters={
+                "QUERY_TAG": config.query_tag,
+            },
         )
 
     # key pair authentication
@@ -81,4 +87,7 @@ def connect(config: SnowflakeAuthConfig) -> snowflake.connector.SnowflakeConnect
             user=config.user,
             private_key=pkb,
             database=config.default_database,
+            session_parameters={
+                "QUERY_TAG": config.query_tag,
+            },
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.8.3"
+version = "0.8.5"
 description = ""
 authors = ["Metaphor <dev@metaphor.io>"]
 packages = [


### PR DESCRIPTION
### 🤔 Why?

Tag each query from connector with a tag, so its easier to do analysis.

### 🤓 What?

- Add optional config `query_tag` and add it in Snowflake session parameter

### 🧪 Tested?

Run snowflake connector locally, the query history show the recent queries all tagged with "MetaphorData"
