### PR TITLE
Handle default site workbook URL

### DIFF
--- a/metaphor/tableau/extractor.py
+++ b/metaphor/tableau/extractor.py
@@ -205,7 +205,7 @@ class TableauExtractor(BaseExtractor):
 
         return Chart(title=view.name, url=view_url, preview=preview_data_url)
 
-    _workbook_url_regex = r"(.+\/site\/\w+)\/workbooks\/(\d+)(\/.*)*"
+    _workbook_url_regex = r"(.+)\/workbooks\/(\d+)(\/.*)?"
 
     @staticmethod
     def _parse_workbook_url(workbook_url: str) -> Tuple[str, str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.2"
+version = "0.10.3"
 description = ""
 authors = ["Metaphor <dev@metaphor.io>"]
 packages = [

--- a/tests/tableau/test_extractor.py
+++ b/tests/tableau/test_extractor.py
@@ -25,6 +25,25 @@ def test_view_url():
     )
 
 
+def test_parse_workbook_url():
+
+    extractor = TableauExtractor()
+
+    # Tableau Online
+    base_url, workbook_id = extractor._parse_workbook_url(
+        "https://10ax.online.tableau.com/#/site/abc/workbooks/123"
+    )
+    assert base_url == "https://10ax.online.tableau.com/#/site/abc"
+    assert workbook_id == "123"
+
+    # Tableau Server with Default Site
+    base_url, workbook_id = extractor._parse_workbook_url(
+        "https://tableau01/#/workbooks/123"
+    )
+    assert base_url == "https://tableau01/#"
+    assert workbook_id == "123"
+
+
 def test_parse_dashboard():
     workbook = WorkbookItem("project1")
     workbook._set_values(


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Tableau Default Site uses a different URL format: https://help.tableau.com/current/server/en-us/sites_intro.htm#the-default-site and leads to the following error when parsing the workbook URLs:

```
Traceback (most recent call last):
  File "/Volumes/fiverr_dev/metaphor_venv/lib/python3.7/site-packages/metaphor/tableau/extractor.py", line 99, in extract
    self._parse_dashboard(item)
  File "/Volumes/fiverr_dev/metaphor_venv/lib/python3.7/site-packages/metaphor/tableau/extractor.py", line 122, in _parse_dashboard
    workbook.webpage_url
  File "/Volumes/fiverr_dev/metaphor_venv/lib/python3.7/site-packages/metaphor/tableau/extractor.py", line 214, in _parse_workbook_url
    assert match, f"invalid workbook URL {workbook_url}"
AssertionError: invalid workbook URL http://tableau01/#/workbooks/2231
```

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Make the workbook URL parser more generic & add tests.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Tested locally against Tableau cloud.
