### PR TITLE
Usage percentile doesn t work well when the [sc-6372]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.12"
+version = "0.10.13"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/bigquery/usage/data/result.json
+++ b/tests/bigquery/usage/data/result.json
@@ -14,55 +14,55 @@
             {
               "count": 2.0,
               "field": "event_dimensions.hostname",
-              "percentile": 1.0
+              "percentile": 0.75
             },
             {
               "count": 2.0,
               "field": "event_name",
-              "percentile": 1.0
+              "percentile": 0.75
             }
           ],
           "last365Days": [
             {
               "count": 2.0,
               "field": "event_dimensions.hostname",
-              "percentile": 1.0
+              "percentile": 0.75
             },
             {
               "count": 2.0,
               "field": "event_name",
-              "percentile": 1.0
+              "percentile": 0.75
             }
           ],
           "last7Days": [
             {
               "count": 2.0,
               "field": "event_dimensions.hostname",
-              "percentile": 1.0
+              "percentile": 0.75
             },
             {
               "count": 2.0,
               "field": "event_name",
-              "percentile": 1.0
+              "percentile": 0.75
             }
           ],
           "last90Days": [
             {
               "count": 2.0,
               "field": "event_dimensions.hostname",
-              "percentile": 1.0
+              "percentile": 0.75
             },
             {
               "count": 2.0,
               "field": "event_name",
-              "percentile": 1.0
+              "percentile": 0.75
             }
           ]
         },
         "queryCounts": {
           "last24Hours": {
             "count": 0.0,
-            "percentile": 1.0
+            "percentile": 0.0
           },
           "last30Days": {
             "count": 2.0,
@@ -102,55 +102,55 @@
             {
               "count": 3.0,
               "field": "description",
-              "percentile": 1.0
+              "percentile": 0.75
             },
             {
               "count": 3.0,
               "field": "event_name",
-              "percentile": 1.0
+              "percentile": 0.75
             }
           ],
           "last365Days": [
             {
               "count": 3.0,
               "field": "description",
-              "percentile": 1.0
+              "percentile": 0.75
             },
             {
               "count": 3.0,
               "field": "event_name",
-              "percentile": 1.0
+              "percentile": 0.75
             }
           ],
           "last7Days": [
             {
               "count": 3.0,
               "field": "description",
-              "percentile": 1.0
+              "percentile": 0.75
             },
             {
               "count": 3.0,
               "field": "event_name",
-              "percentile": 1.0
+              "percentile": 0.75
             }
           ],
           "last90Days": [
             {
               "count": 3.0,
               "field": "description",
-              "percentile": 1.0
+              "percentile": 0.75
             },
             {
               "count": 3.0,
               "field": "event_name",
-              "percentile": 1.0
+              "percentile": 0.75
             }
           ]
         },
         "queryCounts": {
           "last24Hours": {
             "count": 0.0,
-            "percentile": 1.0
+            "percentile": 0.0
           },
           "last30Days": {
             "count": 4.0,

--- a/tests/bigquery/usage/test_extractor.py
+++ b/tests/bigquery/usage/test_extractor.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import patch
 
 import pytest
@@ -35,4 +36,5 @@ async def test_extractor(test_root_dir):
 
         events = [EventUtil.trim_event(e) for e in await extractor.extract(config)]
 
+    print(json.dumps(events))
     assert events == load_json(test_root_dir + "/bigquery/usage/data/result.json")


### PR DESCRIPTION
### 🤔 Why?

The calculated percentile for example like [1, 1, 1, 1, 5] is not reasonable, as all "1"s are 80%

### 🤓 What?

- Use rank mode instead of weak mode in percentile rank calculation. Details see https://www.notion.so/metaphordata/Calculation-of-Percentile-de54e81b70cd46f5a093cb373a72a4cc

### 🧪 Tested?

unit tests for all covered cases
