### PR TITLE
MCE validation error url must be an URL address [sc-6065]

### DIFF
--- a/metaphor/tableau/extractor.py
+++ b/metaphor/tableau/extractor.py
@@ -1,5 +1,4 @@
 import base64
-import json
 import re
 from typing import Dict, List, Optional
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.8.23"
+version = "0.8.24"
 description = ""
 authors = ["Metaphor <dev@metaphor.io>"]
 packages = [

--- a/tests/tableau/test_extractor.py
+++ b/tests/tableau/test_extractor.py
@@ -3,13 +3,12 @@ from metaphor.tableau.extractor import TableauExtractor
 
 def test_view_url():
     workbook_url = "https://10ax.online.tableau.com/#/site/abc/workbooks/123/views"
-    workbook_name = "Regional"
-    view_name = "Obesity"
+    view_name = "Regional/sheets/Obesity"
 
     extractor = TableauExtractor()
 
     extractor._get_base_url(workbook_url)
-    view_url = extractor._build_view_url(workbook_name, view_name)
+    view_url = extractor._build_view_url(view_name)
 
     assert (
         view_url == "https://10ax.online.tableau.com/#/site/abc/views/Regional/Obesity"


### PR DESCRIPTION
### 🤔 Why?

Using view name to construct chart URL is not safe, as it may contain empty space or unescaped char. 

### 🤓 What?

- Use API provided content_url to construct the chart URL

### 🧪 Tested?

successfully ingested tableau MCE on dev-yi without error