### PR TITLE
Move BigQueryRunConfig to a separate file [sc-6062]

### DIFF
--- a/metaphor/bigquery/config.py
+++ b/metaphor/bigquery/config.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+from dataclasses import field as dataclass_field
+from typing import List, Optional
+
+from serde import deserialize
+
+from metaphor.common.extractor import RunConfig
+
+
+@deserialize
+@dataclass
+class BigQueryRunConfig(RunConfig):
+    # Path to service account's JSON key file
+    key_path: str
+
+    # Project ID to use. Use the service account's default project if not set
+    project_id: Optional[str] = None
+
+    # Filters for dataset names (any match will be included)
+    dataset_filters: List[str] = dataclass_field(default_factory=lambda: [r".*"])

--- a/metaphor/bigquery/extractor.py
+++ b/metaphor/bigquery/extractor.py
@@ -1,11 +1,8 @@
 import json
 import logging
 import re
-from dataclasses import dataclass
-from dataclasses import field as dataclass_field
-from typing import Any, List, Mapping, Optional, Sequence, Union
+from typing import Any, List, Mapping, Sequence, Union
 
-from serde import deserialize
 from smart_open import open
 
 try:
@@ -28,24 +25,12 @@ from metaphor.models.metadata_change_event import (
     SQLSchema,
 )
 
+from metaphor.bigquery.config import BigQueryRunConfig
 from metaphor.common.event_util import EventUtil
-from metaphor.common.extractor import BaseExtractor, RunConfig
+from metaphor.common.extractor import BaseExtractor
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-
-
-@deserialize
-@dataclass
-class BigQueryRunConfig(RunConfig):
-    # Path to service account's JSON key file
-    key_path: str
-
-    # Project ID to use. Use the service account's default project if not set
-    project_id: Optional[str] = None
-
-    # Filters for dataset names (any match will be included)
-    dataset_filters: List[str] = dataclass_field(default_factory=lambda: [r".*"])
 
 
 def build_client(config: BigQueryRunConfig):

--- a/metaphor/bigquery/usage/config.py
+++ b/metaphor/bigquery/usage/config.py
@@ -4,7 +4,7 @@ from typing import Set
 
 from serde import deserialize
 
-from metaphor.bigquery.extractor import BigQueryRunConfig
+from metaphor.bigquery.config import BigQueryRunConfig
 
 
 @deserialize


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

BigQueryRunConfig should be a module itself for consistency.

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

Move BigQueryRunConfig to `config.py` from `extractor.py`
<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

Local tests passed.
<!--
  Describe how the change was tested end-to-end.
-->
