### PR TITLE
Add redshift support for Metabase [sc-6232]

### DIFF
--- a/metaphor/metabase/extractor.py
+++ b/metaphor/metabase/extractor.py
@@ -82,6 +82,7 @@ class MetabaseExtractor(BaseExtractor):
     _db_engine_mapping = {
         "bigquery-cloud-sdk": DataPlatform.BIGQUERY,
         "snowflake": DataPlatform.SNOWFLAKE,
+        "redshift": DataPlatform.REDSHIFT,
     }
 
     async def extract(self, config: MetabaseRunConfig) -> List[MetadataChangeEvent]:
@@ -170,7 +171,11 @@ class MetabaseExtractor(BaseExtractor):
             self._databases[database_id] = DatabaseInfo(
                 platform, details.get("project-id"), details.get("dataset-id"), None
             )
-        # only support snowflake and bigquery currently
+        elif platform == DataPlatform.REDSHIFT:
+            self._databases[database_id] = DatabaseInfo(
+                platform, details.get("db"), None, None
+            )
+        # platform not in _db_engine_mapping are not supported
 
     def _parse_dashboard(self, dashboard: Dict) -> None:
         dashboard_id = dashboard["id"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.9"
+version = "0.10.11"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
### 🤔 Why?

Some customers are using Metabase with redshift data source.

### 🤓 What?

- Add redshift in support data platform in metabase crawler

### 🧪 Tested?

Local run successfully, verified the dataset id matches Redshift crawler
