### PR TITLE
Use upstream table fullName

### DIFF
--- a/metaphor/tableau/extractor.py
+++ b/metaphor/tableau/extractor.py
@@ -157,18 +157,18 @@ class TableauExtractor(BaseExtractor):
         upstream_datasets = [
             self._parse_dataset_id(table) for table in workbook["upstreamTables"]
         ]
-        source_datasets = set(
-            [
-                str(dataset_id)
-                for dataset_id in upstream_datasets
-                if dataset_id is not None
-            ]
+        source_datasets = list(
+            set(
+                [
+                    str(dataset_id)
+                    for dataset_id in upstream_datasets
+                    if dataset_id is not None
+                ]
+            )
         )
 
         if source_datasets:
-            dashboard.upstream = DashboardUpstream(
-                source_datasets=list(source_datasets)
-            )
+            dashboard.upstream = DashboardUpstream(source_datasets=source_datasets)
 
     def _parse_dataset_id(self, table: Dict) -> Optional[EntityId]:
         table_name = table["name"]

--- a/metaphor/tableau/extractor.py
+++ b/metaphor/tableau/extractor.py
@@ -157,7 +157,7 @@ class TableauExtractor(BaseExtractor):
         upstream_datasets = [
             self._parse_dataset_id(table) for table in workbook["upstreamTables"]
         ]
-        source_datasets = dict.fromkeys(
+        source_datasets = set(
             [
                 str(dataset_id)
                 for dataset_id in upstream_datasets

--- a/metaphor/tableau/extractor.py
+++ b/metaphor/tableau/extractor.py
@@ -157,17 +157,22 @@ class TableauExtractor(BaseExtractor):
         upstream_datasets = [
             self._parse_dataset_id(table) for table in workbook["upstreamTables"]
         ]
-        source_datasets = [
-            str(dataset_id)
-            for dataset_id in upstream_datasets
-            if dataset_id is not None
-        ]
+        source_datasets = dict.fromkeys(
+            [
+                str(dataset_id)
+                for dataset_id in upstream_datasets
+                if dataset_id is not None
+            ]
+        )
 
         if source_datasets:
-            dashboard.upstream = DashboardUpstream(source_datasets=source_datasets)
+            dashboard.upstream = DashboardUpstream(
+                source_datasets=list(source_datasets)
+            )
 
     def _parse_dataset_id(self, table: Dict) -> Optional[EntityId]:
         table_name = table["name"]
+        table_fullname = table["fullName"]
         table_schema = table["schema"]
         database_name = table["database"]["name"]
 
@@ -181,26 +186,41 @@ class TableauExtractor(BaseExtractor):
 
         platform = connection_type_map[connection_type]
 
-        # use BigQuery project ID to replace project name, to be consistent with the BigQuery crawler
-        if platform == DataPlatform.BIGQUERY:
-            if database_name not in self._bigquery_project_name_to_id_map:
-                logger.error(
-                    f"BigQuery project name {database_name} not defined in config 'bigquery_project_name_to_id_map'"
-                )
-                return None
-            database_name = self._bigquery_project_name_to_id_map[database_name]
-
-        if "." in table_name:
-            fullname = f"{database_name}.{table_name}"
+        # if table fullname contains three segments, use it as dataset name
+        if table_fullname.count(".") == 2:
+            fullname = table_fullname
         else:
-            fullname = f"{database_name}.{table_schema}.{table_name}"
+            # use BigQuery project ID to replace project name, to be consistent with the BigQuery crawler
+            if platform == DataPlatform.BIGQUERY:
+                if database_name in self._bigquery_project_name_to_id_map:
+                    database_name = self._bigquery_project_name_to_id_map[database_name]
+                else:
+                    # use project name as database name, may not match with BigQuery crawler
+                    logger.warning(
+                        f"BigQuery project name {database_name} not defined in config 'bigquery_project_name_to_id_map'"
+                    )
+
+            # if table name has two segments, then it contains "schema" and "table_name"
+            if "." in table_name:
+                fullname = f"{database_name}.{table_name}"
+            else:
+                fullname = f"{database_name}.{table_schema}.{table_name}"
+
+        fullname = (
+            fullname.replace("[", "")
+            .replace("]", "")
+            .replace("`", "")
+            .replace("'", "")
+            .replace('"', "")
+            .lower()
+        )
 
         account = (
             self._snowflake_account if platform == DataPlatform.SNOWFLAKE else None
         )
 
-        logger.info(f"dataset id: {fullname} {connection_type} {account}")
-        return to_dataset_entity_id(fullname.lower(), platform, account)
+        logger.debug(f"dataset id: {fullname} {connection_type} {account}")
+        return to_dataset_entity_id(fullname, platform, account)
 
     def _parse_chart(self, view: ViewItem) -> Chart:
         # encode preview image raw bytes into data URL

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.16"
+version = "0.10.18"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/tableau/test_extractor.py
+++ b/tests/tableau/test_extractor.py
@@ -94,11 +94,17 @@ def test_parse_dashboard():
                 "database": {
                     "name": "DEV_DB",
                     "connectionType": "snowflake",
-                    "downstreamDatasources": [
-                        {"name": "Snowflake_test", "vizportalUrlId": "789"}
-                    ],
                 },
-            }
+            },
+            {
+                "name": "CYCLE",
+                "fullName": "[DEV_DB.LONDON].[CYCLE]",
+                "schema": "LONDON",
+                "database": {
+                    "name": "foo",
+                    "connectionType": "snowflake",
+                },
+            },
         ],
     }
 


### PR DESCRIPTION
### 🤔 Why?

In many cases the Tableau GQL upstreamTables `fullName` field contains the correct dataset fullname, especially for BQ, it's using the correct project id instead of the project name. We can try this field first, with fallback to table `name` and `schema` field

### 🤓 What?

- Update the Tableau upstream table name parsing logic to use `fullName` first, before falling back to `name` and `schema`
- Dedupe the upstream datasets

### 🧪 Tested?

- unit tests
- tested with production data GQL response
