### PR TITLE
Add config to disable preview images for Tableau connector

### DIFF
--- a/metaphor/tableau/README.md
+++ b/metaphor/tableau/README.md
@@ -67,6 +67,14 @@ If one of the data sources is using Snowflake dataset, please provide the Snowfl
 snowflake_account: <account_name>
 ```
 
+#### Preview Images
+
+By default, the connector will request the server to generate a preview image for each view. This can take a significant amount of time for a large number of views. You can disable the feature by setting the following config,
+
+```yaml
+disable_preview_image: true
+```
+
 ## Testing
 
 Follow the [Installation](../../README.md) instructions to install `metaphor-connectors` in your environment (or virtualenv). Make sure to include either `all` or `tableau` extra.

--- a/metaphor/tableau/config.py
+++ b/metaphor/tableau/config.py
@@ -32,5 +32,7 @@ class TableauRunConfig(BaseConfig):
     access_token: Optional[TableauTokenAuthConfig]
     user_password: Optional[TableauPasswordAuthConfig]
 
-    # snowflake data source account
+    # Snowflake data source account
     snowflake_account: Optional[str]
+
+    disable_preview_image: bool = False

--- a/metaphor/tableau/extractor.py
+++ b/metaphor/tableau/extractor.py
@@ -192,11 +192,17 @@ class TableauExtractor(BaseExtractor):
 
     def _parse_chart(self, view: ViewItem) -> Chart:
         # encode preview image raw bytes into data URL
-        preview_data_url = (
-            TableauExtractor._build_preview_data_url(view.preview_image, view.name)
-            if self._preview_image
-            else None
-        )
+        try:
+            preview_data_url = (
+                TableauExtractor._build_preview_data_url(view.preview_image)
+                if self._preview_image
+                else None
+            )
+        except Exception as error:
+            logger.error(
+                f"Failed to build preview data URL for {view.name}, error {error}"
+            )
+            return None
 
         view_url = self._build_view_url(view.content_url)
 
@@ -222,11 +228,5 @@ class TableauExtractor(BaseExtractor):
         return f"{self._base_url}/views/{workbook}/{view}" if self._base_url else None
 
     @staticmethod
-    def _build_preview_data_url(preview: bytes, view_name: str) -> Optional[str]:
-        try:
-            return f"data:image/png;base64,{base64.b64encode(preview).decode('ascii')}"
-        except Exception as error:
-            logger.error(
-                f"Failed to encode preview data URL for {view_name}, error {error}"
-            )
-            return None
+    def _build_preview_data_url(preview: bytes) -> Optional[str]:
+        return f"data:image/png;base64,{base64.b64encode(preview).decode('ascii')}"

--- a/metaphor/tableau/extractor.py
+++ b/metaphor/tableau/extractor.py
@@ -190,6 +190,7 @@ class TableauExtractor(BaseExtractor):
 
     def _parse_chart(self, view: ViewItem) -> Chart:
         # encode preview image raw bytes into data URL
+        preview_data_url = None
         try:
             preview_data_url = (
                 TableauExtractor._build_preview_data_url(view.preview_image)
@@ -200,7 +201,6 @@ class TableauExtractor(BaseExtractor):
             logger.error(
                 f"Failed to build preview data URL for {view.name}, error {error}"
             )
-            return None
 
         view_url = self._build_view_url(view.content_url)
 

--- a/metaphor/tableau/extractor.py
+++ b/metaphor/tableau/extractor.py
@@ -46,7 +46,6 @@ class TableauExtractor(BaseExtractor):
         self._views: Dict[str, ViewItem] = {}
         self._dashboards: Dict[str, Dashboard] = {}
         self._snowflake_account = None
-        self._preview_image = True
 
     @staticmethod
     def config_class():
@@ -58,7 +57,6 @@ class TableauExtractor(BaseExtractor):
         logger.info("Fetching metadata from Tableau")
 
         self._snowflake_account = config.snowflake_account
-        self._preview_image = not config.disable_preview_image
 
         assert (
             config.access_token or config.user_password
@@ -86,7 +84,7 @@ class TableauExtractor(BaseExtractor):
                 f"There are {len(views)} views on site: {[view.name for view in views]}\n"
             )
             for item in views:
-                if self._preview_image:
+                if not config.disable_preview_image:
                     server.views.populate_preview_image(item)
                 self._views[item.id] = item
 
@@ -195,7 +193,7 @@ class TableauExtractor(BaseExtractor):
         try:
             preview_data_url = (
                 TableauExtractor._build_preview_data_url(view.preview_image)
-                if self._preview_image
+                if view.preview_image
                 else None
             )
         except Exception as error:
@@ -228,5 +226,5 @@ class TableauExtractor(BaseExtractor):
         return f"{self._base_url}/views/{workbook}/{view}" if self._base_url else None
 
     @staticmethod
-    def _build_preview_data_url(preview: bytes) -> Optional[str]:
+    def _build_preview_data_url(preview: bytes) -> str:
         return f"data:image/png;base64,{base64.b64encode(preview).decode('ascii')}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.9"
+version = "0.10.10"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/tableau/config.yml
+++ b/tests/tableau/config.yml
@@ -5,4 +5,5 @@ access_token:
   token_name: foo
   token_value: bar
 snowflake_account: snow
+disable_preview_image: true
 output: {}

--- a/tests/tableau/test_config.py
+++ b/tests/tableau/test_config.py
@@ -13,6 +13,7 @@ def test_yaml_config(test_root_dir):
             token_value="bar",
         ),
         user_password=None,
+        disable_preview_image=True,
         snowflake_account="snow",
         output=OutputConfig(),
     )


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Generating preview images can take a long time and result in an excessively large output for a large number of views.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Add a config option to disable the feature.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Manually tested against Tableau cloud with preview enabled & disabled.
