### PR TITLE
Use "identity" instead of "name" when building dataset ID

### DIFF
--- a/metaphor/dbt/extractor.py
+++ b/metaphor/dbt/extractor.py
@@ -253,7 +253,7 @@ class DbtExtractor(BaseExtractor):
         for key, source in sources.items():
             assert source.database is not None
             source_map[key] = self._get_dataset_entity_id(
-                source.database, source.schema_, source.name
+                source.database, source.schema_, source.identifier
             )
 
         macro_map = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.16"
+version = "0.10.17"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

As described in https://docs.getdbt.com/reference/resource-properties/identifier, `identifier` is the real table name, whereas `name` is just for dbt's internal references. The two are often the same and that's why the connector has worked in many cases in the past.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Manually tested against a real-world dbt manifest.

