### PR TITLE
not all arguments converted during string [sc-4942]

### DIFF
--- a/metaphor/looker/lookml_parser.py
+++ b/metaphor/looker/lookml_parser.py
@@ -166,7 +166,8 @@ def _build_looker_view(
             str(ds) for ds in _get_upstream_datasets(name, raw_views, connection)
         ]
     except Exception as e:
-        logger.error(f"Can't fetch upstream datasets for view {name}", e)
+        logger.error(f"Can't fetch upstream datasets for view {name}")
+        logger.exception(e)
 
     if "extends" in raw_view:
         view.extends = [

--- a/metaphor/snowflake/profile/extractor.py
+++ b/metaphor/snowflake/profile/extractor.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Dict, List, Tuple
 
 from snowflake.connector import SnowflakeConnection
@@ -35,6 +36,8 @@ from metaphor.models.metadata_change_event import (
 from metaphor.common.extractor import BaseExtractor
 
 logger = get_logger(__name__)
+
+logging.getLogger("snowflake.connector").setLevel(logging.WARNING)
 
 
 class SnowflakeProfileExtractor(BaseExtractor):

--- a/metaphor/snowflake/usage/extractor.py
+++ b/metaphor/snowflake/usage/extractor.py
@@ -173,7 +173,8 @@ class SnowflakeUsageExtractor(BaseExtractor):
 
                 self._update_table_and_columns_usage(table_name, columns, start_time)
         except Exception as e:
-            logger.error(f"access log error, objects: {accessed_objects}", e)
+            logger.error(f"access log error, objects: {accessed_objects}")
+            logger.exception(e)
 
     def _update_table_and_columns_usage(
         self, table_name: str, columns: List[str], start_time: datetime

--- a/metaphor/snowflake/utils.py
+++ b/metaphor/snowflake/utils.py
@@ -41,6 +41,7 @@ def async_query(conn: SnowflakeConnection, query: QueryWithParam) -> SnowflakeCu
     """Executing a snowflake query asynchronously"""
     cursor = conn.cursor()
     if query.params is not None:
+        logger.debug(f"Query {query.query} params {query.params}")
         cursor.execute_async(query.query, query.params)
     else:
         cursor.execute_async(query.query)
@@ -80,7 +81,8 @@ def async_execute(
             try:
                 results = future.result().fetchall()
             except Exception as ex:
-                logger.error(f"Error executing {query_name} for {key}", ex)
+                logger.error(f"Error executing {query_name} for {key}")
+                logger.exception(ex)
                 continue
 
             if results_processor is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.8.10"
+version = "0.8.11"
 description = ""
 authors = ["Metaphor <dev@metaphor.io>"]
 packages = [


### PR DESCRIPTION
### 🤔 Why?

The logging syntax used is incorrect. `logger.error` doesn't take Exception object as second param

### 🤓 What?

- Split the error trace logging into a new logger call
- Silence the snowflake connector logging as it logs each query. 

### 🧪 Tested?

Locally tested the logging works
