### PR TITLE
Drop variant calculation in snowflake profiler [sc-5938]

### DIFF
--- a/metaphor/snowflake/profile/extractor.py
+++ b/metaphor/snowflake/profile/extractor.py
@@ -180,7 +180,6 @@ class SnowflakeProfileExtractor(BaseExtractor):
                         f', MIN("{column}")',
                         f', MAX("{column}")',
                         f', AVG("{column}")',
-                        f', STDDEV(cast("{column}" as double))',
                     ]
                 )
 
@@ -219,10 +218,8 @@ class SnowflakeProfileExtractor(BaseExtractor):
                 index += 1
                 avg = float(results[index]) if results[index] else None
                 index += 1
-                stddev = float(results[index]) if results[index] else None
-                index += 1
             else:
-                min_value, max_value, avg, stddev = None, None, None, None
+                min_value, max_value, avg = None, None, None
 
             fields.append(
                 FieldStatistics(
@@ -233,7 +230,6 @@ class SnowflakeProfileExtractor(BaseExtractor):
                     min_value=min_value,
                     max_value=max_value,
                     average=avg,
-                    std_dev=stddev,
                 )
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.8.17"
+version = "0.8.18"
 description = ""
 authors = ["Metaphor <dev@metaphor.io>"]
 packages = [

--- a/tests/snowflake/profile/test_extractor.py
+++ b/tests/snowflake/profile/test_extractor.py
@@ -20,9 +20,8 @@ def test_build_profiling_query():
 
     expected = (
         'SELECT COUNT(1) ROW_COUNT, COUNT(DISTINCT "id"), COUNT(DISTINCT "price"), '
-        'COUNT_IF("price" is NULL), MIN("price"), MAX("price"), AVG("price"), STDDEV(cast("price" as double)), '
-        'COUNT(DISTINCT "year"), COUNT_IF("year" is NULL), MIN("year"), MAX("year"), AVG("year"), '
-        'STDDEV(cast("year" as double)) '
+        'COUNT_IF("price" is NULL), MIN("price"), MAX("price"), AVG("price"), '
+        'COUNT(DISTINCT "year"), COUNT_IF("year" is NULL), MIN("year"), MAX("year"), AVG("year") '
         'FROM "schema"."table"'
     )
 
@@ -38,7 +37,7 @@ def test_parse_profiling_result():
         ("price", "FLOAT", True),
         ("year", "NUMBER", True),
     ]
-    results = (5, 5, 4, 0, 3, 8, 5, 1.5, 2, 1, 2000, 2020, 2015, 2.3)
+    results = (5, 5, 4, 0, 3, 8, 5, 2, 1, 2000, 2020, 2015)
     dataset = SnowflakeProfileExtractor._init_dataset(account="a", full_name="foo")
 
     SnowflakeProfileExtractor._parse_profiling_result(columns, results, dataset)
@@ -61,7 +60,6 @@ def test_parse_profiling_result():
                     min_value=3.0,
                     nonnull_value_count=5.0,
                     null_value_count=0.0,
-                    std_dev=1.5,
                 ),
                 FieldStatistics(
                     average=2015.0,
@@ -71,7 +69,6 @@ def test_parse_profiling_result():
                     min_value=2000.0,
                     nonnull_value_count=4.0,
                     null_value_count=1.0,
-                    std_dev=2.3,
                 ),
             ]
         ),


### PR DESCRIPTION
### 🤔 Why?

The snowflake profiler is running very slow, taking hours if not forever to run for customers.

### 🤓 What?

- Drop the stddev calculation to speed up the profiling

### 🧪 Tested?

Run locally against ACME and DEMO_DB, took 257s the first run, and 38s the second run. Seems Snowflake is caching the query result
