### PR TITLE
refactor crawlers output config to only specify [sc-6338]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,48 +1,49 @@
 ---
 repos:
-    - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v2.3.0
-      hooks:
-          - id: check-yaml
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+      - id: check-yaml
 
-    - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
-      rev: 0.1.0
-      hooks:
-          - id: yamlfmt
+  - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
+    rev: 0.1.0
+    hooks:
+      - id: yamlfmt
+        args: [--mapping, '2', --sequence, '4', --offset, '2']
 
-    - repo: https://github.com/psf/black
-      rev: 20.8b1
-      hooks:
-          - id: black
-            exclude: ^(metaphor/dbt/generated/.+)$
+  - repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+      - id: black
+        exclude: ^(metaphor/dbt/generated/.+)$
 
-    - repo: https://github.com/pycqa/isort
-      rev: 5.8.0
-      hooks:
-          - id: isort
-            exclude: ^(metaphor/dbt/generated/.+)$
+  - repo: https://github.com/pycqa/isort
+    rev: 5.8.0
+    hooks:
+      - id: isort
+        exclude: ^(metaphor/dbt/generated/.+)$
 
-    - repo: https://github.com/pre-commit/mirrors-mypy
-      rev: v0.931
-      hooks:
-          - id: mypy
-            additional_dependencies:
-                - types-requests
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.931
+    hooks:
+      - id: mypy
+        additional_dependencies:
+          - types-requests
 
-    - repo: local
-      hooks:
-          - id: flakehell
-            name: flakehell
-            entry: flakehell lint
-            language: python
-            pass_filenames: false
-            always_run: true
+  - repo: local
+    hooks:
+      - id: flakehell
+        name: flakehell
+        entry: flakehell lint
+        language: python
+        pass_filenames: false
+        always_run: true
 
-    - repo: local
-      hooks:
-          - id: pytest-check
-            name: pytest-check
-            entry: pytest
-            language: system
-            pass_filenames: false
-            always_run: true
+  - repo: local
+    hooks:
+      - id: pytest-check
+        name: pytest-check
+        entry: pytest
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/metaphor/common/README.md
+++ b/metaphor/common/README.md
@@ -13,7 +13,7 @@ output:
   file:
     # Location of the output directory.
     # To output to S3 directly, use the format s3://<bucket> or s3://<bucket>/<path>
-    directory_path: <output_directory>
+    directory: <output_directory>
 
     # (Optional) Maximum number of messages in each output file split. Default to 200.
     bach_size: <messages_per_file>

--- a/metaphor/common/README.md
+++ b/metaphor/common/README.md
@@ -11,9 +11,9 @@ File-based output is the preferred way as it enables decoupling between the conn
 ```yaml
 output:
   file:
-    # Location of the output. Must have a ".json" extension.
-    # To output to S3 directly, use the format s3://<bucket>/<object>
-    path: <output_path>
+    # Location of the output directory.
+    # To output to S3 directly, use the format s3://<bucket> or s3://<bucket>/<path>
+    directory_path: <output_directory>
 
     # (Optional) Maximum number of messages in each output file split. Default to 200.
     bach_size: <messages_per_file>

--- a/metaphor/common/file_sink.py
+++ b/metaphor/common/file_sink.py
@@ -24,7 +24,7 @@ logger = get_logger(__name__)
 class FileSinkConfig:
     # Location of the sink directory, where the MCE file and logs will be output to.
     # Can be local file directory, s3://bucket/ or s3://bucket/path/
-    directory_path: str
+    directory: str
 
     # Output logs
     write_logs: bool = True
@@ -40,7 +40,7 @@ class FileSink(Sink):
     """File sink functions"""
 
     def __init__(self, config: FileSinkConfig):
-        self.path = config.directory_path.rstrip("/")
+        self.path = config.directory.rstrip("/")
         self.bach_size = config.bach_size
         self.write_logs = config.write_logs
 

--- a/metaphor/common/s3.py
+++ b/metaphor/common/s3.py
@@ -1,3 +1,4 @@
+import os
 from typing import Union
 
 from smart_open import open
@@ -24,6 +25,8 @@ def write_file(
             # See https://github.com/RaRe-Technologies/smart_open#s3-credentials
             "client": None if s3_session is None else s3_session.client("s3"),
         }
+    else:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
 
     mode = "wb" if binary_mode else "w"
     with open(path, mode, transport_params=transport_params) as fp:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,5 +95,9 @@ pyflakes = ["+*"]
 pycodestyle = ["-*"]
 pyflakes = ["-*"]
 
+[tool.flakehell.exceptions."**/site-packages/*.py"]
+pycodestyle = ["-*"]
+pyflakes = ["-*"]
+
 [tool.mypy]
 ignore_missing_imports = true

--- a/tests/common/config.json
+++ b/tests/common/config.json
@@ -8,7 +8,7 @@
     },
     "file": {
       "assume_role_arn": "arn",
-      "path": "path"
+      "directory_path": "path"
     }
   }
 }

--- a/tests/common/config.json
+++ b/tests/common/config.json
@@ -8,7 +8,7 @@
     },
     "file": {
       "assume_role_arn": "arn",
-      "directory_path": "path"
+      "directory": "path"
     }
   }
 }

--- a/tests/common/config.yml
+++ b/tests/common/config.yml
@@ -1,3 +1,4 @@
+---
 output:
   api:
     url: url
@@ -6,4 +7,4 @@ output:
     timeout: 2
   file:
     assume_role_arn: arn
-    path: path
+    directory_path: path

--- a/tests/common/config.yml
+++ b/tests/common/config.yml
@@ -7,4 +7,4 @@ output:
     timeout: 2
   file:
     assume_role_arn: arn
-    directory_path: path
+    directory: path

--- a/tests/common/test_config.py
+++ b/tests/common/test_config.py
@@ -9,7 +9,7 @@ def test_json_config(test_root_dir):
     assert config == RunConfig(
         output=OutputConfig(
             api=ApiSinkConfig(url="url", api_key="api_key", batch_size=1, timeout=2),
-            file=FileSinkConfig(path="path", assume_role_arn="arn"),
+            file=FileSinkConfig(directory_path="path", assume_role_arn="arn"),
         )
     )
 
@@ -20,6 +20,6 @@ def test_yaml_config(test_root_dir):
     assert config == RunConfig(
         output=OutputConfig(
             api=ApiSinkConfig(url="url", api_key="api_key", batch_size=1, timeout=2),
-            file=FileSinkConfig(path="path", assume_role_arn="arn"),
+            file=FileSinkConfig(directory_path="path", assume_role_arn="arn"),
         )
     )

--- a/tests/common/test_config.py
+++ b/tests/common/test_config.py
@@ -9,7 +9,7 @@ def test_json_config(test_root_dir):
     assert config == RunConfig(
         output=OutputConfig(
             api=ApiSinkConfig(url="url", api_key="api_key", batch_size=1, timeout=2),
-            file=FileSinkConfig(directory_path="path", assume_role_arn="arn"),
+            file=FileSinkConfig(directory="path", assume_role_arn="arn"),
         )
     )
 
@@ -20,6 +20,6 @@ def test_yaml_config(test_root_dir):
     assert config == RunConfig(
         output=OutputConfig(
             api=ApiSinkConfig(url="url", api_key="api_key", batch_size=1, timeout=2),
-            file=FileSinkConfig(directory_path="path", assume_role_arn="arn"),
+            file=FileSinkConfig(directory="path", assume_role_arn="arn"),
         )
     )

--- a/tests/common/test_file_sink.py
+++ b/tests/common/test_file_sink.py
@@ -17,22 +17,20 @@ def events_from_json(file):
 
 
 def test_file_sink_no_split(test_root_dir):
-    _, output = tempfile.mkstemp(suffix=".json")
-    prefix = output[0:-5]
+    path = tempfile.mkdtemp()
 
     messages = [
         MetadataChangeEvent(person=Person(logical_id=PersonLogicalID("foo1@bar.com"))),
         MetadataChangeEvent(person=Person(logical_id=PersonLogicalID("foo2@bar.com"))),
     ]
 
-    sink = FileSink(FileSinkConfig(path=output, bach_size=2))
+    sink = FileSink(FileSinkConfig(directory_path=path, bach_size=2))
     assert sink.sink(messages) is True
-    assert messages == events_from_json(f"{prefix}-1-of-1.json")
+    assert messages == events_from_json(f"{path}/1-of-1.json")
 
 
 def test_file_sink_split(test_root_dir):
-    _, output = tempfile.mkstemp(suffix=".json")
-    prefix = output[0:-5]
+    path = tempfile.mkdtemp()
 
     messages = [
         MetadataChangeEvent(person=Person(logical_id=PersonLogicalID("foo1@bar.com"))),
@@ -42,16 +40,15 @@ def test_file_sink_split(test_root_dir):
         MetadataChangeEvent(person=Person(logical_id=PersonLogicalID("foo5@bar.com"))),
     ]
 
-    sink = FileSink(FileSinkConfig(path=output, bach_size=2))
+    sink = FileSink(FileSinkConfig(directory_path=path, bach_size=2))
     assert sink.sink(messages) is True
-    assert messages[0:2] == events_from_json(f"{prefix}-1-of-3.json")
-    assert messages[2:4] == events_from_json(f"{prefix}-2-of-3.json")
-    assert messages[4:] == events_from_json(f"{prefix}-3-of-3.json")
+    assert messages[0:2] == events_from_json(f"{path}/1-of-3.json")
+    assert messages[2:4] == events_from_json(f"{path}/2-of-3.json")
+    assert messages[4:] == events_from_json(f"{path}/3-of-3.json")
 
 
 def test_sink_metadata(test_root_dir):
-    _, output = tempfile.mkstemp(suffix=".json")
-    prefix = output[0:-5]
+    path = tempfile.mkdtemp()
 
     metadata = CrawlerRunMetadata(
         crawler_name="foo",
@@ -61,7 +58,7 @@ def test_sink_metadata(test_root_dir):
         entity_count=1.0,
     )
 
-    sink = FileSink(FileSinkConfig(path=output, bach_size=2))
+    sink = FileSink(FileSinkConfig(directory_path=path, bach_size=2))
     sink.sink_metadata(metadata)
 
-    assert metadata.to_dict() == load_json(f"{prefix}-run.metadata")
+    assert metadata.to_dict() == load_json(f"{path}/run.metadata")

--- a/tests/common/test_file_sink.py
+++ b/tests/common/test_file_sink.py
@@ -17,20 +17,20 @@ def events_from_json(file):
 
 
 def test_file_sink_no_split(test_root_dir):
-    path = tempfile.mkdtemp()
+    directory = tempfile.mkdtemp()
 
     messages = [
         MetadataChangeEvent(person=Person(logical_id=PersonLogicalID("foo1@bar.com"))),
         MetadataChangeEvent(person=Person(logical_id=PersonLogicalID("foo2@bar.com"))),
     ]
 
-    sink = FileSink(FileSinkConfig(directory_path=path, bach_size=2))
+    sink = FileSink(FileSinkConfig(directory=directory, bach_size=2))
     assert sink.sink(messages) is True
-    assert messages == events_from_json(f"{path}/1-of-1.json")
+    assert messages == events_from_json(f"{directory}/1-of-1.json")
 
 
 def test_file_sink_split(test_root_dir):
-    path = tempfile.mkdtemp()
+    directory = tempfile.mkdtemp()
 
     messages = [
         MetadataChangeEvent(person=Person(logical_id=PersonLogicalID("foo1@bar.com"))),
@@ -40,15 +40,15 @@ def test_file_sink_split(test_root_dir):
         MetadataChangeEvent(person=Person(logical_id=PersonLogicalID("foo5@bar.com"))),
     ]
 
-    sink = FileSink(FileSinkConfig(directory_path=path, bach_size=2))
+    sink = FileSink(FileSinkConfig(directory=directory, bach_size=2))
     assert sink.sink(messages) is True
-    assert messages[0:2] == events_from_json(f"{path}/1-of-3.json")
-    assert messages[2:4] == events_from_json(f"{path}/2-of-3.json")
-    assert messages[4:] == events_from_json(f"{path}/3-of-3.json")
+    assert messages[0:2] == events_from_json(f"{directory}/1-of-3.json")
+    assert messages[2:4] == events_from_json(f"{directory}/2-of-3.json")
+    assert messages[4:] == events_from_json(f"{directory}/3-of-3.json")
 
 
 def test_sink_metadata(test_root_dir):
-    path = tempfile.mkdtemp()
+    directory = tempfile.mkdtemp()
 
     metadata = CrawlerRunMetadata(
         crawler_name="foo",
@@ -58,7 +58,7 @@ def test_sink_metadata(test_root_dir):
         entity_count=1.0,
     )
 
-    sink = FileSink(FileSinkConfig(directory_path=path, bach_size=2))
+    sink = FileSink(FileSinkConfig(directory=directory, bach_size=2))
     sink.sink_metadata(metadata)
 
-    assert metadata.to_dict() == load_json(f"{path}/run.metadata")
+    assert metadata.to_dict() == load_json(f"{directory}/run.metadata")


### PR DESCRIPTION
### 🤔 Why?

Current the file sink config specifies the MCE json file path, but the log file and metadata file path are derived from the json path. This is unclear to the user and unsafe.

Part of https://github.com/MetaphorData/connectors/issues/95

### 🤓 What?

- Change the file sink config to specify the directory instead, and the MCE file, as well as log and metadata, are all written to the same directory.
- Fix issues with pre-commit hook

### 🧪 Tested?

file written to local directory and S3 dev-yi
![image](https://user-images.githubusercontent.com/1462654/151074186-1fcf30ec-a4d5-4c6d-921e-29ab103952ca.png)

