### PR TITLE
Fix catalog parsing by ignoring seeds

### DIFF
--- a/metaphor/dbt/extractor.py
+++ b/metaphor/dbt/extractor.py
@@ -147,6 +147,11 @@ class DbtExtractor(BaseExtractor):
     def _parse_catalog_model(self, model: CatalogTable) -> None:
         assert model.unique_id is not None
 
+        # Catalog nodes can be either models or seeds.
+        # The only way to distinguish them is by their ID prefix
+        if not model.unique_id.startswith("model."):
+            return
+
         virtual_view = self._init_virtual_view(model.unique_id)
         dbt_model = virtual_view.dbt_model
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.8.11"
+version = "0.8.12"
 description = ""
 authors = ["Metaphor <dev@metaphor.io>"]
 packages = [

--- a/tests/dbt/data/trial_v3/catalog.json
+++ b/tests/dbt/data/trial_v3/catalog.json
@@ -7,6 +7,35 @@
     "env": {}
   },
   "nodes": {
+    "seed.trial.my_first_dbt_model": {
+      "metadata": {
+        "type": "VIEW",
+        "schema": "DBT_DEV",
+        "name": "MY_FIRST_DBT_MODEL",
+        "database": "DEMO_DB",
+        "comment": "A starter dbt model, my_first_dbt_model",
+        "owner": "ACCOUNTADMIN"
+      },
+      "columns": {
+        "ID": {
+          "type": "NUMBER",
+          "index": 1,
+          "name": "ID",
+          "comment": null
+        }
+      },
+      "stats": {
+        "has_stats": {
+          "id": "has_stats",
+          "label": "Has Stats?",
+          "value": false,
+          "include": false,
+          "description": "Indicates whether there are statistics for this table"
+        }
+      },
+      "unique_id": "model.trial.my_first_dbt_model"
+    },
+
     "model.trial.my_first_dbt_model": {
       "metadata": {
         "type": "VIEW",


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

The connect crashes when it encounters a "seed node" in catalog.json:

```
Traceback (most recent call last):
  File "/Users/marslan/.pyenv/versions/3.8.12/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Users/marslan/.pyenv/versions/3.8.12/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/Users/marslan/Metaphor/connectors/metaphor/dbt/__main__.py", line 6, in <module>
    cli_main("DBT metadata extractor", DbtRunConfig, DbtExtractor)
  File "/Users/marslan/Metaphor/connectors/metaphor/common/cli.py", line 27, in cli_main
    extractor.run(config=config_cls.from_yaml_file(args.config))
  File "/Users/marslan/Metaphor/connectors/metaphor/common/extractor.py", line 65, in run
    events: List[MetadataChangeEvent] = asyncio.run(self.extract(config))
  File "/Users/marslan/.pyenv/versions/3.8.12/lib/python3.8/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/Users/marslan/.pyenv/versions/3.8.12/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/Users/marslan/Metaphor/connectors/metaphor/dbt/extractor.py", line 99, in extract
    self._parse_catalog()
  File "/Users/marslan/Metaphor/connectors/metaphor/dbt/extractor.py", line 142, in _parse_catalog
    self._parse_catalog_model(node)
  File "/Users/marslan/Metaphor/connectors/metaphor/dbt/extractor.py", line 150, in _parse_catalog_model
    virtual_view = self._init_virtual_view(model.unique_id)
  File "/Users/marslan/Metaphor/connectors/metaphor/dbt/extractor.py", line 422, in _init_virtual_view
    name=self._get_model_name_from_unique_id(unique_id),
  File "/Users/marslan/Metaphor/connectors/metaphor/dbt/extractor.py", line 387, in _get_model_name_from_unique_id
    assert unique_id.startswith("model."), f"invalid model id {unique_id}"
AssertionError: invalid model id seed.dribbble.controller_mapping
```
 
### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Only process the "model nodes" from catalog.json by checking for the specific ID prefix.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Tested against a real-world catalog.json file.

