### PR TITLE
Tableau lineage BigQuery use project Id [sc-6500]

### DIFF
--- a/metaphor/bigquery/lineage/extractor.py
+++ b/metaphor/bigquery/lineage/extractor.py
@@ -2,7 +2,7 @@ import logging
 import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Optional
 
 from metaphor.models.metadata_change_event import (
     DataPlatform,
@@ -128,7 +128,6 @@ class BigQueryLineageExtractor(BaseExtractor):
         self._datasets: Dict[str, Dataset] = {}
         self._datasets_pattern: List[re.Pattern[str]] = []
         self._dataset_filter: DatasetFilter = DatasetFilter()
-        self._excluded_usernames: Set[str] = set()
 
     async def extract(
         self, config: BigQueryLineageRunConfig
@@ -169,9 +168,6 @@ class BigQueryLineageExtractor(BaseExtractor):
             destination.project_id, destination.dataset_id, destination.table_id
         ):
             logger.info(f"Skipped table: {destination.table_name()}")
-            return
-
-        if job_change.user_email in self._excluded_usernames:
             return
 
         table_name = destination.table_name()

--- a/metaphor/tableau/README.md
+++ b/metaphor/tableau/README.md
@@ -67,6 +67,14 @@ If one of the data sources is using Snowflake dataset, please provide the Snowfl
 snowflake_account: <account_name>
 ```
 
+#### BigQuery project ID
+
+If one of the data sources is using BigQuery dataset, please provide the BigQuery project ID (NOT project name) as follows,
+
+```yaml
+bigquery_project_id: <project_id>
+```
+
 ## Testing
 
 Follow the [Installation](../../README.md) instructions to install `metaphor-connectors` in your environment (or virtualenv). Make sure to include either `all` or `tableau` extra.

--- a/metaphor/tableau/README.md
+++ b/metaphor/tableau/README.md
@@ -69,10 +69,12 @@ snowflake_account: <account_name>
 
 #### BigQuery project ID
 
-If one of the data sources is using BigQuery dataset, please provide the BigQuery project ID (NOT project name) as follows,
+If one of the data sources is using BigQuery dataset, please provide the BigQuery project name to project ID map as follows,
 
 ```yaml
-bigquery_project_id: <project_id>
+bigquery_project_name_to_id_map:
+  project_name1: prject_id1
+  project_name2: prject_id2
 ```
 
 ## Testing

--- a/metaphor/tableau/README.md
+++ b/metaphor/tableau/README.md
@@ -77,6 +77,8 @@ bigquery_project_name_to_id_map:
   project_name2: prject_id2
 ```
 
+More information about BigQuery project name and project ID can be found [here](https://cloud.google.com/resource-manager/docs/creating-managing-projects#before_you_begin) 
+
 ## Testing
 
 Follow the [Installation](../../README.md) instructions to install `metaphor-connectors` in your environment (or virtualenv). Make sure to include either `all` or `tableau` extra.

--- a/metaphor/tableau/config.py
+++ b/metaphor/tableau/config.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Dict, Optional
 
 from pydantic.dataclasses import dataclass
 from serde import deserialize
@@ -35,5 +35,5 @@ class TableauRunConfig(BaseConfig):
     # Snowflake data source account
     snowflake_account: Optional[str] = None
 
-    # BigQuery data source project ID
-    bigquery_project_id: Optional[str] = None
+    # BigQuery data source project name to project ID map
+    bigquery_project_name_to_id_map: Optional[Dict] = None

--- a/metaphor/tableau/config.py
+++ b/metaphor/tableau/config.py
@@ -1,3 +1,4 @@
+import dataclasses
 from typing import Dict, Optional
 
 from pydantic.dataclasses import dataclass
@@ -36,4 +37,6 @@ class TableauRunConfig(BaseConfig):
     snowflake_account: Optional[str] = None
 
     # BigQuery data source project name to project ID map
-    bigquery_project_name_to_id_map: Optional[Dict] = None
+    bigquery_project_name_to_id_map: Dict[str, str] = dataclasses.field(
+        default_factory=dict
+    )

--- a/metaphor/tableau/config.py
+++ b/metaphor/tableau/config.py
@@ -32,5 +32,8 @@ class TableauRunConfig(BaseConfig):
     access_token: Optional[TableauTokenAuthConfig]
     user_password: Optional[TableauPasswordAuthConfig]
 
-    # snowflake data source account
-    snowflake_account: Optional[str]
+    # Snowflake data source account
+    snowflake_account: Optional[str] = None
+
+    # BigQuery data source project ID
+    bigquery_project_id: Optional[str] = None

--- a/metaphor/tableau/extractor.py
+++ b/metaphor/tableau/extractor.py
@@ -46,8 +46,8 @@ class TableauExtractor(BaseExtractor):
         self._base_url: Optional[str] = None
         self._views: Dict[str, ViewItem] = {}
         self._dashboards: Dict[str, Dashboard] = {}
-        self._snowflake_account = None
-        self._bigquery_project_name_to_id_map = None
+        self._snowflake_account: Optional[str] = None
+        self._bigquery_project_name_to_id_map: Dict[str, str] = {}
 
     @staticmethod
     def config_class():
@@ -59,7 +59,10 @@ class TableauExtractor(BaseExtractor):
         logger.info("Fetching metadata from Tableau")
 
         self._snowflake_account = config.snowflake_account
-        self._bigquery_project_name_to_id_map = config.bigquery_project_name_to_id_map
+        if config.bigquery_project_name_to_id_map is not None:
+            self._bigquery_project_name_to_id_map = (
+                config.bigquery_project_name_to_id_map
+            )
 
         assert (
             config.access_token or config.user_password

--- a/metaphor/tableau/extractor.py
+++ b/metaphor/tableau/extractor.py
@@ -87,6 +87,7 @@ class TableauExtractor(BaseExtractor):
                 f"There are {len(views)} views on site: {[view.name for view in views]}\n"
             )
             for item in views:
+                # log view item detail for debugging purpose
                 logger.debug(json.dumps(item.__dict__, default=str))
                 server.views.populate_preview_image(item)
                 self._views[item.id] = item
@@ -98,6 +99,7 @@ class TableauExtractor(BaseExtractor):
             )
             for item in workbooks:
                 server.workbooks.populate_views(item, usage=True)
+                # log workbook item detail for debugging purpose
                 logger.debug(json.dumps(item.__dict__, default=str))
 
                 try:
@@ -111,7 +113,6 @@ class TableauExtractor(BaseExtractor):
             # by the REST api, can NOT use id to match entities.
             resp = server.metadata.query(workbooks_graphql_query)
             resp_data = resp["data"]
-            logger.debug(json.dumps(resp_data))
             for item in resp_data["workbooks"]:
                 try:
                     self._parse_dashboard_upstream(item)

--- a/metaphor/tableau/extractor.py
+++ b/metaphor/tableau/extractor.py
@@ -47,7 +47,7 @@ class TableauExtractor(BaseExtractor):
         self._views: Dict[str, ViewItem] = {}
         self._dashboards: Dict[str, Dashboard] = {}
         self._snowflake_account: Optional[str] = None
-        self._bigquery_project_name_to_id_map: Dict[str, str] = {}
+        self._bigquery_project_name_to_id_map: Dict[str, str] = dict()
 
     @staticmethod
     def config_class():
@@ -59,10 +59,7 @@ class TableauExtractor(BaseExtractor):
         logger.info("Fetching metadata from Tableau")
 
         self._snowflake_account = config.snowflake_account
-        if config.bigquery_project_name_to_id_map is not None:
-            self._bigquery_project_name_to_id_map = (
-                config.bigquery_project_name_to_id_map
-            )
+        self._bigquery_project_name_to_id_map = config.bigquery_project_name_to_id_map
 
         assert (
             config.access_token or config.user_password

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.9"
+version = "0.10.10"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/tableau/config.yml
+++ b/tests/tableau/config.yml
@@ -5,4 +5,5 @@ access_token:
   token_name: foo
   token_value: bar
 snowflake_account: snow
+bigquery_project_id: bq
 output: {}

--- a/tests/tableau/config.yml
+++ b/tests/tableau/config.yml
@@ -5,5 +5,6 @@ access_token:
   token_name: foo
   token_value: bar
 snowflake_account: snow
-bigquery_project_id: bq
+bigquery_project_name_to_id_map:
+  bq_name: bq_id
 output: {}

--- a/tests/tableau/config_no_optional.yml
+++ b/tests/tableau/config_no_optional.yml
@@ -1,0 +1,7 @@
+---
+server_url: https://10ay.online.tableau.com
+site_name: abc
+access_token:
+  token_name: foo
+  token_value: bar
+output: {}

--- a/tests/tableau/test_config.py
+++ b/tests/tableau/test_config.py
@@ -14,6 +14,6 @@ def test_yaml_config(test_root_dir):
         ),
         user_password=None,
         snowflake_account="snow",
-        bigquery_project_id="bq",
+        bigquery_project_name_to_id_map={"bq_name": "bq_id"},
         output=OutputConfig(),
     )

--- a/tests/tableau/test_config.py
+++ b/tests/tableau/test_config.py
@@ -14,5 +14,6 @@ def test_yaml_config(test_root_dir):
         ),
         user_password=None,
         snowflake_account="snow",
+        bigquery_project_id="bq",
         output=OutputConfig(),
     )

--- a/tests/tableau/test_config.py
+++ b/tests/tableau/test_config.py
@@ -17,3 +17,22 @@ def test_yaml_config(test_root_dir):
         bigquery_project_name_to_id_map={"bq_name": "bq_id"},
         output=OutputConfig(),
     )
+
+
+def test_yaml_config_no_optional(test_root_dir):
+    config = TableauRunConfig.from_yaml_file(
+        f"{test_root_dir}/tableau/config_no_optional.yml"
+    )
+
+    assert config == TableauRunConfig(
+        server_url="https://10ay.online.tableau.com",
+        site_name="abc",
+        access_token=TableauTokenAuthConfig(
+            token_name="foo",
+            token_value="bar",
+        ),
+        user_password=None,
+        snowflake_account=None,
+        bigquery_project_name_to_id_map=dict(),
+        output=OutputConfig(),
+    )


### PR DESCRIPTION
### 🤔 Why?

The Tableau API is returning the BigQuery project name as database name. This is not consistent with BQ crawler which uses project ID.

### 🤓 What?

- Add optional config to allow the user to provide the big query project ID, since it's difficult, hacky and unreliable to parse the info from the Tableau data sources API response.
- Add more logs in zip file to aid the debugging of missing lineage

### 🧪 Tested?

tested on local run, and verified the dataset ID matches the one from BQ crawler
