### PR TITLE
Speed up snowflake profiler using approximation [sc-5603]

### DIFF
--- a/metaphor/snowflake/profile/README.md
+++ b/metaphor/snowflake/profile/README.md
@@ -21,7 +21,7 @@ The config file inherits all the required and optional fields from the general S
 
 ### Optional Configurations
 
-#### Exclude_views
+#### Exclude Views
 
 By default, the connector only profile Snowflake "base table", i.e. exclude views and temporary tables. The following config can enable profiling on all tables and views.
 
@@ -29,15 +29,15 @@ By default, the connector only profile Snowflake "base table", i.e. exclude view
 exclude_views: false
 ```
 
-#### Sample Probability
+#### Sampling
 
-For tables with large number of rows, profiling can be inefficient. To speed up the process, we can choose to do percentage based random sampling on the data by setting the config below:
+For tables with large number of rows, it can take a long time to profile. To speed up the process, we can choose to do percentage-based random sampling on the data by setting `sample_percentage`:
 
 ```yaml
-sample_probability: <number between 0 and 100>
+sample_percentage: <number between 0 and 100>
 ```
 
-For example, `sample_probability = 1` means random sampling of 1% rows in the table. Keep in mind that sampling won't apply to smaller tables (with less than 100K rows), in that case, we do complete table profiling.
+For example, `sample_percentage = 1` means random sampling of 1% rows in the table. Keep in mind that sampling won't apply to smaller tables (with less than 100K rows), in that case, we do complete table profiling.
 
 ## Testing
 

--- a/metaphor/snowflake/profile/README.md
+++ b/metaphor/snowflake/profile/README.md
@@ -31,13 +31,13 @@ exclude_views: false
 
 #### Sampling
 
-For tables with large number of rows, it can take a long time to profile. To speed up the process, we can choose to do percentage-based random sampling on the data by setting `sample_percentage`:
+For tables with large number of rows, it can take a long time to profile. To speed up the process, we can choose to do percentage-based random sampling on the data by setting `sampling_percentage`:
 
 ```yaml
-sample_percentage: <number between 0 and 100>
+sampling_percentage: <number between 0 and 100>
 ```
 
-For example, `sample_percentage = 1` means random sampling of 1% rows in the table. Keep in mind that sampling won't apply to smaller tables (with less than 100K rows), in that case, we do complete table profiling.
+For example, `sampling_percentage = 1` means random sampling of 1% rows in the table. Keep in mind that sampling won't apply to smaller tables (with less than 100K rows), in that case, we do complete table profiling.
 
 ## Testing
 

--- a/metaphor/snowflake/profile/README.md
+++ b/metaphor/snowflake/profile/README.md
@@ -19,11 +19,25 @@ grant select on future materialized views in database identifier($db) to role me
 
 The config file inherits all the required and optional fields from the general Snowflake connector [Config File](../README.md#config-file).
 
+### Optional Configurations
+
+#### Exclude_views
+
 By default, the connector only profile Snowflake "base table", i.e. exclude views and temporary tables. The following config can enable profiling on all tables and views.
 
 ```yaml
 exclude_views: false
 ```
+
+#### Sample Probability
+
+For tables with large number of rows, profiling can be inefficient. To speed up the process, we can choose to do percentage based random sampling on the data by setting the config below:
+
+```yaml
+sample_probability: <number between 0 and 100>
+```
+
+For example, `sample_probability = 1` means random sampling of 1% rows in the table. Keep in mind that sampling won't apply to smaller tables (with less than 100K rows), in that case, we do complete table profiling.
 
 ## Testing
 

--- a/metaphor/snowflake/profile/config.py
+++ b/metaphor/snowflake/profile/config.py
@@ -14,4 +14,4 @@ class SnowflakeProfileRunConfig(SnowflakeRunConfig):
     include_views: bool = False
 
     # Sampling percentage, i.e. 1 means 1% of rows will be sampled. Value must be between 0 and 100
-    sample_percentage: Optional[float] = None
+    sampling_percentage: Optional[float] = None

--- a/metaphor/snowflake/profile/config.py
+++ b/metaphor/snowflake/profile/config.py
@@ -13,5 +13,5 @@ class SnowflakeProfileRunConfig(SnowflakeRunConfig):
     # Include views in profiling
     include_views: bool = False
 
-    # Sampling probability in percentage, i.e. 1 means 1% of rows will be sampled. Value must be between 0 and 100
-    sample_probability: Optional[float] = None
+    # Sampling percentage, i.e. 1 means 1% of rows will be sampled. Value must be between 0 and 100
+    sample_percentage: Optional[float] = None

--- a/metaphor/snowflake/profile/config.py
+++ b/metaphor/snowflake/profile/config.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional
 
 from serde import deserialize
 
@@ -11,3 +12,6 @@ class SnowflakeProfileRunConfig(SnowflakeRunConfig):
 
     # Include views in profiling
     include_views: bool = False
+
+    # Sampling probability in percentage, i.e. 1 means 1% of rows will be sampled. Value must be between 0 and 100
+    sample_probability: Optional[float] = None

--- a/metaphor/snowflake/profile/extractor.py
+++ b/metaphor/snowflake/profile/extractor.py
@@ -52,7 +52,7 @@ class SnowflakeProfileExtractor(BaseExtractor):
     def __init__(self):
         self.max_concurrency = None
         self.include_views = None
-        self._sample_percentage = None
+        self._sampling_percentage = None
         self._datasets: Dict[str, Dataset] = {}
 
     async def extract(
@@ -64,10 +64,10 @@ class SnowflakeProfileExtractor(BaseExtractor):
         self.max_concurrency = config.max_concurrency
         self.include_views = config.include_views
 
-        assert config.sample_percentage is None or (
-            0 < config.sample_percentage <= 100
-        ), f"Invalid sample probability ${config.sample_percentage}, value must be between 0 and 100"
-        self._sample_percentage = config.sample_percentage
+        assert config.sampling_percentage is None or (
+            0 < config.sampling_percentage <= 100
+        ), f"Invalid sample probability ${config.sampling_percentage}, value must be between 0 and 100"
+        self._sampling_percentage = config.sampling_percentage
 
         conn = connect(config)
 
@@ -161,7 +161,7 @@ class SnowflakeProfileExtractor(BaseExtractor):
                     dataset.schema,
                     dataset.name,
                     dataset.row_count,
-                    self._sample_percentage,
+                    self._sampling_percentage,
                 )
             )
 
@@ -182,7 +182,7 @@ class SnowflakeProfileExtractor(BaseExtractor):
         schema: str,
         name: str,
         row_count: int,
-        sample_percentage: Optional[float],
+        sampling_percentage: Optional[float],
     ) -> str:
         query = ["SELECT COUNT(1) ROW_COUNT"]
 
@@ -203,8 +203,8 @@ class SnowflakeProfileExtractor(BaseExtractor):
 
         query.append(f' FROM "{schema}"."{name}"')
 
-        if row_count >= SAMPLING_THRESHOLD and sample_percentage is not None:
-            query.append(f" SAMPLE SYSTEM ({sample_percentage})")
+        if row_count >= SAMPLING_THRESHOLD and sampling_percentage is not None:
+            query.append(f" SAMPLE SYSTEM ({sampling_percentage})")
 
         return "".join(query)
 

--- a/metaphor/snowflake/profile/extractor.py
+++ b/metaphor/snowflake/profile/extractor.py
@@ -52,7 +52,7 @@ class SnowflakeProfileExtractor(BaseExtractor):
     def __init__(self):
         self.max_concurrency = None
         self.include_views = None
-        self._sample_probability = None
+        self._sample_percentage = None
         self._datasets: Dict[str, Dataset] = {}
 
     async def extract(
@@ -64,10 +64,10 @@ class SnowflakeProfileExtractor(BaseExtractor):
         self.max_concurrency = config.max_concurrency
         self.include_views = config.include_views
 
-        assert config.sample_probability is None or (
-            0 < config.sample_probability <= 100
-        ), f"Invalid sample probability ${config.sample_probability}, value must be between 0 and 100"
-        self._sample_probability = config.sample_probability
+        assert config.sample_percentage is None or (
+            0 < config.sample_percentage <= 100
+        ), f"Invalid sample probability ${config.sample_percentage}, value must be between 0 and 100"
+        self._sample_percentage = config.sample_percentage
 
         conn = connect(config)
 
@@ -161,7 +161,7 @@ class SnowflakeProfileExtractor(BaseExtractor):
                     dataset.schema,
                     dataset.name,
                     dataset.row_count,
-                    self._sample_probability,
+                    self._sample_percentage,
                 )
             )
 
@@ -182,7 +182,7 @@ class SnowflakeProfileExtractor(BaseExtractor):
         schema: str,
         name: str,
         row_count: int,
-        sample_probability: Optional[float],
+        sample_percentage: Optional[float],
     ) -> str:
         query = ["SELECT COUNT(1) ROW_COUNT"]
 
@@ -203,8 +203,8 @@ class SnowflakeProfileExtractor(BaseExtractor):
 
         query.append(f' FROM "{schema}"."{name}"')
 
-        if row_count >= SAMPLING_THRESHOLD and sample_probability is not None:
-            query.append(f" SAMPLE SYSTEM ({sample_probability})")
+        if row_count >= SAMPLING_THRESHOLD and sample_percentage is not None:
+            query.append(f" SAMPLE SYSTEM ({sample_percentage})")
 
         return "".join(query)
 

--- a/metaphor/snowflake/utils.py
+++ b/metaphor/snowflake/utils.py
@@ -29,6 +29,7 @@ class DatasetInfo:
     schema: str
     name: str
     type: str
+    row_count: Optional[int] = None
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.8.19"
+version = "0.8.20"
 description = ""
 authors = ["Metaphor <dev@metaphor.io>"]
 packages = [

--- a/tests/snowflake/profile/test_extractor.py
+++ b/tests/snowflake/profile/test_extractor.py
@@ -26,7 +26,28 @@ def test_build_profiling_query():
     )
 
     assert (
-        SnowflakeProfileExtractor._build_profiling_query(columns, schema, name)
+        SnowflakeProfileExtractor._build_profiling_query(columns, schema, name, 0, None)
+        == expected
+    )
+
+
+def test_build_profiling_query_with_sampling():
+    columns = [
+        ("id", "STRING", False),
+        ("price", "FLOAT", True),
+    ]
+    schema, name = "schema", "table"
+
+    expected = (
+        'SELECT COUNT(1) ROW_COUNT, COUNT(DISTINCT "id"), COUNT(DISTINCT "price"), '
+        'COUNT_IF("price" is NULL), MIN("price"), MAX("price"), AVG("price") '
+        'FROM "schema"."table" SAMPLE SYSTEM (1)'
+    )
+
+    assert (
+        SnowflakeProfileExtractor._build_profiling_query(
+            columns, schema, name, 100000000, 1
+        )
         == expected
     )
 


### PR DESCRIPTION
### 🤔 Why?

The snowflake profiler is currently doing full table scan, which can be very slow for large tables. We should provide the option to do random sampling on the data. 

### 🤓 What?

- Add the capability and config to do random sampling based on percentage.

### 🧪 Tested?

Tested on dribble data with 1% sampling, finished `ANALYTICS` DB in 30min.

Update: finished dribble `RAW` and `ANALYTICS` in just under 1hr