### PR TITLE
Derive config class name directly in CLI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,8 @@ repos:
       rev: v0.931
       hooks:
           - id: mypy
+            additional_dependencies:
+                - types-requests
 
     - repo: local
       hooks:

--- a/metaphor/bigquery/__main__.py
+++ b/metaphor/bigquery/__main__.py
@@ -1,6 +1,6 @@
 from metaphor.common.cli import cli_main
 
-from .extractor import BigQueryExtractor, BigQueryRunConfig
+from .extractor import BigQueryExtractor
 
 if __name__ == "__main__":
-    cli_main("BigQuery metadata extractor", BigQueryRunConfig, BigQueryExtractor)
+    cli_main("BigQuery metadata extractor", BigQueryExtractor)

--- a/metaphor/bigquery/usage/__main__.py
+++ b/metaphor/bigquery/usage/__main__.py
@@ -1,10 +1,6 @@
 from metaphor.common.cli import cli_main
 
-from .extractor import BigQueryUsageExtractor, BigQueryUsageRunConfig
+from .extractor import BigQueryUsageExtractor
 
 if __name__ == "__main__":
-    cli_main(
-        "BigQuery usage metadata extractor",
-        BigQueryUsageRunConfig,
-        BigQueryUsageExtractor,
-    )
+    cli_main("BigQuery usage metadata extractor", BigQueryUsageExtractor)

--- a/metaphor/common/cli.py
+++ b/metaphor/common/cli.py
@@ -3,12 +3,10 @@ import logging
 import os
 from typing import Type
 
-from .extractor import BaseExtractor, RunConfig
+from .extractor import BaseExtractor
 
 
-def cli_main(
-    description: str, config_cls: Type[RunConfig], extractor_cls: Type[BaseExtractor]
-):
+def cli_main(description: str, extractor_cls: Type[BaseExtractor]):
     logging.basicConfig(
         format="%(asctime)s %(levelname)s - %(message)s", level=logging.INFO
     )
@@ -18,6 +16,7 @@ def cli_main(
     args = parser.parse_args()
 
     extractor = extractor_cls()
+    config_cls = extractor.config_class()
 
     extension = os.path.splitext(args.config)[-1].lower()
 

--- a/metaphor/dbt/__main__.py
+++ b/metaphor/dbt/__main__.py
@@ -1,6 +1,6 @@
 from metaphor.common.cli import cli_main
 
-from .extractor import DbtExtractor, DbtRunConfig
+from .extractor import DbtExtractor
 
 if __name__ == "__main__":
-    cli_main("DBT metadata extractor", DbtRunConfig, DbtExtractor)
+    cli_main("DBT metadata extractor", DbtExtractor)

--- a/metaphor/google_directory/__main__.py
+++ b/metaphor/google_directory/__main__.py
@@ -1,8 +1,6 @@
 from metaphor.common.cli import cli_main
 
-from .extractor import GoogleDirectoryExtractor, GoogleDirectoryRunConfig
+from .extractor import GoogleDirectoryExtractor
 
 if __name__ == "__main__":
-    cli_main(
-        "Google directory connector", GoogleDirectoryRunConfig, GoogleDirectoryExtractor
-    )
+    cli_main("Google directory connector", GoogleDirectoryExtractor)

--- a/metaphor/looker/__main__.py
+++ b/metaphor/looker/__main__.py
@@ -1,6 +1,6 @@
 from metaphor.common.cli import cli_main
 
-from .extractor import LookerExtractor, LookerRunConfig
+from .extractor import LookerExtractor
 
 if __name__ == "__main__":
-    cli_main("Looker metadata extractor", LookerRunConfig, LookerExtractor)
+    cli_main("Looker metadata extractor", LookerExtractor)

--- a/metaphor/metabase/__main__.py
+++ b/metaphor/metabase/__main__.py
@@ -1,6 +1,6 @@
 from metaphor.common.cli import cli_main
 
-from .extractor import MetabaseExtractor, MetabaseRunConfig
+from .extractor import MetabaseExtractor
 
 if __name__ == "__main__":
-    cli_main("Metabase metadata extractor", MetabaseRunConfig, MetabaseExtractor)
+    cli_main("Metabase metadata extractor", MetabaseExtractor)

--- a/metaphor/postgresql/__main__.py
+++ b/metaphor/postgresql/__main__.py
@@ -1,6 +1,6 @@
 from metaphor.common.cli import cli_main
 
-from .extractor import PostgreSQLExtractor, PostgreSQLRunConfig
+from .extractor import PostgreSQLExtractor
 
 if __name__ == "__main__":
-    cli_main("PostgreSQL metadata extractor", PostgreSQLRunConfig, PostgreSQLExtractor)
+    cli_main("PostgreSQL metadata extractor", PostgreSQLExtractor)

--- a/metaphor/redshift/__main__.py
+++ b/metaphor/redshift/__main__.py
@@ -1,7 +1,6 @@
 from metaphor.common.cli import cli_main
 
-from .config import RedshiftRunConfig
 from .extractor import RedshiftExtractor
 
 if __name__ == "__main__":
-    cli_main("Redshift metadata extractor", RedshiftRunConfig, RedshiftExtractor)
+    cli_main("Redshift metadata extractor", RedshiftExtractor)

--- a/metaphor/redshift/usage/__main__.py
+++ b/metaphor/redshift/usage/__main__.py
@@ -1,11 +1,6 @@
 from metaphor.common.cli import cli_main
 
-from .config import RedshiftUsageRunConfig
 from .extractor import RedshiftUsageExtractor
 
 if __name__ == "__main__":
-    cli_main(
-        "Redshift usage metadata extractor",
-        RedshiftUsageRunConfig,
-        RedshiftUsageExtractor,
-    )
+    cli_main("Redshift usage metadata extractor", RedshiftUsageExtractor)

--- a/metaphor/slack_directory/__main__.py
+++ b/metaphor/slack_directory/__main__.py
@@ -1,6 +1,6 @@
 from metaphor.common.cli import cli_main
 
-from .extractor import SlackExtractor, SlackRunConfig
+from .extractor import SlackExtractor
 
 if __name__ == "__main__":
-    cli_main("Slack directory extractor", SlackRunConfig, SlackExtractor)
+    cli_main("Slack directory extractor", SlackExtractor)

--- a/metaphor/snowflake/__main__.py
+++ b/metaphor/snowflake/__main__.py
@@ -1,6 +1,6 @@
 from metaphor.common.cli import cli_main
 
-from .extractor import SnowflakeExtractor, SnowflakeRunConfig
+from .extractor import SnowflakeExtractor
 
 if __name__ == "__main__":
-    cli_main("Snowflake metadata extractor", SnowflakeRunConfig, SnowflakeExtractor)
+    cli_main("Snowflake metadata extractor", SnowflakeExtractor)

--- a/metaphor/snowflake/profile/__main__.py
+++ b/metaphor/snowflake/profile/__main__.py
@@ -1,10 +1,6 @@
 from metaphor.common.cli import cli_main
 
-from .extractor import SnowflakeProfileExtractor, SnowflakeProfileRunConfig
+from .extractor import SnowflakeProfileExtractor
 
 if __name__ == "__main__":
-    cli_main(
-        "Snowflake data profile extractor",
-        SnowflakeProfileRunConfig,
-        SnowflakeProfileExtractor,
-    )
+    cli_main("Snowflake data profile extractor", SnowflakeProfileExtractor)

--- a/metaphor/snowflake/usage/__main__.py
+++ b/metaphor/snowflake/usage/__main__.py
@@ -1,10 +1,6 @@
 from metaphor.common.cli import cli_main
 
-from .extractor import SnowflakeUsageExtractor, SnowflakeUsageRunConfig
+from .extractor import SnowflakeUsageExtractor
 
 if __name__ == "__main__":
-    cli_main(
-        "Snowflake usage metadata extractor",
-        SnowflakeUsageRunConfig,
-        SnowflakeUsageExtractor,
-    )
+    cli_main("Snowflake usage metadata extractor", SnowflakeUsageExtractor)

--- a/metaphor/tableau/__main__.py
+++ b/metaphor/tableau/__main__.py
@@ -1,6 +1,6 @@
 from metaphor.common.cli import cli_main
 
-from .extractor import TableauExtractor, TableauRunConfig
+from .extractor import TableauExtractor
 
 if __name__ == "__main__":
-    cli_main("Tableau metadata extractor", TableauRunConfig, TableauExtractor)
+    cli_main("Tableau metadata extractor", TableauExtractor)


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

The extract class already has a method to get the corresponding config class so there's no need to specify it explicitly.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled. Also fixed missing dependency for mypy pre-commit hook (See https://github.com/pre-commit/mirrors-mypy/issues/50 for more details).

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Selectively ran a few connectors locally to verify. 