### PR TITLE
Support dbt 1 0 [sc-5881]

### DIFF
--- a/metaphor/dbt/catalog_parser_v1.py
+++ b/metaphor/dbt/catalog_parser_v1.py
@@ -1,0 +1,148 @@
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Optional
+
+from metaphor.models.metadata_change_event import (
+    DataPlatform,
+    Dataset,
+    DatasetStatistics,
+    VirtualView,
+)
+
+from metaphor.common.logger import get_logger
+from metaphor.dbt.generated.dbt_catalog_v1 import CatalogTable, DbtCatalog
+from metaphor.dbt.util import (
+    build_docs_url,
+    init_dataset,
+    init_documentation,
+    init_field,
+    init_field_doc,
+    init_virtual_view,
+)
+
+logger = get_logger(__name__)
+
+
+class CatalogParserV1:
+    """
+    dbt catalog parser, using v1 schema https://schemas.getdbt.com/dbt/catalog/v1.json
+    """
+
+    def __init__(
+        self,
+        platform: DataPlatform,
+        account: Optional[str],
+        docs_base_url: Optional[str],
+        datasets: Dict[str, Dataset],
+        virtual_views: Dict[str, VirtualView],
+    ):
+        self._platform = platform
+        self._account = account
+        self._docs_base_url = docs_base_url
+        self._datasets = datasets
+        self._virtual_views = virtual_views
+
+    def parse(self, catalog_file: Optional[str]) -> None:
+        if not catalog_file:
+            return
+
+        try:
+            catalog = DbtCatalog.parse_file(Path(catalog_file))
+        except Exception as e:
+            logger.error(f"Parse catalog json error: {e}")
+            return
+
+        for node in catalog.nodes.values():
+            self._parse_catalog_model(node)
+
+        for source in catalog.sources.values():
+            self._parse_catalog_source(source)
+
+    def _parse_catalog_model(self, model: CatalogTable) -> None:
+        assert model.unique_id is not None
+
+        # Catalog nodes can be either models or seeds.
+        # The only way to distinguish them is by their ID prefix
+        if not model.unique_id.startswith("model."):
+            return
+
+        virtual_view = init_virtual_view(self._virtual_views, model.unique_id)
+        dbt_model = virtual_view.dbt_model
+
+        dbt_model.description = dbt_model.description or model.metadata.comment
+        dbt_model.docs_url = build_docs_url(self._docs_base_url, model.unique_id)
+
+        for col in model.columns.values():
+            column_name = col.name.lower()
+            field = init_field(dbt_model.fields, column_name)
+            field.description = field.description or col.comment
+            field.native_type = field.native_type or col.type or "Not Set"
+
+    def _parse_catalog_source(self, model: CatalogTable) -> None:
+        meta = model.metadata
+        columns = model.columns
+
+        assert model.unique_id is not None
+        assert meta.database is not None
+
+        dataset = init_dataset(
+            self._datasets,
+            meta.database,
+            meta.schema_,
+            meta.name,
+            self._platform,
+            self._account,
+            model.unique_id,
+        )
+
+        # TODO (ch1236): Re-enable once we figure the source & expected format
+        # self._init_ownership(dataset)
+        # assert dataset.ownership is not None and dataset.ownership.people is not None
+        # dataset.ownership.people.append(self._build_owner(meta["owner"]))
+
+        init_documentation(dataset)
+        if meta.comment:
+            dataset.documentation.dataset_documentations = [meta.comment]
+
+        for col in columns.values():
+            if col.comment:
+                column_name = col.name.lower()
+                field_doc = init_field_doc(dataset, column_name)
+                field_doc.documentation = col.comment
+
+    @staticmethod
+    def _parse_catalog_statistics(dataset: Dataset, model: CatalogTable) -> None:
+        stats = model.stats
+
+        has_stats = stats.get("has_stats")
+        if has_stats is not None and has_stats.value is not None:
+            statistics = DatasetStatistics()
+            found_statistics = False
+
+            row_count = stats.get("row_count")
+            if row_count is not None and row_count.value is not None:
+                found_statistics = True
+                statistics.record_count = float(row_count.value)
+
+            bytes = stats.get("bytes")
+            if bytes is not None and bytes.value is not None:
+                found_statistics = True
+                statistics.data_size = (
+                    float(bytes.value) / 1048576  # convert bytes to MB
+                )
+
+            last_modified = stats.get("last_modified")
+            if last_modified is not None and last_modified.value is not None:
+                found_statistics = True
+                if isinstance(last_modified.value, str):
+                    # Must set tzinfo explicitly due to https://bugs.python.org/issue22377
+                    statistics.last_updated = datetime.strptime(
+                        last_modified.value, "%Y-%m-%d %H:%M%Z"
+                    ).replace(tzinfo=timezone.utc)
+                else:
+                    statistics.last_updated = datetime.fromtimestamp(
+                        last_modified.value
+                    ).replace(tzinfo=timezone.utc)
+
+            if found_statistics:
+                dataset.statistics = statistics

--- a/metaphor/dbt/extractor.py
+++ b/metaphor/dbt/extractor.py
@@ -1,59 +1,24 @@
-import re
-from datetime import datetime, timezone
-from email.utils import parseaddr
-from pathlib import Path
+import json
 from typing import Dict, List, Optional, Union
 
 from metaphor.models.metadata_change_event import (
     DataPlatform,
     Dataset,
-    DatasetDocumentation,
-    DatasetLogicalID,
-    DatasetSchema,
-    DatasetStatistics,
-    DbtMacro,
-    DbtMacroArgument,
-    DbtMaterialization,
-    DbtMaterializationType,
-    DbtModel,
-    DbtTest,
-    FieldDocumentation,
     MetadataChangeEvent,
-    SchemaField,
-    SchemaType,
     VirtualView,
-    VirtualViewLogicalID,
-    VirtualViewType,
 )
 
-from metaphor.common.entity_id import (
-    EntityId,
-    dataset_fullname,
-    to_dataset_entity_id,
-    to_person_entity_id,
-    to_virtual_view_entity_id,
-)
 from metaphor.common.event_util import EventUtil
 from metaphor.common.extractor import BaseExtractor
 from metaphor.common.logger import get_logger
 from metaphor.dbt.config import DbtRunConfig
 
-from .generated.dbt_catalog_v1 import CatalogTable, DbtCatalog
-from .generated.dbt_manifest_v3 import (
-    CompiledModelNode,
-    CompiledSchemaTestNode,
-    DbtManifest,
-    ParsedMacro,
-    ParsedModelNode,
-    ParsedSchemaTestNode,
-    ParsedSourceDefinition,
-)
+from .catalog_parser_v1 import CatalogParserV1
+from .generated.dbt_catalog_v1 import DbtCatalog
+from .manifest_parser_v3 import ManifestParserV3
+from .manifest_parser_v4 import ManifestParserV4
 
 logger = get_logger(__name__)
-
-# compiled node has 'compiled_sql' field
-MODEL_NODE_TYPE = Union[CompiledModelNode, ParsedModelNode]
-TEST_NODE_TYPE = Union[CompiledSchemaTestNode, ParsedSchemaTestNode]
 
 
 class DbtExtractor(BaseExtractor):
@@ -71,7 +36,6 @@ class DbtExtractor(BaseExtractor):
         self.account: Optional[str] = None
         self.docs_base_url: Optional[str] = None
         self.project_source_url: Optional[str] = None
-        self._manifest: DbtManifest
         self._catalog: Optional[DbtCatalog] = None
         self._datasets: Dict[str, Dataset] = {}
         self._virtual_views: Dict[str, VirtualView] = {}
@@ -84,22 +48,52 @@ class DbtExtractor(BaseExtractor):
         self.docs_base_url = config.docs_base_url
         self.project_source_url = config.project_source_url
 
-        try:
-            self._manifest = DbtManifest.parse_file(Path(config.manifest))
-        except Exception as e:
-            logger.error(f"Read manifest json error: {e}")
-            raise e
+        with open(config.manifest) as file:
+            manifest_json = json.load(file)
 
-        if config.catalog:
-            try:
-                self._catalog = DbtCatalog.parse_file(Path(config.catalog))
-            except Exception as e:
-                logger.error(f"Read catalog json error: {e}")
-                raise e
+        manifest_metadata = manifest_json.get("metadata", "")
 
-        self._parse_manifest()
+        platform = manifest_metadata.get("adapter_type", "").upper()
+        assert platform in DataPlatform.__members__, f"Invalid data platform {platform}"
+        self.platform = DataPlatform[platform]
 
-        self._parse_catalog()
+        schema_version = (
+            manifest_metadata.get("dbt_schema_version", "")
+            .rsplit("/", 1)[-1]
+            .split(".")[0]
+        )
+
+        manifest_parser: Union[ManifestParserV3, ManifestParserV4]
+        if schema_version in ("v1", "v2", "v3"):
+            manifest_parser = ManifestParserV3(
+                self.platform,
+                self.account,
+                self.project_source_url,
+                self._datasets,
+                self._virtual_views,
+            )
+        elif schema_version == "v4":
+            manifest_parser = ManifestParserV4(
+                self.platform,
+                self.account,
+                self.project_source_url,
+                self._datasets,
+                self._virtual_views,
+            )
+        else:
+            raise ValueError(f"unsupported manifest schema '{schema_version}'")
+
+        manifest_parser.parse(manifest_json)
+
+        catalog_parser = CatalogParserV1(
+            self.platform,
+            self.account,
+            self.docs_base_url,
+            self._datasets,
+            self._virtual_views,
+        )
+
+        catalog_parser.parse(config.catalog)
 
         dataset_events = [
             EventUtil.build_dataset_event(d) for d in self._datasets.values()
@@ -108,377 +102,3 @@ class DbtExtractor(BaseExtractor):
             EventUtil.build_virtual_view_event(d) for d in self._virtual_views.values()
         ]
         return dataset_events + virtual_view_events
-
-    def _parse_manifest(self) -> None:
-        assert self._manifest is not None
-
-        metadata = self._manifest.metadata
-
-        assert metadata.adapter_type is not None
-        platform = metadata.adapter_type.upper()
-        assert platform in DataPlatform.__members__, f"Invalid data platform {platform}"
-        self.platform = DataPlatform[platform]
-
-        nodes = self._manifest.nodes
-        sources = self._manifest.sources
-        macros = self._manifest.macros
-
-        models = {
-            k: v
-            for (k, v) in nodes.items()
-            if isinstance(v, (CompiledModelNode, ParsedModelNode))
-            # if upgraded to python 3.8+, can use get_args(MODEL_NODE_TYPE)
-        }
-        tests = {
-            k: v
-            for (k, v) in nodes.items()
-            if isinstance(v, (CompiledSchemaTestNode, ParsedSchemaTestNode))
-        }
-
-        self._parse_manifest_nodes(sources, macros, tests, models)
-
-    def _parse_catalog(self) -> None:
-        if self._catalog is None:
-            return
-
-        for node in self._catalog.nodes.values():
-            self._parse_catalog_model(node)
-
-        for source in self._catalog.sources.values():
-            self._parse_catalog_source(source)
-
-    def _parse_catalog_model(self, model: CatalogTable) -> None:
-        assert model.unique_id is not None
-
-        # Catalog nodes can be either models or seeds.
-        # The only way to distinguish them is by their ID prefix
-        if not model.unique_id.startswith("model."):
-            return
-
-        virtual_view = self._init_virtual_view(model.unique_id)
-        dbt_model = virtual_view.dbt_model
-
-        dbt_model.description = dbt_model.description or model.metadata.comment
-        dbt_model.docs_url = self._build_docs_url(model.unique_id)
-
-        for col in model.columns.values():
-            column_name = col.name.lower()
-            field = self._init_field(dbt_model.fields, column_name)
-            field.description = field.description or col.comment
-            field.native_type = field.native_type or col.type or "Not Set"
-
-    def _build_docs_url(self, unique_id: str) -> Optional[str]:
-        return (
-            f"{self.docs_base_url}/#!/model/{unique_id}" if self.docs_base_url else None
-        )
-
-    def _build_source_code_url(self, file_path: str) -> Optional[str]:
-        return (
-            f"{self.project_source_url}/{file_path}"
-            if self.project_source_url
-            else None
-        )
-
-    def _parse_catalog_source(self, model: CatalogTable) -> None:
-        meta = model.metadata
-        columns = model.columns
-
-        assert model.unique_id is not None
-        assert meta.database is not None
-
-        dataset = self._init_dataset(
-            meta.database, meta.schema_, meta.name, model.unique_id
-        )
-
-        # TODO (ch1236): Re-enable once we figure the source & expected format
-        # self._init_ownership(dataset)
-        # assert dataset.ownership is not None and dataset.ownership.people is not None
-        # dataset.ownership.people.append(self._build_owner(meta["owner"]))
-
-        self._init_documentation(dataset)
-        if meta.comment:
-            dataset.documentation.dataset_documentations = [meta.comment]
-
-        for col in columns.values():
-            if col.comment:
-                column_name = col.name.lower()
-                field_doc = self._init_field_doc(dataset, column_name)
-                field_doc.documentation = col.comment
-
-    @staticmethod
-    def _parse_catalog_statistics(dataset: Dataset, model: CatalogTable) -> None:
-        stats = model.stats
-
-        has_stats = stats.get("has_stats")
-        if has_stats is not None and has_stats.value is not None:
-            statistics = DatasetStatistics()
-            found_statistics = False
-
-            row_count = stats.get("row_count")
-            if row_count is not None and row_count.value is not None:
-                found_statistics = True
-                statistics.record_count = float(row_count.value)
-
-            bytes = stats.get("bytes")
-            if bytes is not None and bytes.value is not None:
-                found_statistics = True
-                statistics.data_size = (
-                    float(bytes.value) / 1048576  # convert bytes to MB
-                )
-
-            last_modified = stats.get("last_modified")
-            if last_modified is not None and last_modified.value is not None:
-                found_statistics = True
-                if isinstance(last_modified.value, str):
-                    # Must set tzinfo explicitly due to https://bugs.python.org/issue22377
-                    statistics.last_updated = datetime.strptime(
-                        last_modified.value, "%Y-%m-%d %H:%M%Z"
-                    ).replace(tzinfo=timezone.utc)
-                else:
-                    statistics.last_updated = datetime.fromtimestamp(
-                        last_modified.value
-                    ).replace(tzinfo=timezone.utc)
-
-            if found_statistics:
-                dataset.statistics = statistics
-
-    def _parse_manifest_nodes(
-        self,
-        sources: Dict[str, ParsedSourceDefinition],
-        macros: Dict[str, ParsedMacro],
-        tests: Dict[str, TEST_NODE_TYPE],
-        models: Dict[str, MODEL_NODE_TYPE],
-    ) -> None:
-        source_map = {}
-        for key, source in sources.items():
-            assert source.database is not None
-            source_map[key] = self._get_dataset_entity_id(
-                source.database, source.schema_, source.identifier
-            )
-
-        macro_map = {}
-        for key, macro in macros.items():
-            arguments = (
-                [
-                    DbtMacroArgument(
-                        name=arg.name,
-                        type=arg.type,
-                        description=arg.description,
-                    )
-                    for arg in macro.arguments
-                ]
-                if macro.arguments
-                else []
-            )
-
-            macro_map[key] = DbtMacro(
-                name=macro.name,
-                unique_id=macro.unique_id,
-                package_name=macro.package_name,
-                description=macro.description,
-                arguments=arguments,
-                sql=macro.macro_sql,
-                depends_on_macros=macro.depends_on.macros if macro.depends_on else None,
-            )
-
-        for _, model in models.items():
-            self._init_virtual_view(model.unique_id)
-
-        for key, model in models.items():
-            virtual_view = self._init_virtual_view(model.unique_id)
-            virtual_view.dbt_model = DbtModel(
-                package_name=model.package_name,
-                description=model.description,
-                url=self._build_source_code_url(model.original_file_path),
-                tags=model.tags,
-                raw_sql=model.raw_sql,
-                fields=[],
-            )
-            dbt_model = virtual_view.dbt_model
-
-            if isinstance(model, CompiledModelNode):
-                dbt_model.compiled_sql = model.compiled_sql
-
-            dbt_model.owners = self._get_model_owner_ids(model)
-
-            assert model.config is not None and model.database is not None
-            materialized = model.config.materialized
-
-            if materialized:
-                try:
-                    materialization_type = DbtMaterializationType[materialized.upper()]
-                except KeyError:
-                    materialization_type = DbtMaterializationType.OTHER
-
-                dbt_model.materialization = DbtMaterialization(
-                    type=materialization_type,
-                    target_dataset=str(
-                        self._get_dataset_entity_id(
-                            model.database, model.schema_, model.alias or model.name
-                        )
-                    ),
-                )
-
-            if model.columns is not None:
-                for col in model.columns.values():
-                    column_name = col.name.lower()
-                    field = self._init_field(dbt_model.fields, column_name)
-                    field.description = col.description
-                    field.native_type = col.data_type or "Not Set"
-
-            if model.depends_on is not None:
-                if model.depends_on.nodes:
-                    dbt_model.source_models = self._unique_list(
-                        [
-                            self._get_virtual_view_id(self._virtual_views[n].logical_id)
-                            for n in model.depends_on.nodes
-                            if n.startswith("model.")
-                        ]
-                    )
-
-                    dbt_model.source_datasets = self._unique_list(
-                        [
-                            str(source_map[n])
-                            for n in model.depends_on.nodes
-                            if n.startswith("source.")
-                        ]
-                    )
-
-                if model.depends_on.macros:
-                    dbt_model.macros = [macro_map[n] for n in model.depends_on.macros]
-
-        for key, test in tests.items():
-            # check test is referring a model
-            if test.depends_on is None or not test.depends_on.nodes:
-                continue
-
-            model_unique_id = test.depends_on.nodes[0]
-            if not model_unique_id.startswith("model."):
-                continue
-
-            columns = []
-            if test.columns:
-                columns = list(test.columns.keys())
-            elif test.column_name:
-                columns = [test.column_name]
-
-            dbt_test = DbtTest(
-                name=test.name,
-                unique_id=test.unique_id,
-                columns=columns,
-                depends_on_macros=test.depends_on.macros,
-            )
-
-            if isinstance(test, CompiledSchemaTestNode):
-                dbt_test.sql = test.compiled_sql
-
-            self._init_dbt_tests(model_unique_id).append(dbt_test)
-
-    def _get_dataset_entity_id(self, db: str, schema: str, table: str) -> EntityId:
-        return to_dataset_entity_id(
-            dataset_fullname(db, schema, table), self.platform, self.account
-        )
-
-    @staticmethod
-    def _get_virtual_view_id(logical_id: VirtualViewLogicalID) -> str:
-        return str(to_virtual_view_entity_id(logical_id.name, logical_id.type))
-
-    @staticmethod
-    def _get_model_name_from_unique_id(unique_id: str) -> str:
-        assert unique_id.startswith("model."), f"invalid model id {unique_id}"
-        return unique_id[6:]
-
-    @staticmethod
-    def _get_model_owner_ids(
-        model: MODEL_NODE_TYPE, owner_key="owner"
-    ) -> Optional[List[str]]:
-        # v3 use 'model.config.meta' while v1, v2 use 'model.meta'
-        if model.config and model.config.meta and owner_key in model.config.meta:
-            owners = model.config.meta[owner_key]
-        elif model.meta and owner_key in model.meta:
-            owners = model.meta[owner_key]
-        else:
-            return None
-
-        parts = re.split(r"(\s|,)", owners.strip())
-        return DbtExtractor._unique_list(
-            [str(to_person_entity_id(p)) for p in parts if "@" in parseaddr(p)[1]]
-        )
-
-    def _init_dataset(
-        self, database: str, schema: str, name: str, unique_id: str
-    ) -> Dataset:
-        if unique_id not in self._datasets:
-            self._datasets[unique_id] = Dataset(
-                logical_id=DatasetLogicalID(
-                    name=dataset_fullname(database, schema, name),
-                    platform=self.platform,
-                    account=self.account,
-                )
-            )
-        return self._datasets[unique_id]
-
-    def _init_virtual_view(self, unique_id: str) -> VirtualView:
-        if unique_id not in self._virtual_views:
-            self._virtual_views[unique_id] = VirtualView(
-                logical_id=VirtualViewLogicalID(
-                    name=self._get_model_name_from_unique_id(unique_id),
-                    type=VirtualViewType.DBT_MODEL,
-                ),
-            )
-        return self._virtual_views[unique_id]
-
-    def _init_dbt_tests(self, dbt_model_unique_id: str) -> List[DbtTest]:
-        assert dbt_model_unique_id in self._virtual_views
-
-        dbt_model = self._virtual_views[dbt_model_unique_id].dbt_model
-        if dbt_model.tests is None:
-            dbt_model.tests = []
-        return dbt_model.tests
-
-    @staticmethod
-    def _init_schema(dataset: Dataset) -> None:
-        if not dataset.schema:
-            dataset.schema = DatasetSchema()
-            dataset.schema.schema_type = SchemaType.SQL
-            dataset.schema.fields = []
-
-    @staticmethod
-    def _init_field(fields: List[SchemaField], column: str) -> SchemaField:
-        field = next((f for f in fields if f.field_path == column), None)
-        if not field:
-            field = SchemaField(field_path=column)
-            fields.append(field)
-        return field
-
-    @staticmethod
-    def _init_documentation(dataset: Dataset) -> None:
-        if not dataset.documentation:
-            dataset.documentation = DatasetDocumentation()
-            dataset.documentation.dataset_documentations = []
-            dataset.documentation.field_documentations = []
-
-    @staticmethod
-    def _init_field_doc(dataset: Dataset, column: str) -> FieldDocumentation:
-        assert (
-            dataset.documentation is not None
-            and dataset.documentation.field_documentations is not None
-        )
-
-        doc = next(
-            (
-                d
-                for d in dataset.documentation.field_documentations
-                if d.field_path == column
-            ),
-            None,
-        )
-        if not doc:
-            doc = FieldDocumentation()
-            doc.field_path = column
-            dataset.documentation.field_documentations.append(doc)
-        return doc
-
-    @staticmethod
-    def _unique_list(vars: List[str]) -> List[str]:
-        return list(dict.fromkeys(vars))

--- a/metaphor/dbt/manifest_parser_v3.py
+++ b/metaphor/dbt/manifest_parser_v3.py
@@ -1,0 +1,227 @@
+from typing import Dict, Optional, Union
+
+from metaphor.models.metadata_change_event import (
+    DataPlatform,
+    Dataset,
+    DbtMacro,
+    DbtMacroArgument,
+    DbtMaterialization,
+    DbtMaterializationType,
+    DbtModel,
+    DbtTest,
+    VirtualView,
+)
+from pydantic.utils import unique_list
+
+from metaphor.common.entity_id import dataset_fullname, to_dataset_entity_id
+from metaphor.common.logger import get_logger
+
+from .generated.dbt_manifest_v3 import (
+    CompiledModelNode,
+    CompiledSchemaTestNode,
+    DbtManifest,
+    ParsedMacro,
+    ParsedModelNode,
+    ParsedSchemaTestNode,
+    ParsedSourceDefinition,
+)
+from .util import (
+    build_source_code_url,
+    get_model_owner_ids,
+    get_virtual_view_id,
+    init_dbt_tests,
+    init_field,
+    init_virtual_view,
+)
+
+logger = get_logger(__name__)
+
+# compiled node has 'compiled_sql' field
+MODEL_NODE_TYPE = Union[CompiledModelNode, ParsedModelNode]
+TEST_NODE_TYPE = Union[CompiledSchemaTestNode, ParsedSchemaTestNode]
+
+
+class ManifestParserV3:
+    """
+    dbt manifest parser, using v3 schema https://schemas.getdbt.com/dbt/manifest/v3.json
+    backward compatible with older schema
+    """
+
+    def __init__(
+        self,
+        platform: DataPlatform,
+        account: Optional[str],
+        project_source_url: Optional[str],
+        datasets: Dict[str, Dataset],
+        virtual_views: Dict[str, VirtualView],
+    ):
+        self._platform = platform
+        self._account = account
+        self._project_source_url = project_source_url
+        self._datasets = datasets
+        self._virtual_views = virtual_views
+
+    def parse(self, manifest_json: dict) -> None:
+        try:
+            manifest = DbtManifest.parse_obj(manifest_json)
+        except Exception as e:
+            logger.error(f"Parse manifest json error: {e}")
+            raise e
+
+        nodes = manifest.nodes
+        sources = manifest.sources
+        macros = manifest.macros
+
+        models = {
+            k: v
+            for (k, v) in nodes.items()
+            if isinstance(v, (CompiledModelNode, ParsedModelNode))
+            # if upgraded to python 3.8+, can use get_args(MODEL_NODE_TYPE)
+        }
+        tests = {
+            k: v
+            for (k, v) in nodes.items()
+            if isinstance(v, (CompiledSchemaTestNode, ParsedSchemaTestNode))
+        }
+
+        self._parse_manifest_nodes(sources, macros, tests, models)
+
+    def _parse_manifest_nodes(
+        self,
+        sources: Dict[str, ParsedSourceDefinition],
+        macros: Dict[str, ParsedMacro],
+        tests: Dict[str, TEST_NODE_TYPE],
+        models: Dict[str, MODEL_NODE_TYPE],
+    ) -> None:
+        source_map = {}
+        for key, source in sources.items():
+            assert source.database is not None
+            source_map[key] = to_dataset_entity_id(
+                dataset_fullname(source.database, source.schema_, source.identifier),
+                self._platform,
+                self._account,
+            )
+
+        macro_map = {}
+        for key, macro in macros.items():
+            arguments = (
+                [
+                    DbtMacroArgument(
+                        name=arg.name,
+                        type=arg.type,
+                        description=arg.description,
+                    )
+                    for arg in macro.arguments
+                ]
+                if macro.arguments
+                else []
+            )
+
+            macro_map[key] = DbtMacro(
+                name=macro.name,
+                unique_id=macro.unique_id,
+                package_name=macro.package_name,
+                description=macro.description,
+                arguments=arguments,
+                sql=macro.macro_sql,
+                depends_on_macros=macro.depends_on.macros if macro.depends_on else None,
+            )
+
+        for _, model in models.items():
+            init_virtual_view(self._virtual_views, model.unique_id)
+
+        for key, model in models.items():
+            virtual_view = init_virtual_view(self._virtual_views, model.unique_id)
+            virtual_view.dbt_model = DbtModel(
+                package_name=model.package_name,
+                description=model.description,
+                url=build_source_code_url(
+                    self._project_source_url, model.original_file_path
+                ),
+                tags=model.tags,
+                raw_sql=model.raw_sql,
+                fields=[],
+            )
+            dbt_model = virtual_view.dbt_model
+
+            if isinstance(model, CompiledModelNode):
+                dbt_model.compiled_sql = model.compiled_sql
+
+            dbt_model.owners = get_model_owner_ids(model)
+
+            assert model.config is not None and model.database is not None
+            materialized = model.config.materialized
+
+            if materialized:
+                try:
+                    materialization_type = DbtMaterializationType[materialized.upper()]
+                except KeyError:
+                    materialization_type = DbtMaterializationType.OTHER
+
+                dbt_model.materialization = DbtMaterialization(
+                    type=materialization_type,
+                    target_dataset=str(
+                        to_dataset_entity_id(
+                            dataset_fullname(
+                                model.database, model.schema_, model.alias or model.name
+                            ),
+                            self._platform,
+                            self._account,
+                        )
+                    ),
+                )
+
+            if model.columns is not None:
+                for col in model.columns.values():
+                    column_name = col.name.lower()
+                    field = init_field(dbt_model.fields, column_name)
+                    field.description = col.description
+                    field.native_type = col.data_type or "Not Set"
+
+            if model.depends_on is not None:
+                if model.depends_on.nodes:
+                    dbt_model.source_models = unique_list(
+                        [
+                            get_virtual_view_id(self._virtual_views[n].logical_id)
+                            for n in model.depends_on.nodes
+                            if n.startswith("model.")
+                        ]
+                    )
+
+                    dbt_model.source_datasets = unique_list(
+                        [
+                            str(source_map[n])
+                            for n in model.depends_on.nodes
+                            if n.startswith("source.")
+                        ]
+                    )
+
+                if model.depends_on.macros:
+                    dbt_model.macros = [macro_map[n] for n in model.depends_on.macros]
+
+        for key, test in tests.items():
+            # check test is referring a model
+            if test.depends_on is None or not test.depends_on.nodes:
+                continue
+
+            model_unique_id = test.depends_on.nodes[0]
+            if not model_unique_id.startswith("model."):
+                continue
+
+            columns = []
+            if test.columns:
+                columns = list(test.columns.keys())
+            elif test.column_name:
+                columns = [test.column_name]
+
+            dbt_test = DbtTest(
+                name=test.name,
+                unique_id=test.unique_id,
+                columns=columns,
+                depends_on_macros=test.depends_on.macros,
+            )
+
+            if isinstance(test, CompiledSchemaTestNode):
+                dbt_test.sql = test.compiled_sql
+
+            init_dbt_tests(self._virtual_views, model_unique_id).append(dbt_test)

--- a/metaphor/dbt/manifest_parser_v4.py
+++ b/metaphor/dbt/manifest_parser_v4.py
@@ -1,0 +1,226 @@
+from typing import Dict, Optional, Union
+
+from metaphor.models.metadata_change_event import (
+    DataPlatform,
+    Dataset,
+    DbtMacro,
+    DbtMacroArgument,
+    DbtMaterialization,
+    DbtMaterializationType,
+    DbtModel,
+    DbtTest,
+    VirtualView,
+)
+from pydantic.utils import unique_list
+
+from metaphor.common.entity_id import dataset_fullname, to_dataset_entity_id
+from metaphor.common.logger import get_logger
+
+from .generated.dbt_manifest_v4 import (
+    CompiledGenericTestNode,
+    CompiledModelNode,
+    DbtManifest,
+    ParsedGenericTestNode,
+    ParsedMacro,
+    ParsedModelNode,
+    ParsedSourceDefinition,
+)
+from .util import (
+    build_source_code_url,
+    get_model_owner_ids,
+    get_virtual_view_id,
+    init_dbt_tests,
+    init_field,
+    init_virtual_view,
+)
+
+logger = get_logger(__name__)
+
+# compiled node has 'compiled_sql' field
+MODEL_NODE_TYPE = Union[CompiledModelNode, ParsedModelNode]
+TEST_NODE_TYPE = Union[CompiledGenericTestNode, ParsedGenericTestNode]
+
+
+class ManifestParserV4:
+    """
+    dbt manifest parser, using v4 schema https://schemas.getdbt.com/dbt/manifest/v4.json
+    """
+
+    def __init__(
+        self,
+        platform: DataPlatform,
+        account: Optional[str],
+        project_source_url: Optional[str],
+        datasets: Dict[str, Dataset],
+        virtual_views: Dict[str, VirtualView],
+    ):
+        self._platform = platform
+        self._account = account
+        self._project_source_url = project_source_url
+        self._datasets = datasets
+        self._virtual_views = virtual_views
+
+    def parse(self, manifest_json: dict) -> None:
+        try:
+            manifest = DbtManifest.parse_obj(manifest_json)
+        except Exception as e:
+            logger.error(f"Parse manifest json error: {e}")
+            raise e
+
+        nodes = manifest.nodes
+        sources = manifest.sources
+        macros = manifest.macros
+
+        models = {
+            k: v
+            for (k, v) in nodes.items()
+            if isinstance(v, (CompiledModelNode, ParsedModelNode))
+            # if upgraded to python 3.8+, can use get_args(MODEL_NODE_TYPE)
+        }
+        tests = {
+            k: v
+            for (k, v) in nodes.items()
+            if isinstance(v, (CompiledGenericTestNode, ParsedGenericTestNode))
+        }
+
+        self._parse_manifest_nodes(sources, macros, tests, models)
+
+    def _parse_manifest_nodes(
+        self,
+        sources: Dict[str, ParsedSourceDefinition],
+        macros: Dict[str, ParsedMacro],
+        tests: Dict[str, TEST_NODE_TYPE],
+        models: Dict[str, MODEL_NODE_TYPE],
+    ) -> None:
+        source_map = {}
+        for key, source in sources.items():
+            assert source.database is not None
+            source_map[key] = to_dataset_entity_id(
+                dataset_fullname(source.database, source.schema_, source.identifier),
+                self._platform,
+                self._account,
+            )
+
+        macro_map = {}
+        for key, macro in macros.items():
+            arguments = (
+                [
+                    DbtMacroArgument(
+                        name=arg.name,
+                        type=arg.type,
+                        description=arg.description,
+                    )
+                    for arg in macro.arguments
+                ]
+                if macro.arguments
+                else []
+            )
+
+            macro_map[key] = DbtMacro(
+                name=macro.name,
+                unique_id=macro.unique_id,
+                package_name=macro.package_name,
+                description=macro.description,
+                arguments=arguments,
+                sql=macro.macro_sql,
+                depends_on_macros=macro.depends_on.macros if macro.depends_on else None,
+            )
+
+        for _, model in models.items():
+            init_virtual_view(self._virtual_views, model.unique_id)
+
+        for key, model in models.items():
+            virtual_view = init_virtual_view(self._virtual_views, model.unique_id)
+            virtual_view.dbt_model = DbtModel(
+                package_name=model.package_name,
+                description=model.description,
+                url=build_source_code_url(
+                    self._project_source_url, model.original_file_path
+                ),
+                tags=model.tags,
+                raw_sql=model.raw_sql,
+                fields=[],
+            )
+            dbt_model = virtual_view.dbt_model
+
+            if isinstance(model, CompiledModelNode):
+                dbt_model.compiled_sql = model.compiled_sql
+
+            dbt_model.owners = get_model_owner_ids(model)
+
+            assert model.config is not None and model.database is not None
+            materialized = model.config.materialized
+
+            if materialized:
+                try:
+                    materialization_type = DbtMaterializationType[materialized.upper()]
+                except KeyError:
+                    materialization_type = DbtMaterializationType.OTHER
+
+                dbt_model.materialization = DbtMaterialization(
+                    type=materialization_type,
+                    target_dataset=str(
+                        to_dataset_entity_id(
+                            dataset_fullname(
+                                model.database, model.schema_, model.alias or model.name
+                            ),
+                            self._platform,
+                            self._account,
+                        )
+                    ),
+                )
+
+            if model.columns is not None:
+                for col in model.columns.values():
+                    column_name = col.name.lower()
+                    field = init_field(dbt_model.fields, column_name)
+                    field.description = col.description
+                    field.native_type = col.data_type or "Not Set"
+
+            if model.depends_on is not None:
+                if model.depends_on.nodes:
+                    dbt_model.source_models = unique_list(
+                        [
+                            get_virtual_view_id(self._virtual_views[n].logical_id)
+                            for n in model.depends_on.nodes
+                            if n.startswith("model.")
+                        ]
+                    )
+
+                    dbt_model.source_datasets = unique_list(
+                        [
+                            str(source_map[n])
+                            for n in model.depends_on.nodes
+                            if n.startswith("source.")
+                        ]
+                    )
+
+                if model.depends_on.macros:
+                    dbt_model.macros = [macro_map[n] for n in model.depends_on.macros]
+
+        for key, test in tests.items():
+            # check test is referring a model
+            if test.depends_on is None or not test.depends_on.nodes:
+                continue
+
+            model_unique_id = test.depends_on.nodes[0]
+            if not model_unique_id.startswith("model."):
+                continue
+
+            columns = []
+            if test.columns:
+                columns = list(test.columns.keys())
+            elif test.column_name:
+                columns = [test.column_name]
+
+            dbt_test = DbtTest(
+                name=test.name,
+                unique_id=test.unique_id,
+                columns=columns,
+                depends_on_macros=test.depends_on.macros,
+            )
+
+            if isinstance(test, CompiledGenericTestNode):
+                dbt_test.sql = test.compiled_sql
+
+            init_dbt_tests(self._virtual_views, model_unique_id).append(dbt_test)

--- a/metaphor/dbt/util.py
+++ b/metaphor/dbt/util.py
@@ -1,0 +1,168 @@
+import re
+from email.utils import parseaddr
+from typing import Dict, List, Optional, Union
+
+from metaphor.models.metadata_change_event import (
+    DataPlatform,
+    Dataset,
+    DatasetDocumentation,
+    DatasetLogicalID,
+    DatasetSchema,
+    DbtTest,
+    FieldDocumentation,
+    SchemaField,
+    SchemaType,
+    VirtualView,
+    VirtualViewLogicalID,
+    VirtualViewType,
+)
+from pydantic.utils import unique_list
+
+from metaphor.common.entity_id import (
+    EntityId,
+    dataset_fullname,
+    to_dataset_entity_id,
+    to_person_entity_id,
+    to_virtual_view_entity_id,
+)
+from metaphor.dbt.generated.dbt_manifest_v3 import (
+    CompiledModelNode as CompiledModelNode_v3,
+)
+from metaphor.dbt.generated.dbt_manifest_v3 import ParsedModelNode as ParsedModelNode_v3
+from metaphor.dbt.generated.dbt_manifest_v4 import (
+    CompiledModelNode as CompiledModelNode_v4,
+)
+from metaphor.dbt.generated.dbt_manifest_v4 import ParsedModelNode as ParsedModelNode_v4
+
+MODEL_NODE_TYPE = Union[
+    CompiledModelNode_v3, ParsedModelNode_v3, CompiledModelNode_v4, ParsedModelNode_v4
+]
+
+
+def get_dataset_entity_id(self, db: str, schema: str, table: str) -> EntityId:
+    return to_dataset_entity_id(
+        dataset_fullname(db, schema, table), self._platform, self._account
+    )
+
+
+def get_virtual_view_id(logical_id: VirtualViewLogicalID) -> str:
+    return str(to_virtual_view_entity_id(logical_id.name, logical_id.type))
+
+
+def get_model_name_from_unique_id(unique_id: str) -> str:
+    assert unique_id.startswith("model."), f"invalid model id {unique_id}"
+    return unique_id[6:]
+
+
+def get_model_owner_ids(
+    model: MODEL_NODE_TYPE, owner_key="owner"
+) -> Optional[List[str]]:
+    # v3 use 'model.config.meta' while v1, v2 use 'model.meta'
+    if model.config and model.config.meta and owner_key in model.config.meta:
+        owners = model.config.meta[owner_key]
+    elif model.meta and owner_key in model.meta:
+        owners = model.meta[owner_key]
+    else:
+        return None
+
+    parts = re.split(r"(\s|,)", owners.strip())
+    return unique_list(
+        [str(to_person_entity_id(p)) for p in parts if "@" in parseaddr(p)[1]]
+    )
+
+
+def init_dataset(
+    datasets: Dict[str, Dataset],
+    database: str,
+    schema: str,
+    name: str,
+    platform: DataPlatform,
+    account: Optional[str],
+    unique_id: str,
+) -> Dataset:
+    if unique_id not in datasets:
+        datasets[unique_id] = Dataset(
+            logical_id=DatasetLogicalID(
+                name=dataset_fullname(database, schema, name),
+                platform=platform,
+                account=account,
+            )
+        )
+    return datasets[unique_id]
+
+
+def init_virtual_view(
+    virtual_views: Dict[str, VirtualView], unique_id: str
+) -> VirtualView:
+    if unique_id not in virtual_views:
+        virtual_views[unique_id] = VirtualView(
+            logical_id=VirtualViewLogicalID(
+                name=get_model_name_from_unique_id(unique_id),
+                type=VirtualViewType.DBT_MODEL,
+            ),
+        )
+    return virtual_views[unique_id]
+
+
+def init_dbt_tests(
+    virtual_views: Dict[str, VirtualView], dbt_model_unique_id: str
+) -> List[DbtTest]:
+    assert dbt_model_unique_id in virtual_views
+
+    dbt_model = virtual_views[dbt_model_unique_id].dbt_model
+    if dbt_model.tests is None:
+        dbt_model.tests = []
+    return dbt_model.tests
+
+
+def init_schema(dataset: Dataset) -> None:
+    if not dataset.schema:
+        dataset.schema = DatasetSchema()
+        dataset.schema.schema_type = SchemaType.SQL
+        dataset.schema.fields = []
+
+
+def init_field(fields: List[SchemaField], column: str) -> SchemaField:
+    field = next((f for f in fields if f.field_path == column), None)
+    if not field:
+        field = SchemaField(field_path=column)
+        fields.append(field)
+    return field
+
+
+def init_documentation(dataset: Dataset) -> None:
+    if not dataset.documentation:
+        dataset.documentation = DatasetDocumentation()
+        dataset.documentation.dataset_documentations = []
+        dataset.documentation.field_documentations = []
+
+
+def init_field_doc(dataset: Dataset, column: str) -> FieldDocumentation:
+    assert (
+        dataset.documentation is not None
+        and dataset.documentation.field_documentations is not None
+    )
+
+    doc = next(
+        (
+            d
+            for d in dataset.documentation.field_documentations
+            if d.field_path == column
+        ),
+        None,
+    )
+    if not doc:
+        doc = FieldDocumentation()
+        doc.field_path = column
+        dataset.documentation.field_documentations.append(doc)
+    return doc
+
+
+def build_docs_url(docs_base_url: Optional[str], unique_id: str) -> Optional[str]:
+    return f"{docs_base_url}/#!/model/{unique_id}" if docs_base_url else None
+
+
+def build_source_code_url(
+    project_source_url: Optional[str], file_path: str
+) -> Optional[str]:
+    return f"{project_source_url}/{file_path}" if project_source_url else None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.19"
+version = "0.10.20"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/dbt/data/trial_v4/catalog.json
+++ b/tests/dbt/data/trial_v4/catalog.json
@@ -1,0 +1,458 @@
+{
+  "metadata": {
+    "dbt_schema_version": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+    "dbt_version": "1.0.1",
+    "generated_at": "2022-02-03T07:01:59.019175Z",
+    "invocation_id": "90972c0a-9798-4994-a8c1-f7f9cc174648",
+    "env": {}
+  },
+  "nodes": {
+    "model.trial.my_first_dbt_model": {
+      "metadata": {
+        "type": "VIEW",
+        "schema": "DBT_YI",
+        "name": "MY_FIRST_DBT_MODEL",
+        "database": "DEV_DB",
+        "comment": "A starter dbt model, my_first_dbt_model",
+        "owner": "ACCOUNTADMIN"
+      },
+      "columns": {
+        "ID": {
+          "type": "NUMBER",
+          "index": 1,
+          "name": "ID",
+          "comment": null
+        }
+      },
+      "stats": {
+        "has_stats": {
+          "id": "has_stats",
+          "label": "Has Stats?",
+          "value": false,
+          "include": false,
+          "description": "Indicates whether there are statistics for this table"
+        }
+      },
+      "unique_id": "model.trial.my_first_dbt_model"
+    },
+    "model.trial.my_second_dbt_model": {
+      "metadata": {
+        "type": "VIEW",
+        "schema": "DBT_YI",
+        "name": "MY_SECOND_DBT_MODEL",
+        "database": "DEV_DB",
+        "comment": "A starter dbt model, my_second_dbt_model",
+        "owner": "ACCOUNTADMIN"
+      },
+      "columns": {
+        "ID": {
+          "type": "NUMBER",
+          "index": 1,
+          "name": "ID",
+          "comment": null
+        }
+      },
+      "stats": {
+        "has_stats": {
+          "id": "has_stats",
+          "label": "Has Stats?",
+          "value": false,
+          "include": false,
+          "description": "Indicates whether there are statistics for this table"
+        }
+      },
+      "unique_id": "model.trial.my_second_dbt_model"
+    },
+    "model.trial.trial_model_1": {
+      "metadata": {
+        "type": "BASE TABLE",
+        "schema": "DBT_YI",
+        "name": "TRIAL_MODEL_1",
+        "database": "DEV_DB",
+        "comment": "First trial model, mapping columns from NETFLIX source table",
+        "owner": "ACCOUNTADMIN"
+      },
+      "columns": {
+        "SHOW_ID": {
+          "type": "TEXT",
+          "index": 1,
+          "name": "SHOW_ID",
+          "comment": "The show id, primary key for this table"
+        },
+        "TYPE": {
+          "type": "TEXT",
+          "index": 2,
+          "name": "TYPE",
+          "comment": "The type of the show, e.g. Movie or TV Show"
+        },
+        "TITLE": {
+          "type": "TEXT",
+          "index": 3,
+          "name": "TITLE",
+          "comment": "The title of the show"
+        },
+        "COUNTRY": {
+          "type": "TEXT",
+          "index": 4,
+          "name": "COUNTRY",
+          "comment": "The country where the show was originated from"
+        },
+        "RELEASE_YEAR": {
+          "type": "NUMBER",
+          "index": 5,
+          "name": "RELEASE_YEAR",
+          "comment": "The year the show was released"
+        }
+      },
+      "stats": {
+        "row_count": {
+          "id": "row_count",
+          "label": "Row Count",
+          "value": 7787.0,
+          "include": true,
+          "description": "An approximate count of rows in this table"
+        },
+        "bytes": {
+          "id": "bytes",
+          "label": "Approximate Size",
+          "value": 185856.0,
+          "include": true,
+          "description": "Approximate size of the table as reported by Snowflake"
+        },
+        "last_modified": {
+          "id": "last_modified",
+          "label": "Last Modified",
+          "value": "2022-02-03 07:01UTC",
+          "include": true,
+          "description": "The timestamp for last update/change"
+        },
+        "has_stats": {
+          "id": "has_stats",
+          "label": "Has Stats?",
+          "value": true,
+          "include": false,
+          "description": "Indicates whether there are statistics for this table"
+        }
+      },
+      "unique_id": "model.trial.trial_model_1"
+    },
+    "model.trial.trial_model_2": {
+      "metadata": {
+        "type": "BASE TABLE",
+        "schema": "DBT_YI",
+        "name": "SALES_SUMMARY",
+        "database": "DEV_DB",
+        "comment": "Second trial model, get statistics from SALES_RECORDS table",
+        "owner": "ACCOUNTADMIN"
+      },
+      "columns": {
+        "COUNTRY": {
+          "type": "TEXT",
+          "index": 1,
+          "name": "COUNTRY",
+          "comment": "The country where the sales records are from"
+        },
+        "ITEM_TYPE": {
+          "type": "TEXT",
+          "index": 2,
+          "name": "ITEM_TYPE",
+          "comment": "The type of the item, e.g. clothes, household, etc"
+        },
+        "YEAR": {
+          "type": "NUMBER",
+          "index": 3,
+          "name": "YEAR",
+          "comment": "The year that the aggregated sales statistics is for"
+        },
+        "REVENUE": {
+          "type": "NUMBER",
+          "index": 4,
+          "name": "REVENUE",
+          "comment": "The total revenue aggregated over the country + item_type + year"
+        },
+        "PROFIT": {
+          "type": "NUMBER",
+          "index": 5,
+          "name": "PROFIT",
+          "comment": "The total profit aggregated over the country + item_type + year"
+        }
+      },
+      "stats": {
+        "row_count": {
+          "id": "row_count",
+          "label": "Row Count",
+          "value": 17656.0,
+          "include": true,
+          "description": "An approximate count of rows in this table"
+        },
+        "bytes": {
+          "id": "bytes",
+          "label": "Approximate Size",
+          "value": 219136.0,
+          "include": true,
+          "description": "Approximate size of the table as reported by Snowflake"
+        },
+        "last_modified": {
+          "id": "last_modified",
+          "label": "Last Modified",
+          "value": "2022-02-03 07:01UTC",
+          "include": true,
+          "description": "The timestamp for last update/change"
+        },
+        "has_stats": {
+          "id": "has_stats",
+          "label": "Has Stats?",
+          "value": true,
+          "include": false,
+          "description": "Indicates whether there are statistics for this table"
+        }
+      },
+      "unique_id": "model.trial.trial_model_2"
+    }
+  },
+  "sources": {
+    "source.trial.DBT_DEV.NETFLIX": {
+      "metadata": {
+        "type": "BASE TABLE",
+        "schema": "DBT_DEV",
+        "name": "NETFLIX",
+        "database": "DEV_DB",
+        "comment": null,
+        "owner": "ACCOUNTADMIN"
+      },
+      "columns": {
+        "SHOW_ID": {
+          "type": "TEXT",
+          "index": 1,
+          "name": "SHOW_ID",
+          "comment": "SHOW_ID. SALES_RECORDS"
+        },
+        "TYPE": {
+          "type": "TEXT",
+          "index": 2,
+          "name": "TYPE",
+          "comment": "TYPE. SALES_RECORDS"
+        },
+        "TITLE": {
+          "type": "TEXT",
+          "index": 3,
+          "name": "TITLE",
+          "comment": "TITLE. SALES_RECORDS"
+        },
+        "DIRECTOR": {
+          "type": "TEXT",
+          "index": 4,
+          "name": "DIRECTOR",
+          "comment": "DIRECTOR. SALES_RECORDS"
+        },
+        "CAST": {
+          "type": "TEXT",
+          "index": 5,
+          "name": "CAST",
+          "comment": "CAST. SALES_RECORDS"
+        },
+        "COUNTRY": {
+          "type": "TEXT",
+          "index": 6,
+          "name": "COUNTRY",
+          "comment": "COUNTRY. SALES_RECORDS"
+        },
+        "DATE_ADDED": {
+          "type": "DATE",
+          "index": 7,
+          "name": "DATE_ADDED",
+          "comment": "DATE_ADDED. SALES_RECORDS"
+        },
+        "RELEASE_YEAR": {
+          "type": "NUMBER",
+          "index": 8,
+          "name": "RELEASE_YEAR",
+          "comment": "RELEASE_YEAR. SALES_RECORDS"
+        },
+        "RATING": {
+          "type": "TEXT",
+          "index": 9,
+          "name": "RATING",
+          "comment": "RATING. SALES_RECORDS"
+        },
+        "DURATION": {
+          "type": "TEXT",
+          "index": 10,
+          "name": "DURATION",
+          "comment": "DURATION. SALES_RECORDS"
+        },
+        "LISTED_IN": {
+          "type": "TEXT",
+          "index": 11,
+          "name": "LISTED_IN",
+          "comment": "LISTED_IN. SALES_RECORDS"
+        },
+        "DESCRIPTION": {
+          "type": "TEXT",
+          "index": 12,
+          "name": "DESCRIPTION",
+          "comment": "DESCRIPTION. SALES_RECORDS"
+        }
+      },
+      "stats": {
+        "row_count": {
+          "id": "row_count",
+          "label": "Row Count",
+          "value": 7787.0,
+          "include": true,
+          "description": "An approximate count of rows in this table"
+        },
+        "bytes": {
+          "id": "bytes",
+          "label": "Approximate Size",
+          "value": 1655296.0,
+          "include": true,
+          "description": "Approximate size of the table as reported by Snowflake"
+        },
+        "last_modified": {
+          "id": "last_modified",
+          "label": "Last Modified",
+          "value": "2021-10-01 21:13UTC",
+          "include": true,
+          "description": "The timestamp for last update/change"
+        },
+        "has_stats": {
+          "id": "has_stats",
+          "label": "Has Stats?",
+          "value": true,
+          "include": false,
+          "description": "Indicates whether there are statistics for this table"
+        }
+      },
+      "unique_id": "source.trial.DBT_DEV.NETFLIX"
+    },
+    "source.trial.DBT_DEV.SALES_RECORDS": {
+      "metadata": {
+        "type": "BASE TABLE",
+        "schema": "DBT_DEV",
+        "name": "SALES_RECORDS",
+        "database": "DEV_DB",
+        "comment": null,
+        "owner": "ACCOUNTADMIN"
+      },
+      "columns": {
+        "REGION": {
+          "type": "TEXT",
+          "index": 1,
+          "name": "REGION",
+          "comment": "REGION. SALES_RECORDS"
+        },
+        "COUNTRY": {
+          "type": "TEXT",
+          "index": 2,
+          "name": "COUNTRY",
+          "comment": "COUNTRY. SALES_RECORDS"
+        },
+        "ITEM_TYPE": {
+          "type": "TEXT",
+          "index": 3,
+          "name": "ITEM_TYPE",
+          "comment": "ITEM_TYPE. SALES_RECORDS"
+        },
+        "SALES_CHANNEL": {
+          "type": "TEXT",
+          "index": 4,
+          "name": "SALES_CHANNEL",
+          "comment": "SALES_CHANNEL. SALES_RECORDS"
+        },
+        "ORDER_PRIORITY": {
+          "type": "TEXT",
+          "index": 5,
+          "name": "ORDER_PRIORITY",
+          "comment": "ORDER_PRIORITY. SALES_RECORDS"
+        },
+        "ORDER_DATE": {
+          "type": "DATE",
+          "index": 6,
+          "name": "ORDER_DATE",
+          "comment": "ORDER_DATE. SALES_RECORDS"
+        },
+        "ORDER_ID": {
+          "type": "NUMBER",
+          "index": 7,
+          "name": "ORDER_ID",
+          "comment": "ORDER_ID. SALES_RECORDS"
+        },
+        "SHIP_DATE": {
+          "type": "DATE",
+          "index": 8,
+          "name": "SHIP_DATE",
+          "comment": "SHIP_DATE. SALES_RECORDS"
+        },
+        "UNITS_SOLD": {
+          "type": "NUMBER",
+          "index": 9,
+          "name": "UNITS_SOLD",
+          "comment": "UNITS_SOLD. SALES_RECORDS"
+        },
+        "UNIT_PRICE": {
+          "type": "NUMBER",
+          "index": 10,
+          "name": "UNIT_PRICE",
+          "comment": "UNIT_PRICE. SALES_RECORDS"
+        },
+        "UNIT_COST": {
+          "type": "NUMBER",
+          "index": 11,
+          "name": "UNIT_COST",
+          "comment": "UNIT_COST. SALES_RECORDS"
+        },
+        "TOTAL_REVENUE": {
+          "type": "NUMBER",
+          "index": 12,
+          "name": "TOTAL_REVENUE",
+          "comment": "TOTAL_REVENUE. SALES_RECORDS"
+        },
+        "TOTAL_COST": {
+          "type": "NUMBER",
+          "index": 13,
+          "name": "TOTAL_COST",
+          "comment": "TOTAL_COST. SALES_RECORDS"
+        },
+        "TOTAL_PROFIT": {
+          "type": "NUMBER",
+          "index": 14,
+          "name": "TOTAL_PROFIT",
+          "comment": "TOTAL_PROFIT. SALES_RECORDS"
+        }
+      },
+      "stats": {
+        "row_count": {
+          "id": "row_count",
+          "label": "Row Count",
+          "value": 100000.0,
+          "include": true,
+          "description": "An approximate count of rows in this table"
+        },
+        "bytes": {
+          "id": "bytes",
+          "label": "Approximate Size",
+          "value": 2019328.0,
+          "include": true,
+          "description": "Approximate size of the table as reported by Snowflake"
+        },
+        "last_modified": {
+          "id": "last_modified",
+          "label": "Last Modified",
+          "value": "2021-10-01 21:14UTC",
+          "include": true,
+          "description": "The timestamp for last update/change"
+        },
+        "has_stats": {
+          "id": "has_stats",
+          "label": "Has Stats?",
+          "value": true,
+          "include": false,
+          "description": "Indicates whether there are statistics for this table"
+        }
+      },
+      "unique_id": "source.trial.DBT_DEV.SALES_RECORDS"
+    }
+  },
+  "errors": null
+}

--- a/tests/dbt/data/trial_v4/manifest.json
+++ b/tests/dbt/data/trial_v4/manifest.json
@@ -1,0 +1,8633 @@
+{
+  "metadata": {
+    "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v4.json",
+    "dbt_version": "1.0.1",
+    "generated_at": "2022-02-03T07:01:55.160948Z",
+    "invocation_id": "90972c0a-9798-4994-a8c1-f7f9cc174648",
+    "env": {},
+    "project_id": "58723627fcebc230ab0d53ddf5f16e34",
+    "user_id": "6ec20d7d-8712-4cd3-9028-3073d2157361",
+    "send_anonymous_usage_stats": true,
+    "adapter_type": "snowflake"
+  },
+  "nodes": {
+    "model.trial.my_first_dbt_model": {
+      "raw_sql": "/*\n    Welcome to your first dbt model!\n    Did you know that you can also configure models directly within SQL files?\n    This will override configurations stated in dbt_project.yml\n\n    Try changing \"table\" to \"view\" below\n*/\n\nwith source_data as (\n\n    select 1 as id\n    union all\n    select null as id\n\n)\n\nselect *\nfrom source_data\n\n/*\n    Uncomment the line below to remove records with null `id` values\n*/\n\n-- where id is not null",
+      "compiled": true,
+      "resource_type": "model",
+      "depends_on": {
+        "macros": [],
+        "nodes": []
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": null,
+        "database": null,
+        "tags": [],
+        "meta": {
+          "owner": "yi@metaphor.io"
+        },
+        "materialized": "view",
+        "persist_docs": {
+          "relation": true,
+          "columns": true
+        },
+        "quoting": {},
+        "column_types": {},
+        "full_refresh": null,
+        "on_schema_change": "ignore",
+        "post-hook": [],
+        "pre-hook": []
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI",
+      "fqn": [
+        "trial",
+        "example",
+        "my_first_dbt_model"
+      ],
+      "unique_id": "model.trial.my_first_dbt_model",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "example/my_first_dbt_model.sql",
+      "original_file_path": "models/example/my_first_dbt_model.sql",
+      "name": "my_first_dbt_model",
+      "alias": "my_first_dbt_model",
+      "checksum": {
+        "name": "sha256",
+        "checksum": "19723996b16262b4d4a31d9c821866f16a0cc1e2bea514d8c221d6aae2e1cc76"
+      },
+      "tags": [],
+      "refs": [],
+      "sources": [],
+      "description": "A starter dbt model, my_first_dbt_model",
+      "columns": {
+        "id": {
+          "name": "id",
+          "description": "The primary key for this table, auto generated id",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        }
+      },
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": "trial://models/example/schema.yml",
+      "compiled_path": "target/compiled/trial/models/example/my_first_dbt_model.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {
+        "persist_docs": {
+          "relation": true,
+          "columns": true
+        },
+        "materialized": "view"
+      },
+      "created_at": 1643871657.177454,
+      "compiled_sql": "/*\n    Welcome to your first dbt model!\n    Did you know that you can also configure models directly within SQL files?\n    This will override configurations stated in dbt_project.yml\n\n    Try changing \"table\" to \"view\" below\n*/\n\nwith source_data as (\n\n    select 1 as id\n    union all\n    select null as id\n\n)\n\nselect *\nfrom source_data\n\n/*\n    Uncomment the line below to remove records with null `id` values\n*/\n\n-- where id is not null",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": "DEV_DB.DBT_YI.my_first_dbt_model"
+    },
+    "model.trial.my_second_dbt_model": {
+      "raw_sql": "-- Use the `ref` function to select from other models\n\nselect *\nfrom {{ ref('my_first_dbt_model') }}\nwhere id = 1",
+      "compiled": true,
+      "resource_type": "model",
+      "depends_on": {
+        "macros": [],
+        "nodes": [
+          "model.trial.my_first_dbt_model"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": null,
+        "database": null,
+        "tags": [],
+        "meta": {
+          "owner": "yi@metaphor.io"
+        },
+        "materialized": "view",
+        "persist_docs": {
+          "relation": true,
+          "columns": true
+        },
+        "quoting": {},
+        "column_types": {},
+        "full_refresh": null,
+        "on_schema_change": "ignore",
+        "post-hook": [],
+        "pre-hook": []
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI",
+      "fqn": [
+        "trial",
+        "example",
+        "my_second_dbt_model"
+      ],
+      "unique_id": "model.trial.my_second_dbt_model",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "example/my_second_dbt_model.sql",
+      "original_file_path": "models/example/my_second_dbt_model.sql",
+      "name": "my_second_dbt_model",
+      "alias": "my_second_dbt_model",
+      "checksum": {
+        "name": "sha256",
+        "checksum": "b3aa346f283f3c9c9a75936f3b80d2572ca9ab39aee4c02b30553d3fe2ba5692"
+      },
+      "tags": [],
+      "refs": [
+        [
+          "my_first_dbt_model"
+        ]
+      ],
+      "sources": [],
+      "description": "A starter dbt model, my_second_dbt_model",
+      "columns": {
+        "id": {
+          "name": "id",
+          "description": "The primary key for this table, referencing the primary key in 'my_first_dbt_model'",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        }
+      },
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": "trial://models/example/schema.yml",
+      "compiled_path": "target/compiled/trial/models/example/my_second_dbt_model.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {
+        "persist_docs": {
+          "relation": true,
+          "columns": true
+        },
+        "materialized": "view"
+      },
+      "created_at": 1643871657.179069,
+      "compiled_sql": "-- Use the `ref` function to select from other models\n\nselect *\nfrom DEV_DB.DBT_YI.my_first_dbt_model\nwhere id = 1",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": "DEV_DB.DBT_YI.my_second_dbt_model"
+    },
+    "model.trial.trial_model_1": {
+      "raw_sql": "{{ config(materialized='table') }}\n\nselect show_id, type, title, country, release_year \nfrom {{ source('DBT_DEV', 'NETFLIX') }}",
+      "compiled": true,
+      "resource_type": "model",
+      "depends_on": {
+        "macros": [],
+        "nodes": [
+          "source.trial.DBT_DEV.NETFLIX"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": null,
+        "database": null,
+        "tags": [],
+        "meta": {
+          "owner": "yi@metaphor.io"
+        },
+        "materialized": "table",
+        "persist_docs": {
+          "relation": true,
+          "columns": true
+        },
+        "quoting": {},
+        "column_types": {},
+        "full_refresh": null,
+        "on_schema_change": "ignore",
+        "post-hook": [],
+        "pre-hook": []
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI",
+      "fqn": [
+        "trial",
+        "example",
+        "trial_model_1"
+      ],
+      "unique_id": "model.trial.trial_model_1",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "example/trial_model_1.sql",
+      "original_file_path": "models/example/trial_model_1.sql",
+      "name": "trial_model_1",
+      "alias": "trial_model_1",
+      "checksum": {
+        "name": "sha256",
+        "checksum": "2dd06346f27086fcb5e4049178c75df7e5eaa91e31cd6f82a0a8b2dff0339eaf"
+      },
+      "tags": [],
+      "refs": [],
+      "sources": [
+        [
+          "DBT_DEV",
+          "NETFLIX"
+        ]
+      ],
+      "description": "First trial model, mapping columns from NETFLIX source table",
+      "columns": {
+        "show_id": {
+          "name": "show_id",
+          "description": "The show id, primary key for this table",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "type": {
+          "name": "type",
+          "description": "The type of the show, e.g. Movie or TV Show",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "title": {
+          "name": "title",
+          "description": "The title of the show",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "country": {
+          "name": "country",
+          "description": "The country where the show was originated from",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "release_year": {
+          "name": "release_year",
+          "description": "The year the show was released",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        }
+      },
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": "trial://models/example/schema.yml",
+      "compiled_path": "target/compiled/trial/models/example/trial_model_1.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {
+        "persist_docs": {
+          "relation": true,
+          "columns": true
+        },
+        "materialized": "table"
+      },
+      "created_at": 1643871657.181368,
+      "compiled_sql": "\n\nselect show_id, type, title, country, release_year \nfrom DEV_DB.DBT_DEV.NETFLIX",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": "DEV_DB.DBT_YI.trial_model_1"
+    },
+    "model.trial.trial_model_2": {
+      "raw_sql": "{{ config(materialized='table', alias='sales_summary') }}\n\nselect country, item_type, \n  year(order_date) as year, \n  sum(total_revenue) as revenue, \n  sum(total_profit) as profit\nfrom {{ source('DBT_DEV', 'SALES_RECORDS') }}\ngroup by country, item_type, year(order_date)\norder by revenue desc",
+      "compiled": true,
+      "resource_type": "model",
+      "depends_on": {
+        "macros": [],
+        "nodes": [
+          "source.trial.DBT_DEV.SALES_RECORDS"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": "sales_summary",
+        "schema": null,
+        "database": null,
+        "tags": [],
+        "meta": {
+          "owner": "yi@metaphor.io"
+        },
+        "materialized": "table",
+        "persist_docs": {
+          "relation": true,
+          "columns": true
+        },
+        "quoting": {},
+        "column_types": {},
+        "full_refresh": null,
+        "on_schema_change": "ignore",
+        "post-hook": [],
+        "pre-hook": []
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI",
+      "fqn": [
+        "trial",
+        "example",
+        "trial_model_2"
+      ],
+      "unique_id": "model.trial.trial_model_2",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "example/trial_model_2.sql",
+      "original_file_path": "models/example/trial_model_2.sql",
+      "name": "trial_model_2",
+      "alias": "sales_summary",
+      "checksum": {
+        "name": "sha256",
+        "checksum": "1fb1c72d355260f6dad90492056d3c8f5bcf6a23d7547c07a9c8b4c74141af3c"
+      },
+      "tags": [],
+      "refs": [],
+      "sources": [
+        [
+          "DBT_DEV",
+          "SALES_RECORDS"
+        ]
+      ],
+      "description": "Second trial model, get statistics from SALES_RECORDS table",
+      "columns": {
+        "country": {
+          "name": "country",
+          "description": "The country where the sales records are from",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "item_type": {
+          "name": "item_type",
+          "description": "The type of the item, e.g. clothes, household, etc",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "year": {
+          "name": "year",
+          "description": "The year that the aggregated sales statistics is for",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "revenue": {
+          "name": "revenue",
+          "description": "The total revenue aggregated over the country + item_type + year",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "profit": {
+          "name": "profit",
+          "description": "The total profit aggregated over the country + item_type + year",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        }
+      },
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": "trial://models/example/schema.yml",
+      "compiled_path": "target/compiled/trial/models/example/trial_model_2.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {
+        "persist_docs": {
+          "relation": true,
+          "columns": true
+        },
+        "materialized": "table",
+        "alias": "sales_summary"
+      },
+      "created_at": 1643871657.1839292,
+      "compiled_sql": "\n\nselect country, item_type, \n  year(order_date) as year, \n  sum(total_revenue) as revenue, \n  sum(total_profit) as profit\nfrom DEV_DB.DBT_DEV.SALES_RECORDS\ngroup by country, item_type, year(order_date)\norder by revenue desc",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": "DEV_DB.DBT_YI.sales_summary"
+    },
+    "test.trial.unique_my_first_dbt_model_id.16e066b321": {
+      "raw_sql": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "unique",
+        "kwargs": {
+          "column_name": "id",
+          "model": "{{ get_where_subquery(ref('my_first_dbt_model')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_unique",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "model.trial.my_first_dbt_model"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "unique_my_first_dbt_model_id"
+      ],
+      "unique_id": "test.trial.unique_my_first_dbt_model_id.16e066b321",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "unique_my_first_dbt_model_id.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "unique_my_first_dbt_model_id",
+      "alias": "unique_my_first_dbt_model_id",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [
+        [
+          "my_first_dbt_model"
+        ]
+      ],
+      "sources": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/unique_my_first_dbt_model_id.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.188994,
+      "compiled_sql": "\n    \n    \n\nselect\n    id as unique_field,\n    count(*) as n_records\n\nfrom DEV_DB.DBT_YI.my_first_dbt_model\nwhere id is not null\ngroup by id\nhaving count(*) > 1\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "id",
+      "file_key_name": "models.my_first_dbt_model"
+    },
+    "test.trial.not_null_my_first_dbt_model_id.5fb22c2710": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "id",
+          "model": "{{ get_where_subquery(ref('my_first_dbt_model')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "model.trial.my_first_dbt_model"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "not_null_my_first_dbt_model_id"
+      ],
+      "unique_id": "test.trial.not_null_my_first_dbt_model_id.5fb22c2710",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "not_null_my_first_dbt_model_id.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "not_null_my_first_dbt_model_id",
+      "alias": "not_null_my_first_dbt_model_id",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [
+        [
+          "my_first_dbt_model"
+        ]
+      ],
+      "sources": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/not_null_my_first_dbt_model_id.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.19025,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_YI.my_first_dbt_model\nwhere id is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "id",
+      "file_key_name": "models.my_first_dbt_model"
+    },
+    "test.trial.unique_my_second_dbt_model_id.57a0f8c493": {
+      "raw_sql": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "unique",
+        "kwargs": {
+          "column_name": "id",
+          "model": "{{ get_where_subquery(ref('my_second_dbt_model')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_unique",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "model.trial.my_second_dbt_model"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "unique_my_second_dbt_model_id"
+      ],
+      "unique_id": "test.trial.unique_my_second_dbt_model_id.57a0f8c493",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "unique_my_second_dbt_model_id.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "unique_my_second_dbt_model_id",
+      "alias": "unique_my_second_dbt_model_id",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [
+        [
+          "my_second_dbt_model"
+        ]
+      ],
+      "sources": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/unique_my_second_dbt_model_id.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.191454,
+      "compiled_sql": "\n    \n    \n\nselect\n    id as unique_field,\n    count(*) as n_records\n\nfrom DEV_DB.DBT_YI.my_second_dbt_model\nwhere id is not null\ngroup by id\nhaving count(*) > 1\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "id",
+      "file_key_name": "models.my_second_dbt_model"
+    },
+    "test.trial.not_null_my_second_dbt_model_id.151b76d778": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "id",
+          "model": "{{ get_where_subquery(ref('my_second_dbt_model')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "model.trial.my_second_dbt_model"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "not_null_my_second_dbt_model_id"
+      ],
+      "unique_id": "test.trial.not_null_my_second_dbt_model_id.151b76d778",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "not_null_my_second_dbt_model_id.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "not_null_my_second_dbt_model_id",
+      "alias": "not_null_my_second_dbt_model_id",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [
+        [
+          "my_second_dbt_model"
+        ]
+      ],
+      "sources": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/not_null_my_second_dbt_model_id.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.1927612,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_YI.my_second_dbt_model\nwhere id is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "id",
+      "file_key_name": "models.my_second_dbt_model"
+    },
+    "test.trial.unique_trial_model_1_show_id.6e142709e3": {
+      "raw_sql": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "unique",
+        "kwargs": {
+          "column_name": "show_id",
+          "model": "{{ get_where_subquery(ref('trial_model_1')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_unique",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "model.trial.trial_model_1"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "unique_trial_model_1_show_id"
+      ],
+      "unique_id": "test.trial.unique_trial_model_1_show_id.6e142709e3",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "unique_trial_model_1_show_id.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "unique_trial_model_1_show_id",
+      "alias": "unique_trial_model_1_show_id",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [
+        [
+          "trial_model_1"
+        ]
+      ],
+      "sources": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/unique_trial_model_1_show_id.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.193929,
+      "compiled_sql": "\n    \n    \n\nselect\n    show_id as unique_field,\n    count(*) as n_records\n\nfrom DEV_DB.DBT_YI.trial_model_1\nwhere show_id is not null\ngroup by show_id\nhaving count(*) > 1\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "show_id",
+      "file_key_name": "models.trial_model_1"
+    },
+    "test.trial.not_null_trial_model_1_show_id.210878cb19": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "show_id",
+          "model": "{{ get_where_subquery(ref('trial_model_1')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "model.trial.trial_model_1"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "not_null_trial_model_1_show_id"
+      ],
+      "unique_id": "test.trial.not_null_trial_model_1_show_id.210878cb19",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "not_null_trial_model_1_show_id.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "not_null_trial_model_1_show_id",
+      "alias": "not_null_trial_model_1_show_id",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [
+        [
+          "trial_model_1"
+        ]
+      ],
+      "sources": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/not_null_trial_model_1_show_id.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.1950982,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_YI.trial_model_1\nwhere show_id is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "show_id",
+      "file_key_name": "models.trial_model_1"
+    },
+    "test.trial.not_null_trial_model_1_type.051dc613aa": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "type",
+          "model": "{{ get_where_subquery(ref('trial_model_1')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "model.trial.trial_model_1"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "not_null_trial_model_1_type"
+      ],
+      "unique_id": "test.trial.not_null_trial_model_1_type.051dc613aa",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "not_null_trial_model_1_type.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "not_null_trial_model_1_type",
+      "alias": "not_null_trial_model_1_type",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [
+        [
+          "trial_model_1"
+        ]
+      ],
+      "sources": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/not_null_trial_model_1_type.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.196268,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_YI.trial_model_1\nwhere type is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "type",
+      "file_key_name": "models.trial_model_1"
+    },
+    "test.trial.not_null_trial_model_1_title.b49e531d6d": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "title",
+          "model": "{{ get_where_subquery(ref('trial_model_1')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "model.trial.trial_model_1"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "not_null_trial_model_1_title"
+      ],
+      "unique_id": "test.trial.not_null_trial_model_1_title.b49e531d6d",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "not_null_trial_model_1_title.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "not_null_trial_model_1_title",
+      "alias": "not_null_trial_model_1_title",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [
+        [
+          "trial_model_1"
+        ]
+      ],
+      "sources": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/not_null_trial_model_1_title.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.1980832,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_YI.trial_model_1\nwhere title is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "title",
+      "file_key_name": "models.trial_model_1"
+    },
+    "test.trial.not_null_trial_model_2_country.8170348e7c": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "country",
+          "model": "{{ get_where_subquery(ref('trial_model_2')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "model.trial.trial_model_2"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "not_null_trial_model_2_country"
+      ],
+      "unique_id": "test.trial.not_null_trial_model_2_country.8170348e7c",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "not_null_trial_model_2_country.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "not_null_trial_model_2_country",
+      "alias": "not_null_trial_model_2_country",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [
+        [
+          "trial_model_2"
+        ]
+      ],
+      "sources": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/not_null_trial_model_2_country.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.19926,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_YI.sales_summary\nwhere country is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "country",
+      "file_key_name": "models.trial_model_2"
+    },
+    "test.trial.not_null_trial_model_2_item_type.1e87bba840": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "item_type",
+          "model": "{{ get_where_subquery(ref('trial_model_2')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "model.trial.trial_model_2"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "not_null_trial_model_2_item_type"
+      ],
+      "unique_id": "test.trial.not_null_trial_model_2_item_type.1e87bba840",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "not_null_trial_model_2_item_type.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "not_null_trial_model_2_item_type",
+      "alias": "not_null_trial_model_2_item_type",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [
+        [
+          "trial_model_2"
+        ]
+      ],
+      "sources": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/not_null_trial_model_2_item_type.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.200418,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_YI.sales_summary\nwhere item_type is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "item_type",
+      "file_key_name": "models.trial_model_2"
+    },
+    "test.trial.not_null_trial_model_2_year.eb13ae8f8b": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "year",
+          "model": "{{ get_where_subquery(ref('trial_model_2')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "model.trial.trial_model_2"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "not_null_trial_model_2_year"
+      ],
+      "unique_id": "test.trial.not_null_trial_model_2_year.eb13ae8f8b",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "not_null_trial_model_2_year.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "not_null_trial_model_2_year",
+      "alias": "not_null_trial_model_2_year",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [
+        [
+          "trial_model_2"
+        ]
+      ],
+      "sources": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/not_null_trial_model_2_year.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.2017028,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_YI.sales_summary\nwhere year is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "year",
+      "file_key_name": "models.trial_model_2"
+    },
+    "test.trial.not_null_trial_model_2_revenue.c697e41758": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "revenue",
+          "model": "{{ get_where_subquery(ref('trial_model_2')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "model.trial.trial_model_2"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "not_null_trial_model_2_revenue"
+      ],
+      "unique_id": "test.trial.not_null_trial_model_2_revenue.c697e41758",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "not_null_trial_model_2_revenue.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "not_null_trial_model_2_revenue",
+      "alias": "not_null_trial_model_2_revenue",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [
+        [
+          "trial_model_2"
+        ]
+      ],
+      "sources": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/not_null_trial_model_2_revenue.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.2028549,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_YI.sales_summary\nwhere revenue is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "revenue",
+      "file_key_name": "models.trial_model_2"
+    },
+    "test.trial.not_null_trial_model_2_profit.faa538228c": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "profit",
+          "model": "{{ get_where_subquery(ref('trial_model_2')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "model.trial.trial_model_2"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "not_null_trial_model_2_profit"
+      ],
+      "unique_id": "test.trial.not_null_trial_model_2_profit.faa538228c",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "not_null_trial_model_2_profit.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "not_null_trial_model_2_profit",
+      "alias": "not_null_trial_model_2_profit",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [
+        [
+          "trial_model_2"
+        ]
+      ],
+      "sources": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/not_null_trial_model_2_profit.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.2040188,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_YI.sales_summary\nwhere profit is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "profit",
+      "file_key_name": "models.trial_model_2"
+    },
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_COUNTRY.17f064dcca": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "COUNTRY",
+          "model": "{{ get_where_subquery(source('DBT_DEV', 'SALES_RECORDS')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "source.trial.DBT_DEV.SALES_RECORDS"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "source_not_null_DBT_DEV_SALES_RECORDS_COUNTRY"
+      ],
+      "unique_id": "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_COUNTRY.17f064dcca",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "source_not_null_DBT_DEV_SALES_RECORDS_COUNTRY.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "source_not_null_DBT_DEV_SALES_RECORDS_COUNTRY",
+      "alias": "source_not_null_DBT_DEV_SALES_RECORDS_COUNTRY",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [],
+      "sources": [
+        [
+          "DBT_DEV",
+          "SALES_RECORDS"
+        ]
+      ],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/source_not_null_DBT_DEV_SALES_RECORDS_COUNTRY.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.2183092,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_DEV.SALES_RECORDS\nwhere COUNTRY is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "COUNTRY",
+      "file_key_name": "sources.DBT_DEV"
+    },
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_REGION.c46072ea28": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "REGION",
+          "model": "{{ get_where_subquery(source('DBT_DEV', 'SALES_RECORDS')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "source.trial.DBT_DEV.SALES_RECORDS"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "source_not_null_DBT_DEV_SALES_RECORDS_REGION"
+      ],
+      "unique_id": "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_REGION.c46072ea28",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "source_not_null_DBT_DEV_SALES_RECORDS_REGION.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "source_not_null_DBT_DEV_SALES_RECORDS_REGION",
+      "alias": "source_not_null_DBT_DEV_SALES_RECORDS_REGION",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [],
+      "sources": [
+        [
+          "DBT_DEV",
+          "SALES_RECORDS"
+        ]
+      ],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/source_not_null_DBT_DEV_SALES_RECORDS_REGION.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.219595,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_DEV.SALES_RECORDS\nwhere REGION is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "REGION",
+      "file_key_name": "sources.DBT_DEV"
+    },
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_ITEM_TYPE.c5a7998d7d": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "ITEM_TYPE",
+          "model": "{{ get_where_subquery(source('DBT_DEV', 'SALES_RECORDS')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "source.trial.DBT_DEV.SALES_RECORDS"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "source_not_null_DBT_DEV_SALES_RECORDS_ITEM_TYPE"
+      ],
+      "unique_id": "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_ITEM_TYPE.c5a7998d7d",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "source_not_null_DBT_DEV_SALES_RECORDS_ITEM_TYPE.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "source_not_null_DBT_DEV_SALES_RECORDS_ITEM_TYPE",
+      "alias": "source_not_null_DBT_DEV_SALES_RECORDS_ITEM_TYPE",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [],
+      "sources": [
+        [
+          "DBT_DEV",
+          "SALES_RECORDS"
+        ]
+      ],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/source_not_null_DBT_DEV_SALES_RECORDS_ITEM_TYPE.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.220775,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_DEV.SALES_RECORDS\nwhere ITEM_TYPE is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "ITEM_TYPE",
+      "file_key_name": "sources.DBT_DEV"
+    },
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_SALES_CHANNEL.520c545ccf": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "SALES_CHANNEL",
+          "model": "{{ get_where_subquery(source('DBT_DEV', 'SALES_RECORDS')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "source.trial.DBT_DEV.SALES_RECORDS"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "source_not_null_DBT_DEV_SALES_RECORDS_SALES_CHANNEL"
+      ],
+      "unique_id": "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_SALES_CHANNEL.520c545ccf",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "source_not_null_DBT_DEV_SALES_RECORDS_SALES_CHANNEL.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "source_not_null_DBT_DEV_SALES_RECORDS_SALES_CHANNEL",
+      "alias": "source_not_null_DBT_DEV_SALES_RECORDS_SALES_CHANNEL",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [],
+      "sources": [
+        [
+          "DBT_DEV",
+          "SALES_RECORDS"
+        ]
+      ],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/source_not_null_DBT_DEV_SALES_RECORDS_SALES_CHANNEL.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.221947,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_DEV.SALES_RECORDS\nwhere SALES_CHANNEL is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "SALES_CHANNEL",
+      "file_key_name": "sources.DBT_DEV"
+    },
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_ORDER_PRIORITY.43cf4e7e91": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "ORDER_PRIORITY",
+          "model": "{{ get_where_subquery(source('DBT_DEV', 'SALES_RECORDS')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "source.trial.DBT_DEV.SALES_RECORDS"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "source_not_null_DBT_DEV_SALES_RECORDS_ORDER_PRIORITY"
+      ],
+      "unique_id": "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_ORDER_PRIORITY.43cf4e7e91",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "source_not_null_DBT_DEV_SALES_RECORDS_ORDER_PRIORITY.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "source_not_null_DBT_DEV_SALES_RECORDS_ORDER_PRIORITY",
+      "alias": "source_not_null_DBT_DEV_SALES_RECORDS_ORDER_PRIORITY",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [],
+      "sources": [
+        [
+          "DBT_DEV",
+          "SALES_RECORDS"
+        ]
+      ],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/source_not_null_DBT_DEV_SALES_RECORDS_ORDER_PRIORITY.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.223231,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_DEV.SALES_RECORDS\nwhere ORDER_PRIORITY is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "ORDER_PRIORITY",
+      "file_key_name": "sources.DBT_DEV"
+    },
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_ORDER_DATE.2010925f09": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "ORDER_DATE",
+          "model": "{{ get_where_subquery(source('DBT_DEV', 'SALES_RECORDS')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "source.trial.DBT_DEV.SALES_RECORDS"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "source_not_null_DBT_DEV_SALES_RECORDS_ORDER_DATE"
+      ],
+      "unique_id": "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_ORDER_DATE.2010925f09",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "source_not_null_DBT_DEV_SALES_RECORDS_ORDER_DATE.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "source_not_null_DBT_DEV_SALES_RECORDS_ORDER_DATE",
+      "alias": "source_not_null_DBT_DEV_SALES_RECORDS_ORDER_DATE",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [],
+      "sources": [
+        [
+          "DBT_DEV",
+          "SALES_RECORDS"
+        ]
+      ],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/source_not_null_DBT_DEV_SALES_RECORDS_ORDER_DATE.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.224405,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_DEV.SALES_RECORDS\nwhere ORDER_DATE is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "ORDER_DATE",
+      "file_key_name": "sources.DBT_DEV"
+    },
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_ORDER_ID.32e037a302": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "ORDER_ID",
+          "model": "{{ get_where_subquery(source('DBT_DEV', 'SALES_RECORDS')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "source.trial.DBT_DEV.SALES_RECORDS"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "source_not_null_DBT_DEV_SALES_RECORDS_ORDER_ID"
+      ],
+      "unique_id": "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_ORDER_ID.32e037a302",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "source_not_null_DBT_DEV_SALES_RECORDS_ORDER_ID.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "source_not_null_DBT_DEV_SALES_RECORDS_ORDER_ID",
+      "alias": "source_not_null_DBT_DEV_SALES_RECORDS_ORDER_ID",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [],
+      "sources": [
+        [
+          "DBT_DEV",
+          "SALES_RECORDS"
+        ]
+      ],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/source_not_null_DBT_DEV_SALES_RECORDS_ORDER_ID.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.22557,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_DEV.SALES_RECORDS\nwhere ORDER_ID is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "ORDER_ID",
+      "file_key_name": "sources.DBT_DEV"
+    },
+    "test.trial.source_unique_DBT_DEV_SALES_RECORDS_ORDER_ID.ab6b427de3": {
+      "raw_sql": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "unique",
+        "kwargs": {
+          "column_name": "ORDER_ID",
+          "model": "{{ get_where_subquery(source('DBT_DEV', 'SALES_RECORDS')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_unique",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "source.trial.DBT_DEV.SALES_RECORDS"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "source_unique_DBT_DEV_SALES_RECORDS_ORDER_ID"
+      ],
+      "unique_id": "test.trial.source_unique_DBT_DEV_SALES_RECORDS_ORDER_ID.ab6b427de3",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "source_unique_DBT_DEV_SALES_RECORDS_ORDER_ID.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "source_unique_DBT_DEV_SALES_RECORDS_ORDER_ID",
+      "alias": "source_unique_DBT_DEV_SALES_RECORDS_ORDER_ID",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [],
+      "sources": [
+        [
+          "DBT_DEV",
+          "SALES_RECORDS"
+        ]
+      ],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/source_unique_DBT_DEV_SALES_RECORDS_ORDER_ID.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.2267468,
+      "compiled_sql": "\n    \n    \n\nselect\n    ORDER_ID as unique_field,\n    count(*) as n_records\n\nfrom DEV_DB.DBT_DEV.SALES_RECORDS\nwhere ORDER_ID is not null\ngroup by ORDER_ID\nhaving count(*) > 1\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "ORDER_ID",
+      "file_key_name": "sources.DBT_DEV"
+    },
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_SHIP_DATE.e673d5b4ac": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "SHIP_DATE",
+          "model": "{{ get_where_subquery(source('DBT_DEV', 'SALES_RECORDS')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "source.trial.DBT_DEV.SALES_RECORDS"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "source_not_null_DBT_DEV_SALES_RECORDS_SHIP_DATE"
+      ],
+      "unique_id": "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_SHIP_DATE.e673d5b4ac",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "source_not_null_DBT_DEV_SALES_RECORDS_SHIP_DATE.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "source_not_null_DBT_DEV_SALES_RECORDS_SHIP_DATE",
+      "alias": "source_not_null_DBT_DEV_SALES_RECORDS_SHIP_DATE",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [],
+      "sources": [
+        [
+          "DBT_DEV",
+          "SALES_RECORDS"
+        ]
+      ],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/source_not_null_DBT_DEV_SALES_RECORDS_SHIP_DATE.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.22802,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_DEV.SALES_RECORDS\nwhere SHIP_DATE is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "SHIP_DATE",
+      "file_key_name": "sources.DBT_DEV"
+    },
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_UNITS_SOLD.77de2d383d": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "UNITS_SOLD",
+          "model": "{{ get_where_subquery(source('DBT_DEV', 'SALES_RECORDS')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "source.trial.DBT_DEV.SALES_RECORDS"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "source_not_null_DBT_DEV_SALES_RECORDS_UNITS_SOLD"
+      ],
+      "unique_id": "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_UNITS_SOLD.77de2d383d",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "source_not_null_DBT_DEV_SALES_RECORDS_UNITS_SOLD.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "source_not_null_DBT_DEV_SALES_RECORDS_UNITS_SOLD",
+      "alias": "source_not_null_DBT_DEV_SALES_RECORDS_UNITS_SOLD",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [],
+      "sources": [
+        [
+          "DBT_DEV",
+          "SALES_RECORDS"
+        ]
+      ],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/source_not_null_DBT_DEV_SALES_RECORDS_UNITS_SOLD.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.229177,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_DEV.SALES_RECORDS\nwhere UNITS_SOLD is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "UNITS_SOLD",
+      "file_key_name": "sources.DBT_DEV"
+    },
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_UNIT_PRICE.05e957ffb2": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "UNIT_PRICE",
+          "model": "{{ get_where_subquery(source('DBT_DEV', 'SALES_RECORDS')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "source.trial.DBT_DEV.SALES_RECORDS"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "source_not_null_DBT_DEV_SALES_RECORDS_UNIT_PRICE"
+      ],
+      "unique_id": "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_UNIT_PRICE.05e957ffb2",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "source_not_null_DBT_DEV_SALES_RECORDS_UNIT_PRICE.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "source_not_null_DBT_DEV_SALES_RECORDS_UNIT_PRICE",
+      "alias": "source_not_null_DBT_DEV_SALES_RECORDS_UNIT_PRICE",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [],
+      "sources": [
+        [
+          "DBT_DEV",
+          "SALES_RECORDS"
+        ]
+      ],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/source_not_null_DBT_DEV_SALES_RECORDS_UNIT_PRICE.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.230328,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_DEV.SALES_RECORDS\nwhere UNIT_PRICE is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "UNIT_PRICE",
+      "file_key_name": "sources.DBT_DEV"
+    },
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_UNIT_COST.b8df1b66e1": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "UNIT_COST",
+          "model": "{{ get_where_subquery(source('DBT_DEV', 'SALES_RECORDS')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "source.trial.DBT_DEV.SALES_RECORDS"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "source_not_null_DBT_DEV_SALES_RECORDS_UNIT_COST"
+      ],
+      "unique_id": "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_UNIT_COST.b8df1b66e1",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "source_not_null_DBT_DEV_SALES_RECORDS_UNIT_COST.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "source_not_null_DBT_DEV_SALES_RECORDS_UNIT_COST",
+      "alias": "source_not_null_DBT_DEV_SALES_RECORDS_UNIT_COST",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [],
+      "sources": [
+        [
+          "DBT_DEV",
+          "SALES_RECORDS"
+        ]
+      ],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/source_not_null_DBT_DEV_SALES_RECORDS_UNIT_COST.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.231622,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_DEV.SALES_RECORDS\nwhere UNIT_COST is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "UNIT_COST",
+      "file_key_name": "sources.DBT_DEV"
+    },
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_TOTAL_REVENUE.8e69c2eab1": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "TOTAL_REVENUE",
+          "model": "{{ get_where_subquery(source('DBT_DEV', 'SALES_RECORDS')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "source.trial.DBT_DEV.SALES_RECORDS"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "source_not_null_DBT_DEV_SALES_RECORDS_TOTAL_REVENUE"
+      ],
+      "unique_id": "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_TOTAL_REVENUE.8e69c2eab1",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "source_not_null_DBT_DEV_SALES_RECORDS_TOTAL_REVENUE.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "source_not_null_DBT_DEV_SALES_RECORDS_TOTAL_REVENUE",
+      "alias": "source_not_null_DBT_DEV_SALES_RECORDS_TOTAL_REVENUE",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [],
+      "sources": [
+        [
+          "DBT_DEV",
+          "SALES_RECORDS"
+        ]
+      ],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/source_not_null_DBT_DEV_SALES_RECORDS_TOTAL_REVENUE.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.232772,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_DEV.SALES_RECORDS\nwhere TOTAL_REVENUE is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "TOTAL_REVENUE",
+      "file_key_name": "sources.DBT_DEV"
+    },
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_TOTAL_COST.3bb1c46f03": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "TOTAL_COST",
+          "model": "{{ get_where_subquery(source('DBT_DEV', 'SALES_RECORDS')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "source.trial.DBT_DEV.SALES_RECORDS"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "source_not_null_DBT_DEV_SALES_RECORDS_TOTAL_COST"
+      ],
+      "unique_id": "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_TOTAL_COST.3bb1c46f03",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "source_not_null_DBT_DEV_SALES_RECORDS_TOTAL_COST.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "source_not_null_DBT_DEV_SALES_RECORDS_TOTAL_COST",
+      "alias": "source_not_null_DBT_DEV_SALES_RECORDS_TOTAL_COST",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [],
+      "sources": [
+        [
+          "DBT_DEV",
+          "SALES_RECORDS"
+        ]
+      ],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/source_not_null_DBT_DEV_SALES_RECORDS_TOTAL_COST.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.2339242,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_DEV.SALES_RECORDS\nwhere TOTAL_COST is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "TOTAL_COST",
+      "file_key_name": "sources.DBT_DEV"
+    },
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_TOTAL_PROFIT.5ed94e9968": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "TOTAL_PROFIT",
+          "model": "{{ get_where_subquery(source('DBT_DEV', 'SALES_RECORDS')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "source.trial.DBT_DEV.SALES_RECORDS"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "source_not_null_DBT_DEV_SALES_RECORDS_TOTAL_PROFIT"
+      ],
+      "unique_id": "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_TOTAL_PROFIT.5ed94e9968",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "source_not_null_DBT_DEV_SALES_RECORDS_TOTAL_PROFIT.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "source_not_null_DBT_DEV_SALES_RECORDS_TOTAL_PROFIT",
+      "alias": "source_not_null_DBT_DEV_SALES_RECORDS_TOTAL_PROFIT",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [],
+      "sources": [
+        [
+          "DBT_DEV",
+          "SALES_RECORDS"
+        ]
+      ],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/source_not_null_DBT_DEV_SALES_RECORDS_TOTAL_PROFIT.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.2350779,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_DEV.SALES_RECORDS\nwhere TOTAL_PROFIT is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "TOTAL_PROFIT",
+      "file_key_name": "sources.DBT_DEV"
+    },
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_SHOW_ID.7e52ca1dfe": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "SHOW_ID",
+          "model": "{{ get_where_subquery(source('DBT_DEV', 'NETFLIX')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "source.trial.DBT_DEV.NETFLIX"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "source_not_null_DBT_DEV_NETFLIX_SHOW_ID"
+      ],
+      "unique_id": "test.trial.source_not_null_DBT_DEV_NETFLIX_SHOW_ID.7e52ca1dfe",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "source_not_null_DBT_DEV_NETFLIX_SHOW_ID.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "source_not_null_DBT_DEV_NETFLIX_SHOW_ID",
+      "alias": "source_not_null_DBT_DEV_NETFLIX_SHOW_ID",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [],
+      "sources": [
+        [
+          "DBT_DEV",
+          "NETFLIX"
+        ]
+      ],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/source_not_null_DBT_DEV_NETFLIX_SHOW_ID.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.2365,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_DEV.NETFLIX\nwhere SHOW_ID is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "SHOW_ID",
+      "file_key_name": "sources.DBT_DEV"
+    },
+    "test.trial.source_unique_DBT_DEV_NETFLIX_SHOW_ID.7bfa71959b": {
+      "raw_sql": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "unique",
+        "kwargs": {
+          "column_name": "SHOW_ID",
+          "model": "{{ get_where_subquery(source('DBT_DEV', 'NETFLIX')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_unique",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "source.trial.DBT_DEV.NETFLIX"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "source_unique_DBT_DEV_NETFLIX_SHOW_ID"
+      ],
+      "unique_id": "test.trial.source_unique_DBT_DEV_NETFLIX_SHOW_ID.7bfa71959b",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "source_unique_DBT_DEV_NETFLIX_SHOW_ID.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "source_unique_DBT_DEV_NETFLIX_SHOW_ID",
+      "alias": "source_unique_DBT_DEV_NETFLIX_SHOW_ID",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [],
+      "sources": [
+        [
+          "DBT_DEV",
+          "NETFLIX"
+        ]
+      ],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/source_unique_DBT_DEV_NETFLIX_SHOW_ID.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.23767,
+      "compiled_sql": "\n    \n    \n\nselect\n    SHOW_ID as unique_field,\n    count(*) as n_records\n\nfrom DEV_DB.DBT_DEV.NETFLIX\nwhere SHOW_ID is not null\ngroup by SHOW_ID\nhaving count(*) > 1\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "SHOW_ID",
+      "file_key_name": "sources.DBT_DEV"
+    },
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_TYPE.0f2dec921a": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "TYPE",
+          "model": "{{ get_where_subquery(source('DBT_DEV', 'NETFLIX')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "source.trial.DBT_DEV.NETFLIX"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "source_not_null_DBT_DEV_NETFLIX_TYPE"
+      ],
+      "unique_id": "test.trial.source_not_null_DBT_DEV_NETFLIX_TYPE.0f2dec921a",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "source_not_null_DBT_DEV_NETFLIX_TYPE.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "source_not_null_DBT_DEV_NETFLIX_TYPE",
+      "alias": "source_not_null_DBT_DEV_NETFLIX_TYPE",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [],
+      "sources": [
+        [
+          "DBT_DEV",
+          "NETFLIX"
+        ]
+      ],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/source_not_null_DBT_DEV_NETFLIX_TYPE.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.238846,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_DEV.NETFLIX\nwhere TYPE is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "TYPE",
+      "file_key_name": "sources.DBT_DEV"
+    },
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_TITLE.79ce9afc04": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "TITLE",
+          "model": "{{ get_where_subquery(source('DBT_DEV', 'NETFLIX')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "source.trial.DBT_DEV.NETFLIX"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "source_not_null_DBT_DEV_NETFLIX_TITLE"
+      ],
+      "unique_id": "test.trial.source_not_null_DBT_DEV_NETFLIX_TITLE.79ce9afc04",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "source_not_null_DBT_DEV_NETFLIX_TITLE.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "source_not_null_DBT_DEV_NETFLIX_TITLE",
+      "alias": "source_not_null_DBT_DEV_NETFLIX_TITLE",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [],
+      "sources": [
+        [
+          "DBT_DEV",
+          "NETFLIX"
+        ]
+      ],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/source_not_null_DBT_DEV_NETFLIX_TITLE.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.240406,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_DEV.NETFLIX\nwhere TITLE is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "TITLE",
+      "file_key_name": "sources.DBT_DEV"
+    },
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_DIRECTOR.864f8a60ed": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "DIRECTOR",
+          "model": "{{ get_where_subquery(source('DBT_DEV', 'NETFLIX')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "source.trial.DBT_DEV.NETFLIX"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "source_not_null_DBT_DEV_NETFLIX_DIRECTOR"
+      ],
+      "unique_id": "test.trial.source_not_null_DBT_DEV_NETFLIX_DIRECTOR.864f8a60ed",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "source_not_null_DBT_DEV_NETFLIX_DIRECTOR.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "source_not_null_DBT_DEV_NETFLIX_DIRECTOR",
+      "alias": "source_not_null_DBT_DEV_NETFLIX_DIRECTOR",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [],
+      "sources": [
+        [
+          "DBT_DEV",
+          "NETFLIX"
+        ]
+      ],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/source_not_null_DBT_DEV_NETFLIX_DIRECTOR.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.241601,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_DEV.NETFLIX\nwhere DIRECTOR is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "DIRECTOR",
+      "file_key_name": "sources.DBT_DEV"
+    },
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_CAST.349d8bdc95": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "CAST",
+          "model": "{{ get_where_subquery(source('DBT_DEV', 'NETFLIX')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "source.trial.DBT_DEV.NETFLIX"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "source_not_null_DBT_DEV_NETFLIX_CAST"
+      ],
+      "unique_id": "test.trial.source_not_null_DBT_DEV_NETFLIX_CAST.349d8bdc95",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "source_not_null_DBT_DEV_NETFLIX_CAST.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "source_not_null_DBT_DEV_NETFLIX_CAST",
+      "alias": "source_not_null_DBT_DEV_NETFLIX_CAST",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [],
+      "sources": [
+        [
+          "DBT_DEV",
+          "NETFLIX"
+        ]
+      ],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/source_not_null_DBT_DEV_NETFLIX_CAST.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.2427971,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_DEV.NETFLIX\nwhere CAST is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "CAST",
+      "file_key_name": "sources.DBT_DEV"
+    },
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_COUNTRY.157f099785": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "COUNTRY",
+          "model": "{{ get_where_subquery(source('DBT_DEV', 'NETFLIX')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "source.trial.DBT_DEV.NETFLIX"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "source_not_null_DBT_DEV_NETFLIX_COUNTRY"
+      ],
+      "unique_id": "test.trial.source_not_null_DBT_DEV_NETFLIX_COUNTRY.157f099785",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "source_not_null_DBT_DEV_NETFLIX_COUNTRY.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "source_not_null_DBT_DEV_NETFLIX_COUNTRY",
+      "alias": "source_not_null_DBT_DEV_NETFLIX_COUNTRY",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [],
+      "sources": [
+        [
+          "DBT_DEV",
+          "NETFLIX"
+        ]
+      ],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/source_not_null_DBT_DEV_NETFLIX_COUNTRY.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.244113,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_DEV.NETFLIX\nwhere COUNTRY is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "COUNTRY",
+      "file_key_name": "sources.DBT_DEV"
+    },
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_DATE_ADDED.e0e5bb0d1e": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "DATE_ADDED",
+          "model": "{{ get_where_subquery(source('DBT_DEV', 'NETFLIX')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "source.trial.DBT_DEV.NETFLIX"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "source_not_null_DBT_DEV_NETFLIX_DATE_ADDED"
+      ],
+      "unique_id": "test.trial.source_not_null_DBT_DEV_NETFLIX_DATE_ADDED.e0e5bb0d1e",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "source_not_null_DBT_DEV_NETFLIX_DATE_ADDED.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "source_not_null_DBT_DEV_NETFLIX_DATE_ADDED",
+      "alias": "source_not_null_DBT_DEV_NETFLIX_DATE_ADDED",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [],
+      "sources": [
+        [
+          "DBT_DEV",
+          "NETFLIX"
+        ]
+      ],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/source_not_null_DBT_DEV_NETFLIX_DATE_ADDED.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.2452888,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_DEV.NETFLIX\nwhere DATE_ADDED is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "DATE_ADDED",
+      "file_key_name": "sources.DBT_DEV"
+    },
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_RELEASE_YEAR.c4edf1469a": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "RELEASE_YEAR",
+          "model": "{{ get_where_subquery(source('DBT_DEV', 'NETFLIX')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "source.trial.DBT_DEV.NETFLIX"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "source_not_null_DBT_DEV_NETFLIX_RELEASE_YEAR"
+      ],
+      "unique_id": "test.trial.source_not_null_DBT_DEV_NETFLIX_RELEASE_YEAR.c4edf1469a",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "source_not_null_DBT_DEV_NETFLIX_RELEASE_YEAR.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "source_not_null_DBT_DEV_NETFLIX_RELEASE_YEAR",
+      "alias": "source_not_null_DBT_DEV_NETFLIX_RELEASE_YEAR",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [],
+      "sources": [
+        [
+          "DBT_DEV",
+          "NETFLIX"
+        ]
+      ],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/source_not_null_DBT_DEV_NETFLIX_RELEASE_YEAR.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.24645,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_DEV.NETFLIX\nwhere RELEASE_YEAR is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "RELEASE_YEAR",
+      "file_key_name": "sources.DBT_DEV"
+    },
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_RATING.c4cde59a63": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "RATING",
+          "model": "{{ get_where_subquery(source('DBT_DEV', 'NETFLIX')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "source.trial.DBT_DEV.NETFLIX"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "source_not_null_DBT_DEV_NETFLIX_RATING"
+      ],
+      "unique_id": "test.trial.source_not_null_DBT_DEV_NETFLIX_RATING.c4cde59a63",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "source_not_null_DBT_DEV_NETFLIX_RATING.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "source_not_null_DBT_DEV_NETFLIX_RATING",
+      "alias": "source_not_null_DBT_DEV_NETFLIX_RATING",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [],
+      "sources": [
+        [
+          "DBT_DEV",
+          "NETFLIX"
+        ]
+      ],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/source_not_null_DBT_DEV_NETFLIX_RATING.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.247595,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_DEV.NETFLIX\nwhere RATING is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "RATING",
+      "file_key_name": "sources.DBT_DEV"
+    },
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_DURATION.6083a101be": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "DURATION",
+          "model": "{{ get_where_subquery(source('DBT_DEV', 'NETFLIX')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "source.trial.DBT_DEV.NETFLIX"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "source_not_null_DBT_DEV_NETFLIX_DURATION"
+      ],
+      "unique_id": "test.trial.source_not_null_DBT_DEV_NETFLIX_DURATION.6083a101be",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "source_not_null_DBT_DEV_NETFLIX_DURATION.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "source_not_null_DBT_DEV_NETFLIX_DURATION",
+      "alias": "source_not_null_DBT_DEV_NETFLIX_DURATION",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [],
+      "sources": [
+        [
+          "DBT_DEV",
+          "NETFLIX"
+        ]
+      ],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/source_not_null_DBT_DEV_NETFLIX_DURATION.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.248888,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_DEV.NETFLIX\nwhere DURATION is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "DURATION",
+      "file_key_name": "sources.DBT_DEV"
+    },
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_LISTED_IN.6ba1de80d3": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "LISTED_IN",
+          "model": "{{ get_where_subquery(source('DBT_DEV', 'NETFLIX')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "source.trial.DBT_DEV.NETFLIX"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "source_not_null_DBT_DEV_NETFLIX_LISTED_IN"
+      ],
+      "unique_id": "test.trial.source_not_null_DBT_DEV_NETFLIX_LISTED_IN.6ba1de80d3",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "source_not_null_DBT_DEV_NETFLIX_LISTED_IN.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "source_not_null_DBT_DEV_NETFLIX_LISTED_IN",
+      "alias": "source_not_null_DBT_DEV_NETFLIX_LISTED_IN",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [],
+      "sources": [
+        [
+          "DBT_DEV",
+          "NETFLIX"
+        ]
+      ],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/source_not_null_DBT_DEV_NETFLIX_LISTED_IN.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.250054,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_DEV.NETFLIX\nwhere LISTED_IN is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "LISTED_IN",
+      "file_key_name": "sources.DBT_DEV"
+    },
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_DESCRIPTION.05a82efe6f": {
+      "raw_sql": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "DESCRIPTION",
+          "model": "{{ get_where_subquery(source('DBT_DEV', 'NETFLIX')) }}"
+        },
+        "namespace": null
+      },
+      "compiled": true,
+      "resource_type": "test",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
+        ],
+        "nodes": [
+          "source.trial.DBT_DEV.NETFLIX"
+        ]
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "database": "DEV_DB",
+      "schema": "DBT_YI_dbt_test__audit",
+      "fqn": [
+        "trial",
+        "example",
+        "source_not_null_DBT_DEV_NETFLIX_DESCRIPTION"
+      ],
+      "unique_id": "test.trial.source_not_null_DBT_DEV_NETFLIX_DESCRIPTION.05a82efe6f",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "source_not_null_DBT_DEV_NETFLIX_DESCRIPTION.sql",
+      "original_file_path": "models/example/schema.yml",
+      "name": "source_not_null_DBT_DEV_NETFLIX_DESCRIPTION",
+      "alias": "source_not_null_DBT_DEV_NETFLIX_DESCRIPTION",
+      "checksum": {
+        "name": "none",
+        "checksum": ""
+      },
+      "tags": [],
+      "refs": [],
+      "sources": [
+        [
+          "DBT_DEV",
+          "NETFLIX"
+        ]
+      ],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "compiled_path": "target/compiled/trial/models/example/schema.yml/source_not_null_DBT_DEV_NETFLIX_DESCRIPTION.sql",
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {},
+      "created_at": 1643871657.251211,
+      "compiled_sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_DEV.NETFLIX\nwhere DESCRIPTION is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "relation_name": null,
+      "column_name": "DESCRIPTION",
+      "file_key_name": "sources.DBT_DEV"
+    }
+  },
+  "sources": {
+    "source.trial.DBT_DEV.SALES_RECORDS": {
+      "fqn": [
+        "trial",
+        "example",
+        "DBT_DEV",
+        "SALES_RECORDS"
+      ],
+      "database": "DEV_DB",
+      "schema": "DBT_DEV",
+      "unique_id": "source.trial.DBT_DEV.SALES_RECORDS",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "models/example/schema.yml",
+      "original_file_path": "models/example/schema.yml",
+      "name": "SALES_RECORDS",
+      "source_name": "DBT_DEV",
+      "source_description": "This is the metaphor DBT dev working Schema",
+      "loader": "",
+      "identifier": "SALES_RECORDS",
+      "resource_type": "source",
+      "quoting": {
+        "database": null,
+        "schema": null,
+        "identifier": null,
+        "column": null
+      },
+      "loaded_at_field": null,
+      "freshness": {
+        "warn_after": {
+          "count": null,
+          "period": null
+        },
+        "error_after": {
+          "count": null,
+          "period": null
+        },
+        "filter": null
+      },
+      "external": null,
+      "description": "Sample data of 100K sales records.",
+      "columns": {
+        "COUNTRY": {
+          "name": "COUNTRY",
+          "description": "COUNTRY. SALES_RECORDS",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "REGION": {
+          "name": "REGION",
+          "description": "REGION. SALES_RECORDS",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "ITEM_TYPE": {
+          "name": "ITEM_TYPE",
+          "description": "ITEM_TYPE. SALES_RECORDS",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "SALES_CHANNEL": {
+          "name": "SALES_CHANNEL",
+          "description": "SALES_CHANNEL. SALES_RECORDS",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "ORDER_PRIORITY": {
+          "name": "ORDER_PRIORITY",
+          "description": "ORDER_PRIORITY. SALES_RECORDS",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "ORDER_DATE": {
+          "name": "ORDER_DATE",
+          "description": "ORDER_DATE. SALES_RECORDS",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "ORDER_ID": {
+          "name": "ORDER_ID",
+          "description": "ORDER_ID. SALES_RECORDS",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "SHIP_DATE": {
+          "name": "SHIP_DATE",
+          "description": "SHIP_DATE. SALES_RECORDS",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "UNITS_SOLD": {
+          "name": "UNITS_SOLD",
+          "description": "UNITS_SOLD. SALES_RECORDS",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "UNIT_PRICE": {
+          "name": "UNIT_PRICE",
+          "description": "UNIT_PRICE. SALES_RECORDS",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "UNIT_COST": {
+          "name": "UNIT_COST",
+          "description": "UNIT_COST. SALES_RECORDS",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "TOTAL_REVENUE": {
+          "name": "TOTAL_REVENUE",
+          "description": "TOTAL_REVENUE. SALES_RECORDS",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "TOTAL_COST": {
+          "name": "TOTAL_COST",
+          "description": "TOTAL_COST. SALES_RECORDS",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "TOTAL_PROFIT": {
+          "name": "TOTAL_PROFIT",
+          "description": "TOTAL_PROFIT. SALES_RECORDS",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        }
+      },
+      "meta": {},
+      "source_meta": {},
+      "tags": [],
+      "config": {
+        "enabled": true
+      },
+      "patch_path": null,
+      "unrendered_config": {},
+      "relation_name": "DEV_DB.DBT_DEV.SALES_RECORDS",
+      "created_at": 1643871657.235945
+    },
+    "source.trial.DBT_DEV.NETFLIX": {
+      "fqn": [
+        "trial",
+        "example",
+        "DBT_DEV",
+        "NETFLIX"
+      ],
+      "database": "DEV_DB",
+      "schema": "DBT_DEV",
+      "unique_id": "source.trial.DBT_DEV.NETFLIX",
+      "package_name": "trial",
+      "root_path": "/Users/yi/Work/dbt/trial",
+      "path": "models/example/schema.yml",
+      "original_file_path": "models/example/schema.yml",
+      "name": "NETFLIX",
+      "source_name": "DBT_DEV",
+      "source_description": "This is the metaphor DBT dev working Schema",
+      "loader": "",
+      "identifier": "NETFLIX",
+      "resource_type": "source",
+      "quoting": {
+        "database": null,
+        "schema": null,
+        "identifier": null,
+        "column": null
+      },
+      "loaded_at_field": null,
+      "freshness": {
+        "warn_after": {
+          "count": null,
+          "period": null
+        },
+        "error_after": {
+          "count": null,
+          "period": null
+        },
+        "filter": null
+      },
+      "external": null,
+      "description": "Sample data of Netflix shows.",
+      "columns": {
+        "SHOW_ID": {
+          "name": "SHOW_ID",
+          "description": "SHOW_ID. NETFLIX",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "TYPE": {
+          "name": "TYPE",
+          "description": "TYPE. NETFLIX",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "TITLE": {
+          "name": "TITLE",
+          "description": "TITLE. NETFLIX",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "DIRECTOR": {
+          "name": "DIRECTOR",
+          "description": "DIRECTOR. NETFLIX",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "CAST": {
+          "name": "CAST",
+          "description": "CAST. NETFLIX",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "COUNTRY": {
+          "name": "COUNTRY",
+          "description": "COUNTRY. NETFLIX",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "DATE_ADDED": {
+          "name": "DATE_ADDED",
+          "description": "DATE_ADDED. NETFLIX",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "RELEASE_YEAR": {
+          "name": "RELEASE_YEAR",
+          "description": "RELEASE_YEAR. NETFLIX",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "RATING": {
+          "name": "RATING",
+          "description": "RATING. NETFLIX",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "DURATION": {
+          "name": "DURATION",
+          "description": "DURATION. NETFLIX",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "LISTED_IN": {
+          "name": "LISTED_IN",
+          "description": "LISTED_IN. NETFLIX",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        },
+        "DESCRIPTION": {
+          "name": "DESCRIPTION",
+          "description": "DESCRIPTION. NETFLIX",
+          "meta": {},
+          "data_type": null,
+          "quote": null,
+          "tags": []
+        }
+      },
+      "meta": {},
+      "source_meta": {},
+      "tags": [],
+      "config": {
+        "enabled": true
+      },
+      "patch_path": null,
+      "unrendered_config": {},
+      "relation_name": "DEV_DB.DBT_DEV.NETFLIX",
+      "created_at": 1643871657.2519538
+    }
+  },
+  "macros": {
+    "macro.dbt_snowflake.snowflake__get_catalog": {
+      "unique_id": "macro.dbt_snowflake.snowflake__get_catalog",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/catalog.sql",
+      "original_file_path": "macros/catalog.sql",
+      "name": "snowflake__get_catalog",
+      "macro_sql": "{% macro snowflake__get_catalog(information_schema, schemas) -%}\n  {% set query %}\n      with tables as (\n\n          select\n              table_catalog as \"table_database\",\n              table_schema as \"table_schema\",\n              table_name as \"table_name\",\n              table_type as \"table_type\",\n              comment as \"table_comment\",\n\n              -- note: this is the _role_ that owns the table\n              table_owner as \"table_owner\",\n\n              'Clustering Key' as \"stats:clustering_key:label\",\n              clustering_key as \"stats:clustering_key:value\",\n              'The key used to cluster this table' as \"stats:clustering_key:description\",\n              (clustering_key is not null) as \"stats:clustering_key:include\",\n\n              'Row Count' as \"stats:row_count:label\",\n              row_count as \"stats:row_count:value\",\n              'An approximate count of rows in this table' as \"stats:row_count:description\",\n              (row_count is not null) as \"stats:row_count:include\",\n\n              'Approximate Size' as \"stats:bytes:label\",\n              bytes as \"stats:bytes:value\",\n              'Approximate size of the table as reported by Snowflake' as \"stats:bytes:description\",\n              (bytes is not null) as \"stats:bytes:include\",\n\n              'Last Modified' as \"stats:last_modified:label\",\n              to_varchar(convert_timezone('UTC', last_altered), 'yyyy-mm-dd HH24:MI'||'UTC') as \"stats:last_modified:value\",\n              'The timestamp for last update/change' as \"stats:last_modified:description\",\n              (last_altered is not null and table_type='BASE TABLE') as \"stats:last_modified:include\"\n\n          from {{ information_schema }}.tables\n\n      ),\n\n      columns as (\n\n          select\n              table_catalog as \"table_database\",\n              table_schema as \"table_schema\",\n              table_name as \"table_name\",\n\n              column_name as \"column_name\",\n              ordinal_position as \"column_index\",\n              data_type as \"column_type\",\n              comment as \"column_comment\"\n\n          from {{ information_schema }}.columns\n      )\n\n      select *\n      from tables\n      join columns using (\"table_database\", \"table_schema\", \"table_name\")\n      where (\n        {%- for schema in schemas -%}\n          upper(\"table_schema\") = upper('{{ schema }}'){%- if not loop.last %} or {% endif -%}\n        {%- endfor -%}\n      )\n      order by \"column_index\"\n    {%- endset -%}\n\n  {{ return(run_query(query)) }}\n\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.run_query"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.843296
+    },
+    "macro.dbt_snowflake.snowflake__create_table_as": {
+      "unique_id": "macro.dbt_snowflake.snowflake__create_table_as",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/adapters.sql",
+      "original_file_path": "macros/adapters.sql",
+      "name": "snowflake__create_table_as",
+      "macro_sql": "{% macro snowflake__create_table_as(temporary, relation, sql) -%}\n  {%- set transient = config.get('transient', default=true) -%}\n  {%- set cluster_by_keys = config.get('cluster_by', default=none) -%}\n  {%- set enable_automatic_clustering = config.get('automatic_clustering', default=false) -%}\n  {%- set copy_grants = config.get('copy_grants', default=false) -%}\n\n  {%- if cluster_by_keys is not none and cluster_by_keys is string -%}\n    {%- set cluster_by_keys = [cluster_by_keys] -%}\n  {%- endif -%}\n  {%- if cluster_by_keys is not none -%}\n    {%- set cluster_by_string = cluster_by_keys|join(\", \")-%}\n  {% else %}\n    {%- set cluster_by_string = none -%}\n  {%- endif -%}\n  {%- set sql_header = config.get('sql_header', none) -%}\n\n  {{ sql_header if sql_header is not none }}\n\n      create or replace {% if temporary -%}\n        temporary\n      {%- elif transient -%}\n        transient\n      {%- endif %} table {{ relation }} {% if copy_grants and not temporary -%} copy grants {%- endif %} as\n      (\n        {%- if cluster_by_string is not none -%}\n          select * from(\n            {{ sql }}\n            ) order by ({{ cluster_by_string }})\n        {%- else -%}\n          {{ sql }}\n        {%- endif %}\n      );\n    {% if cluster_by_string is not none and not temporary -%}\n      alter table {{relation}} cluster by ({{cluster_by_string}});\n    {%- endif -%}\n    {% if enable_automatic_clustering and cluster_by_string is not none and not temporary  -%}\n      alter table {{relation}} resume recluster;\n    {%- endif -%}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.861064
+    },
+    "macro.dbt_snowflake.get_column_comment_sql": {
+      "unique_id": "macro.dbt_snowflake.get_column_comment_sql",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/adapters.sql",
+      "original_file_path": "macros/adapters.sql",
+      "name": "get_column_comment_sql",
+      "macro_sql": "{% macro get_column_comment_sql(column_name, column_dict) %}\n  {{ adapter.quote(column_name) if column_dict[column_name]['quote'] else column_name }} COMMENT $${{ column_dict[column_name]['description'] | replace('$', '[$]') }}$$\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.861542
+    },
+    "macro.dbt_snowflake.get_persist_docs_column_list": {
+      "unique_id": "macro.dbt_snowflake.get_persist_docs_column_list",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/adapters.sql",
+      "original_file_path": "macros/adapters.sql",
+      "name": "get_persist_docs_column_list",
+      "macro_sql": "{% macro get_persist_docs_column_list(model_columns, query_columns) %}\n(\n  {% for column_name in query_columns %}\n    {% if (column_name|upper in model_columns) or (column_name in model_columns) %}\n      {{ get_column_comment_sql(column_name, model_columns) }}\n    {% else %}\n      {{column_name}}\n    {% endif %}\n    {{ \", \" if not loop.last else \"\" }}\n  {% endfor %}\n)\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt_snowflake.get_column_comment_sql"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.862176
+    },
+    "macro.dbt_snowflake.snowflake__create_view_as": {
+      "unique_id": "macro.dbt_snowflake.snowflake__create_view_as",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/adapters.sql",
+      "original_file_path": "macros/adapters.sql",
+      "name": "snowflake__create_view_as",
+      "macro_sql": "{% macro snowflake__create_view_as(relation, sql) -%}\n  {%- set secure = config.get('secure', default=false) -%}\n  {%- set copy_grants = config.get('copy_grants', default=false) -%}\n  {%- set sql_header = config.get('sql_header', none) -%}\n\n  {{ sql_header if sql_header is not none }}\n  create or replace {% if secure -%}\n    secure\n  {%- endif %} view {{ relation }} \n  {% if config.persist_column_docs() -%}\n    {% set model_columns = model.columns %}\n    {% set query_columns = get_columns_in_query(sql) %}\n    {{ get_persist_docs_column_list(model_columns, query_columns) }}\n    \n  {%- endif %}\n  {% if copy_grants -%} copy grants {%- endif %} as (\n    {{ sql }}\n  );\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.get_columns_in_query",
+          "macro.dbt_snowflake.get_persist_docs_column_list"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.863256
+    },
+    "macro.dbt_snowflake.snowflake__get_columns_in_relation": {
+      "unique_id": "macro.dbt_snowflake.snowflake__get_columns_in_relation",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/adapters.sql",
+      "original_file_path": "macros/adapters.sql",
+      "name": "snowflake__get_columns_in_relation",
+      "macro_sql": "{% macro snowflake__get_columns_in_relation(relation) -%}\n  {%- set sql -%}\n    describe table {{ relation }}\n  {%- endset -%}\n  {%- set result = run_query(sql) -%}\n\n  {% set maximum = 10000 %}\n  {% if (result | length) >= maximum %}\n    {% set msg %}\n      Too many columns in relation {{ relation }}! dbt can only get\n      information about relations with fewer than {{ maximum }} columns.\n    {% endset %}\n    {% do exceptions.raise_compiler_error(msg) %}\n  {% endif %}\n\n  {% set columns = [] %}\n  {% for row in result %}\n    {% do columns.append(api.Column.from_description(row['name'], row['type'])) %}\n  {% endfor %}\n  {% do return(columns) %}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.run_query"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.864374
+    },
+    "macro.dbt_snowflake.snowflake__list_schemas": {
+      "unique_id": "macro.dbt_snowflake.snowflake__list_schemas",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/adapters.sql",
+      "original_file_path": "macros/adapters.sql",
+      "name": "snowflake__list_schemas",
+      "macro_sql": "{% macro snowflake__list_schemas(database) -%}\n  {# 10k limit from here: https://docs.snowflake.net/manuals/sql-reference/sql/show-schemas.html#usage-notes #}\n  {% set maximum = 10000 %}\n  {% set sql -%}\n    show terse schemas in database {{ database }}\n    limit {{ maximum }}\n  {%- endset %}\n  {% set result = run_query(sql) %}\n  {% if (result | length) >= maximum %}\n    {% set msg %}\n      Too many schemas in database {{ database }}! dbt can only get\n      information about databases with fewer than {{ maximum }} schemas.\n    {% endset %}\n    {% do exceptions.raise_compiler_error(msg) %}\n  {% endif %}\n  {{ return(result) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.run_query"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.865164
+    },
+    "macro.dbt_snowflake.snowflake__list_relations_without_caching": {
+      "unique_id": "macro.dbt_snowflake.snowflake__list_relations_without_caching",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/adapters.sql",
+      "original_file_path": "macros/adapters.sql",
+      "name": "snowflake__list_relations_without_caching",
+      "macro_sql": "{% macro snowflake__list_relations_without_caching(schema_relation) %}\n  {%- set sql -%}\n    show terse objects in {{ schema_relation }}\n  {%- endset -%}\n\n  {%- set result = run_query(sql) -%}\n  {% set maximum = 10000 %}\n  {% if (result | length) >= maximum %}\n    {% set msg %}\n      Too many schemas in schema  {{ schema_relation }}! dbt can only get\n      information about schemas with fewer than {{ maximum }} objects.\n    {% endset %}\n    {% do exceptions.raise_compiler_error(msg) %}\n  {% endif %}\n  {%- do return(result) -%}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.run_query"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.8658931
+    },
+    "macro.dbt_snowflake.snowflake__check_schema_exists": {
+      "unique_id": "macro.dbt_snowflake.snowflake__check_schema_exists",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/adapters.sql",
+      "original_file_path": "macros/adapters.sql",
+      "name": "snowflake__check_schema_exists",
+      "macro_sql": "{% macro snowflake__check_schema_exists(information_schema, schema) -%}\n  {% call statement('check_schema_exists', fetch_result=True) -%}\n        select count(*)\n        from {{ information_schema }}.schemata\n        where upper(schema_name) = upper('{{ schema }}')\n            and upper(catalog_name) = upper('{{ information_schema.database }}')\n  {%- endcall %}\n  {{ return(load_result('check_schema_exists').table) }}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.statement"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.8663712
+    },
+    "macro.dbt_snowflake.snowflake__current_timestamp": {
+      "unique_id": "macro.dbt_snowflake.snowflake__current_timestamp",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/adapters.sql",
+      "original_file_path": "macros/adapters.sql",
+      "name": "snowflake__current_timestamp",
+      "macro_sql": "{% macro snowflake__current_timestamp() -%}\n  convert_timezone('UTC', current_timestamp())\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.866482
+    },
+    "macro.dbt_snowflake.snowflake__snapshot_string_as_time": {
+      "unique_id": "macro.dbt_snowflake.snowflake__snapshot_string_as_time",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/adapters.sql",
+      "original_file_path": "macros/adapters.sql",
+      "name": "snowflake__snapshot_string_as_time",
+      "macro_sql": "{% macro snowflake__snapshot_string_as_time(timestamp) -%}\n    {%- set result = \"to_timestamp_ntz('\" ~ timestamp ~ \"')\" -%}\n    {{ return(result) }}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.8667352
+    },
+    "macro.dbt_snowflake.snowflake__snapshot_get_time": {
+      "unique_id": "macro.dbt_snowflake.snowflake__snapshot_get_time",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/adapters.sql",
+      "original_file_path": "macros/adapters.sql",
+      "name": "snowflake__snapshot_get_time",
+      "macro_sql": "{% macro snowflake__snapshot_get_time() -%}\n  to_timestamp_ntz({{ current_timestamp() }})\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.current_timestamp"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.8668852
+    },
+    "macro.dbt_snowflake.snowflake__rename_relation": {
+      "unique_id": "macro.dbt_snowflake.snowflake__rename_relation",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/adapters.sql",
+      "original_file_path": "macros/adapters.sql",
+      "name": "snowflake__rename_relation",
+      "macro_sql": "{% macro snowflake__rename_relation(from_relation, to_relation) -%}\n  {% call statement('rename_relation') -%}\n    alter table {{ from_relation }} rename to {{ to_relation }}\n  {%- endcall %}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.statement"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.867148
+    },
+    "macro.dbt_snowflake.snowflake__alter_column_type": {
+      "unique_id": "macro.dbt_snowflake.snowflake__alter_column_type",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/adapters.sql",
+      "original_file_path": "macros/adapters.sql",
+      "name": "snowflake__alter_column_type",
+      "macro_sql": "{% macro snowflake__alter_column_type(relation, column_name, new_column_type) -%}\n  {% call statement('alter_column_type') %}\n    alter table {{ relation }} alter {{ adapter.quote(column_name) }} set data type {{ new_column_type }};\n  {% endcall %}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.statement"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.867507
+    },
+    "macro.dbt_snowflake.snowflake__alter_relation_comment": {
+      "unique_id": "macro.dbt_snowflake.snowflake__alter_relation_comment",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/adapters.sql",
+      "original_file_path": "macros/adapters.sql",
+      "name": "snowflake__alter_relation_comment",
+      "macro_sql": "{% macro snowflake__alter_relation_comment(relation, relation_comment) -%}\n  comment on {{ relation.type }} {{ relation }} IS $${{ relation_comment | replace('$', '[$]') }}$$;\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.867811
+    },
+    "macro.dbt_snowflake.snowflake__alter_column_comment": {
+      "unique_id": "macro.dbt_snowflake.snowflake__alter_column_comment",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/adapters.sql",
+      "original_file_path": "macros/adapters.sql",
+      "name": "snowflake__alter_column_comment",
+      "macro_sql": "{% macro snowflake__alter_column_comment(relation, column_dict) -%}\n    {% set existing_columns = adapter.get_columns_in_relation(relation) | map(attribute=\"name\") | list %}\n    alter {{ relation.type }} {{ relation }} alter\n    {% for column_name in column_dict if (column_name in existing_columns) or (column_name|upper in existing_columns) %}\n        {{ get_column_comment_sql(column_name, column_dict) }} {{ ',' if not loop.last else ';' }}\n    {% endfor %}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt_snowflake.get_column_comment_sql"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.868591
+    },
+    "macro.dbt_snowflake.get_current_query_tag": {
+      "unique_id": "macro.dbt_snowflake.get_current_query_tag",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/adapters.sql",
+      "original_file_path": "macros/adapters.sql",
+      "name": "get_current_query_tag",
+      "macro_sql": "{% macro get_current_query_tag() -%}\n  {{ return(run_query(\"show parameters like 'query_tag' in session\").rows[0]['value']) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.run_query"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.868873
+    },
+    "macro.dbt_snowflake.set_query_tag": {
+      "unique_id": "macro.dbt_snowflake.set_query_tag",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/adapters.sql",
+      "original_file_path": "macros/adapters.sql",
+      "name": "set_query_tag",
+      "macro_sql": "{% macro set_query_tag() -%}\n  {% set new_query_tag = config.get('query_tag') %}\n  {% if new_query_tag %}\n    {% set original_query_tag = get_current_query_tag() %}\n    {{ log(\"Setting query_tag to '\" ~ new_query_tag ~ \"'. Will reset to '\" ~ original_query_tag ~ \"' after materialization.\") }}\n    {% do run_query(\"alter session set query_tag = '{}'\".format(new_query_tag)) %}\n    {{ return(original_query_tag)}}\n  {% endif %}\n  {{ return(none)}}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt_snowflake.get_current_query_tag",
+          "macro.dbt.run_query"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.86966
+    },
+    "macro.dbt_snowflake.unset_query_tag": {
+      "unique_id": "macro.dbt_snowflake.unset_query_tag",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/adapters.sql",
+      "original_file_path": "macros/adapters.sql",
+      "name": "unset_query_tag",
+      "macro_sql": "{% macro unset_query_tag(original_query_tag) -%}\n  {% set new_query_tag = config.get('query_tag') %}\n  {% if new_query_tag %}\n    {% if original_query_tag %}\n      {{ log(\"Resetting query_tag to '\" ~ original_query_tag ~ \"'.\") }}\n      {% do run_query(\"alter session set query_tag = '{}'\".format(original_query_tag)) %}\n    {% else %}\n      {{ log(\"No original query_tag, unsetting parameter.\") }}\n      {% do run_query(\"alter session unset query_tag\") %}\n    {% endif %}\n  {% endif %}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.run_query"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.870353
+    },
+    "macro.dbt_snowflake.snowflake__alter_relation_add_remove_columns": {
+      "unique_id": "macro.dbt_snowflake.snowflake__alter_relation_add_remove_columns",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/adapters.sql",
+      "original_file_path": "macros/adapters.sql",
+      "name": "snowflake__alter_relation_add_remove_columns",
+      "macro_sql": "{% macro snowflake__alter_relation_add_remove_columns(relation, add_columns, remove_columns) %}\n  \n  {% if add_columns %}\n    \n    {% set sql -%}\n       alter {{ relation.type }} {{ relation }} add column\n          {% for column in add_columns %}\n            {{ column.name }} {{ column.data_type }}{{ ',' if not loop.last }}\n          {% endfor %}\n    {%- endset -%}\n\n    {% do run_query(sql) %}\n\n  {% endif %}\n\n  {% if remove_columns %}\n  \n    {% set sql -%}\n        alter {{ relation.type }} {{ relation }} drop column\n            {% for column in remove_columns %}\n                {{ column.name }}{{ ',' if not loop.last }}\n            {% endfor %}\n    {%- endset -%}\n    \n    {% do run_query(sql) %}\n    \n  {% endif %}\n\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.run_query"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.871443
+    },
+    "macro.dbt_snowflake.snowflake_dml_explicit_transaction": {
+      "unique_id": "macro.dbt_snowflake.snowflake_dml_explicit_transaction",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/adapters.sql",
+      "original_file_path": "macros/adapters.sql",
+      "name": "snowflake_dml_explicit_transaction",
+      "macro_sql": "{% macro snowflake_dml_explicit_transaction(dml) %}\n  {#\n    Use this macro to wrap all INSERT, MERGE, UPDATE, DELETE, and TRUNCATE \n    statements before passing them into run_query(), or calling in the 'main' statement\n    of a materialization\n  #}\n  {% set dml_transaction -%}\n    begin;\n    {{ dml }};\n    commit;\n  {%- endset %}\n  \n  {% do return(dml_transaction) %}\n\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.871744
+    },
+    "macro.dbt_snowflake.snowflake__truncate_relation": {
+      "unique_id": "macro.dbt_snowflake.snowflake__truncate_relation",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/adapters.sql",
+      "original_file_path": "macros/adapters.sql",
+      "name": "snowflake__truncate_relation",
+      "macro_sql": "{% macro snowflake__truncate_relation(relation) -%}\n  {% set truncate_dml %}\n    truncate table {{ relation }}\n  {% endset %}\n  {% call statement('truncate_relation') -%}\n    {{ snowflake_dml_explicit_transaction(truncate_dml) }}\n  {%- endcall %}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.statement",
+          "macro.dbt_snowflake.snowflake_dml_explicit_transaction"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.872093
+    },
+    "macro.dbt_snowflake.snowflake__get_merge_sql": {
+      "unique_id": "macro.dbt_snowflake.snowflake__get_merge_sql",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/materializations/merge.sql",
+      "original_file_path": "macros/materializations/merge.sql",
+      "name": "snowflake__get_merge_sql",
+      "macro_sql": "{% macro snowflake__get_merge_sql(target, source_sql, unique_key, dest_columns, predicates) -%}\n\n    {#\n       Workaround for Snowflake not being happy with a merge on a constant-false predicate.\n       When no unique_key is provided, this macro will do a regular insert. If a unique_key\n       is provided, then this macro will do a proper merge instead.\n    #}\n\n    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute='name')) -%}\n    {%- set sql_header = config.get('sql_header', none) -%}\n\n    {%- set dml -%}\n    {%- if unique_key is none -%}\n\n        {{ sql_header if sql_header is not none }}\n\n        insert into {{ target }} ({{ dest_cols_csv }})\n        (\n            select {{ dest_cols_csv }}\n            from {{ source_sql }}\n        )\n\n    {%- else -%}\n\n        {{ default__get_merge_sql(target, source_sql, unique_key, dest_columns, predicates) }}\n\n    {%- endif -%}\n    {%- endset -%}\n    \n    {% do return(snowflake_dml_explicit_transaction(dml)) %}\n\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.get_quoted_csv",
+          "macro.dbt.default__get_merge_sql",
+          "macro.dbt_snowflake.snowflake_dml_explicit_transaction"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.87397
+    },
+    "macro.dbt_snowflake.snowflake__get_delete_insert_merge_sql": {
+      "unique_id": "macro.dbt_snowflake.snowflake__get_delete_insert_merge_sql",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/materializations/merge.sql",
+      "original_file_path": "macros/materializations/merge.sql",
+      "name": "snowflake__get_delete_insert_merge_sql",
+      "macro_sql": "{% macro snowflake__get_delete_insert_merge_sql(target, source, unique_key, dest_columns) %}\n    {% set dml = default__get_delete_insert_merge_sql(target, source, unique_key, dest_columns) %}\n    {% do return(snowflake_dml_explicit_transaction(dml)) %}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__get_delete_insert_merge_sql",
+          "macro.dbt_snowflake.snowflake_dml_explicit_transaction"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.874371
+    },
+    "macro.dbt_snowflake.snowflake__snapshot_merge_sql": {
+      "unique_id": "macro.dbt_snowflake.snowflake__snapshot_merge_sql",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/materializations/merge.sql",
+      "original_file_path": "macros/materializations/merge.sql",
+      "name": "snowflake__snapshot_merge_sql",
+      "macro_sql": "{% macro snowflake__snapshot_merge_sql(target, source, insert_cols) %}\n    {% set dml = default__snapshot_merge_sql(target, source, insert_cols) %}\n    {% do return(snowflake_dml_explicit_transaction(dml)) %}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__snapshot_merge_sql",
+          "macro.dbt_snowflake.snowflake_dml_explicit_transaction"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.8747342
+    },
+    "macro.dbt_snowflake.snowflake__load_csv_rows": {
+      "unique_id": "macro.dbt_snowflake.snowflake__load_csv_rows",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/materializations/seed.sql",
+      "original_file_path": "macros/materializations/seed.sql",
+      "name": "snowflake__load_csv_rows",
+      "macro_sql": "{% macro snowflake__load_csv_rows(model, agate_table) %}\n    {% set batch_size = get_batch_size() %}\n    {% set cols_sql = get_seed_column_quoted_csv(model, agate_table.column_names) %}\n    {% set bindings = [] %}\n\n    {% set statements = [] %}\n\n    {% for chunk in agate_table.rows | batch(batch_size) %}\n        {% set bindings = [] %}\n\n        {% for row in chunk %}\n            {% do bindings.extend(row) %}\n        {% endfor %}\n\n        {% set sql %}\n            insert into {{ this.render() }} ({{ cols_sql }}) values\n            {% for row in chunk -%}\n                ({%- for column in agate_table.column_names -%}\n                    %s\n                    {%- if not loop.last%},{%- endif %}\n                {%- endfor -%})\n                {%- if not loop.last%},{%- endif %}\n            {%- endfor %}\n        {% endset %}\n\n        {% do adapter.add_query('BEGIN', auto_begin=False) %}\n        {% do adapter.add_query(sql, bindings=bindings, abridge_sql_log=True) %}\n        {% do adapter.add_query('COMMIT', auto_begin=False) %}\n\n        {% if loop.index0 == 0 %}\n            {% do statements.append(sql) %}\n        {% endif %}\n    {% endfor %}\n\n    {# Return SQL so we can render it out into the compiled files #}\n    {{ return(statements[0]) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.get_batch_size",
+          "macro.dbt.get_seed_column_quoted_csv"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.877814
+    },
+    "macro.dbt_snowflake.materialization_seed_snowflake": {
+      "unique_id": "macro.dbt_snowflake.materialization_seed_snowflake",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/materializations/seed.sql",
+      "original_file_path": "macros/materializations/seed.sql",
+      "name": "materialization_seed_snowflake",
+      "macro_sql": "{% materialization seed, adapter='snowflake' %}\n    {% set original_query_tag = set_query_tag() %}\n\n    {% set relations = materialization_seed_default() %}\n\n    {% do unset_query_tag(original_query_tag) %}\n\n    {{ return(relations) }}\n{% endmaterialization %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt_snowflake.set_query_tag",
+          "macro.dbt.materialization_seed_default",
+          "macro.dbt_snowflake.unset_query_tag"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.878228
+    },
+    "macro.dbt_snowflake.materialization_view_snowflake": {
+      "unique_id": "macro.dbt_snowflake.materialization_view_snowflake",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/materializations/view.sql",
+      "original_file_path": "macros/materializations/view.sql",
+      "name": "materialization_view_snowflake",
+      "macro_sql": "{% materialization view, adapter='snowflake' -%}\n\n    {% set original_query_tag = set_query_tag() %}\n    {% set to_return = create_or_replace_view() %}\n\n    {% set target_relation = this.incorporate(type='view') %}\n    {% do persist_docs(target_relation, model, for_columns=false) %}\n\n    {% do return(to_return) %}\n\n    {% do unset_query_tag(original_query_tag) %}\n\n{%- endmaterialization %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt_snowflake.set_query_tag",
+          "macro.dbt.create_or_replace_view",
+          "macro.dbt.persist_docs",
+          "macro.dbt_snowflake.unset_query_tag"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.8790889
+    },
+    "macro.dbt_snowflake.materialization_table_snowflake": {
+      "unique_id": "macro.dbt_snowflake.materialization_table_snowflake",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/materializations/table.sql",
+      "original_file_path": "macros/materializations/table.sql",
+      "name": "materialization_table_snowflake",
+      "macro_sql": "{% materialization table, adapter='snowflake' %}\n\n  {% set original_query_tag = set_query_tag() %}\n\n  {%- set identifier = model['alias'] -%}\n\n  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}\n  {%- set target_relation = api.Relation.create(identifier=identifier,\n                                                schema=schema,\n                                                database=database, type='table') -%}\n\n  {{ run_hooks(pre_hooks) }}\n\n  {#-- Drop the relation if it was a view to \"convert\" it in a table. This may lead to\n    -- downtime, but it should be a relatively infrequent occurrence  #}\n  {% if old_relation is not none and not old_relation.is_table %}\n    {{ log(\"Dropping relation \" ~ old_relation ~ \" because it is of type \" ~ old_relation.type) }}\n    {{ drop_relation_if_exists(old_relation) }}\n  {% endif %}\n\n  --build model\n  {% call statement('main') -%}\n    {{ create_table_as(false, target_relation, sql) }}\n  {%- endcall %}\n\n  {{ run_hooks(post_hooks) }}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {% do unset_query_tag(original_query_tag) %}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{% endmaterialization %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt_snowflake.set_query_tag",
+          "macro.dbt.run_hooks",
+          "macro.dbt.drop_relation_if_exists",
+          "macro.dbt.statement",
+          "macro.dbt.create_table_as",
+          "macro.dbt.persist_docs",
+          "macro.dbt_snowflake.unset_query_tag"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.881092
+    },
+    "macro.dbt_snowflake.dbt_snowflake_validate_get_incremental_strategy": {
+      "unique_id": "macro.dbt_snowflake.dbt_snowflake_validate_get_incremental_strategy",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/materializations/incremental.sql",
+      "original_file_path": "macros/materializations/incremental.sql",
+      "name": "dbt_snowflake_validate_get_incremental_strategy",
+      "macro_sql": "{% macro dbt_snowflake_validate_get_incremental_strategy(config) %}\n  {#-- Find and validate the incremental strategy #}\n  {%- set strategy = config.get(\"incremental_strategy\", default=\"merge\") -%}\n\n  {% set invalid_strategy_msg -%}\n    Invalid incremental strategy provided: {{ strategy }}\n    Expected one of: 'merge', 'delete+insert'\n  {%- endset %}\n  {% if strategy not in ['merge', 'delete+insert'] %}\n    {% do exceptions.raise_compiler_error(invalid_strategy_msg) %}\n  {% endif %}\n\n  {% do return(strategy) %}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.8830342
+    },
+    "macro.dbt_snowflake.dbt_snowflake_get_incremental_sql": {
+      "unique_id": "macro.dbt_snowflake.dbt_snowflake_get_incremental_sql",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/materializations/incremental.sql",
+      "original_file_path": "macros/materializations/incremental.sql",
+      "name": "dbt_snowflake_get_incremental_sql",
+      "macro_sql": "{% macro dbt_snowflake_get_incremental_sql(strategy, tmp_relation, target_relation, unique_key, dest_columns) %}\n  {% if strategy == 'merge' %}\n    {% do return(get_merge_sql(target_relation, tmp_relation, unique_key, dest_columns)) %}\n  {% elif strategy == 'delete+insert' %}\n    {% do return(get_delete_insert_merge_sql(target_relation, tmp_relation, unique_key, dest_columns)) %}\n  {% else %}\n    {% do exceptions.raise_compiler_error('invalid strategy: ' ~ strategy) %}\n  {% endif %}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.get_merge_sql",
+          "macro.dbt.get_delete_insert_merge_sql"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.883795
+    },
+    "macro.dbt_snowflake.materialization_incremental_snowflake": {
+      "unique_id": "macro.dbt_snowflake.materialization_incremental_snowflake",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/materializations/incremental.sql",
+      "original_file_path": "macros/materializations/incremental.sql",
+      "name": "materialization_incremental_snowflake",
+      "macro_sql": "{% materialization incremental, adapter='snowflake' -%}\n   \n  {% set original_query_tag = set_query_tag() %}\n\n  {%- set unique_key = config.get('unique_key') -%}\n  {%- set full_refresh_mode = (should_full_refresh()) -%}\n\n  {% set target_relation = this %}\n  {% set existing_relation = load_relation(this) %}\n  {% set tmp_relation = make_temp_relation(this) %}\n\n  {#-- Validate early so we don't run SQL if the strategy is invalid --#}\n  {% set strategy = dbt_snowflake_validate_get_incremental_strategy(config) -%}\n  {% set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') %}\n\n  {{ run_hooks(pre_hooks) }}\n\n  {% if existing_relation is none %}\n    {% set build_sql = create_table_as(False, target_relation, sql) %}\n  \n  {% elif existing_relation.is_view %}\n    {#-- Can't overwrite a view with a table - we must drop --#}\n    {{ log(\"Dropping relation \" ~ target_relation ~ \" because it is a view and this model is a table.\") }}\n    {% do adapter.drop_relation(existing_relation) %}\n    {% set build_sql = create_table_as(False, target_relation, sql) %}\n  \n  {% elif full_refresh_mode %}\n    {% set build_sql = create_table_as(False, target_relation, sql) %}\n  \n  {% else %}\n    {% do run_query(create_table_as(True, tmp_relation, sql)) %}\n    {% do adapter.expand_target_column_types(\n           from_relation=tmp_relation,\n           to_relation=target_relation) %}\n    {#-- Process schema changes. Returns dict of changes if successful. Use source columns for upserting/merging --#}\n    {% set dest_columns = process_schema_changes(on_schema_change, tmp_relation, existing_relation) %}\n    {% if not dest_columns %}\n      {% set dest_columns = adapter.get_columns_in_relation(existing_relation) %}\n    {% endif %}\n    {% set build_sql = dbt_snowflake_get_incremental_sql(strategy, tmp_relation, target_relation, unique_key, dest_columns) %}\n  \n  {% endif %}\n\n  {%- call statement('main') -%}\n    {{ build_sql }}\n  {%- endcall -%}\n\n  {{ run_hooks(post_hooks) }}\n\n  {% set target_relation = target_relation.incorporate(type='table') %}\n  {% do persist_docs(target_relation, model) %}\n\n  {% do unset_query_tag(original_query_tag) %}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{%- endmaterialization %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt_snowflake.set_query_tag",
+          "macro.dbt.should_full_refresh",
+          "macro.dbt.load_relation",
+          "macro.dbt.make_temp_relation",
+          "macro.dbt_snowflake.dbt_snowflake_validate_get_incremental_strategy",
+          "macro.dbt.incremental_validate_on_schema_change",
+          "macro.dbt.run_hooks",
+          "macro.dbt.create_table_as",
+          "macro.dbt.run_query",
+          "macro.dbt.process_schema_changes",
+          "macro.dbt_snowflake.dbt_snowflake_get_incremental_sql",
+          "macro.dbt.statement",
+          "macro.dbt.persist_docs",
+          "macro.dbt_snowflake.unset_query_tag"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.886762
+    },
+    "macro.dbt_snowflake.materialization_snapshot_snowflake": {
+      "unique_id": "macro.dbt_snowflake.materialization_snapshot_snowflake",
+      "package_name": "dbt_snowflake",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/snowflake",
+      "path": "macros/materializations/snapshot.sql",
+      "original_file_path": "macros/materializations/snapshot.sql",
+      "name": "materialization_snapshot_snowflake",
+      "macro_sql": "{% materialization snapshot, adapter='snowflake' %}\n    {% set original_query_tag = set_query_tag() %}\n\n    {% set relations = materialization_snapshot_default() %}\n\n    {% do unset_query_tag(original_query_tag) %}\n\n    {{ return(relations) }}\n{% endmaterialization %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt_snowflake.set_query_tag",
+          "macro.dbt.materialization_snapshot_default",
+          "macro.dbt_snowflake.unset_query_tag"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.8873532
+    },
+    "macro.dbt.run_hooks": {
+      "unique_id": "macro.dbt.run_hooks",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/hooks.sql",
+      "original_file_path": "macros/materializations/hooks.sql",
+      "name": "run_hooks",
+      "macro_sql": "{% macro run_hooks(hooks, inside_transaction=True) %}\n  {% for hook in hooks | selectattr('transaction', 'equalto', inside_transaction)  %}\n    {% if not inside_transaction and loop.first %}\n      {% call statement(auto_begin=inside_transaction) %}\n        commit;\n      {% endcall %}\n    {% endif %}\n    {% set rendered = render(hook.get('sql')) | trim %}\n    {% if (rendered | length) > 0 %}\n      {% call statement(auto_begin=inside_transaction) %}\n        {{ rendered }}\n      {% endcall %}\n    {% endif %}\n  {% endfor %}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.statement"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.888932
+    },
+    "macro.dbt.make_hook_config": {
+      "unique_id": "macro.dbt.make_hook_config",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/hooks.sql",
+      "original_file_path": "macros/materializations/hooks.sql",
+      "name": "make_hook_config",
+      "macro_sql": "{% macro make_hook_config(sql, inside_transaction) %}\n    {{ tojson({\"sql\": sql, \"transaction\": inside_transaction}) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.889206
+    },
+    "macro.dbt.before_begin": {
+      "unique_id": "macro.dbt.before_begin",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/hooks.sql",
+      "original_file_path": "macros/materializations/hooks.sql",
+      "name": "before_begin",
+      "macro_sql": "{% macro before_begin(sql) %}\n    {{ make_hook_config(sql, inside_transaction=False) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.make_hook_config"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.88941
+    },
+    "macro.dbt.in_transaction": {
+      "unique_id": "macro.dbt.in_transaction",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/hooks.sql",
+      "original_file_path": "macros/materializations/hooks.sql",
+      "name": "in_transaction",
+      "macro_sql": "{% macro in_transaction(sql) %}\n    {{ make_hook_config(sql, inside_transaction=True) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.make_hook_config"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.889604
+    },
+    "macro.dbt.after_commit": {
+      "unique_id": "macro.dbt.after_commit",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/hooks.sql",
+      "original_file_path": "macros/materializations/hooks.sql",
+      "name": "after_commit",
+      "macro_sql": "{% macro after_commit(sql) %}\n    {{ make_hook_config(sql, inside_transaction=False) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.make_hook_config"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.8897998
+    },
+    "macro.dbt.set_sql_header": {
+      "unique_id": "macro.dbt.set_sql_header",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/configs.sql",
+      "original_file_path": "macros/materializations/configs.sql",
+      "name": "set_sql_header",
+      "macro_sql": "{% macro set_sql_header(config) -%}\n  {{ config.set('sql_header', caller()) }}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.890388
+    },
+    "macro.dbt.should_full_refresh": {
+      "unique_id": "macro.dbt.should_full_refresh",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/configs.sql",
+      "original_file_path": "macros/materializations/configs.sql",
+      "name": "should_full_refresh",
+      "macro_sql": "{% macro should_full_refresh() %}\n  {% set config_full_refresh = config.get('full_refresh') %}\n  {% if config_full_refresh is none %}\n    {% set config_full_refresh = flags.FULL_REFRESH %}\n  {% endif %}\n  {% do return(config_full_refresh) %}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.890806
+    },
+    "macro.dbt.should_store_failures": {
+      "unique_id": "macro.dbt.should_store_failures",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/configs.sql",
+      "original_file_path": "macros/materializations/configs.sql",
+      "name": "should_store_failures",
+      "macro_sql": "{% macro should_store_failures() %}\n  {% set config_store_failures = config.get('store_failures') %}\n  {% if config_store_failures is none %}\n    {% set config_store_failures = flags.STORE_FAILURES %}\n  {% endif %}\n  {% do return(config_store_failures) %}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.891229
+    },
+    "macro.dbt.snapshot_merge_sql": {
+      "unique_id": "macro.dbt.snapshot_merge_sql",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/snapshots/snapshot_merge.sql",
+      "original_file_path": "macros/materializations/snapshots/snapshot_merge.sql",
+      "name": "snapshot_merge_sql",
+      "macro_sql": "{% macro snapshot_merge_sql(target, source, insert_cols) -%}\n  {{ adapter.dispatch('snapshot_merge_sql', 'dbt')(target, source, insert_cols) }}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt_snowflake.snowflake__snapshot_merge_sql"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.8918998
+    },
+    "macro.dbt.default__snapshot_merge_sql": {
+      "unique_id": "macro.dbt.default__snapshot_merge_sql",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/snapshots/snapshot_merge.sql",
+      "original_file_path": "macros/materializations/snapshots/snapshot_merge.sql",
+      "name": "default__snapshot_merge_sql",
+      "macro_sql": "{% macro default__snapshot_merge_sql(target, source, insert_cols) -%}\n    {%- set insert_cols_csv = insert_cols | join(', ') -%}\n\n    merge into {{ target }} as DBT_INTERNAL_DEST\n    using {{ source }} as DBT_INTERNAL_SOURCE\n    on DBT_INTERNAL_SOURCE.dbt_scd_id = DBT_INTERNAL_DEST.dbt_scd_id\n\n    when matched\n     and DBT_INTERNAL_DEST.dbt_valid_to is null\n     and DBT_INTERNAL_SOURCE.dbt_change_type in ('update', 'delete')\n        then update\n        set dbt_valid_to = DBT_INTERNAL_SOURCE.dbt_valid_to\n\n    when not matched\n     and DBT_INTERNAL_SOURCE.dbt_change_type = 'insert'\n        then insert ({{ insert_cols_csv }})\n        values ({{ insert_cols_csv }})\n\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.8922849
+    },
+    "macro.dbt.strategy_dispatch": {
+      "unique_id": "macro.dbt.strategy_dispatch",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/snapshots/strategies.sql",
+      "original_file_path": "macros/materializations/snapshots/strategies.sql",
+      "name": "strategy_dispatch",
+      "macro_sql": "{% macro strategy_dispatch(name) -%}\n{% set original_name = name %}\n  {% if '.' in name %}\n    {% set package_name, name = name.split(\".\", 1) %}\n  {% else %}\n    {% set package_name = none %}\n  {% endif %}\n\n  {% if package_name is none %}\n    {% set package_context = context %}\n  {% elif package_name in context %}\n    {% set package_context = context[package_name] %}\n  {% else %}\n    {% set error_msg %}\n        Could not find package '{{package_name}}', called with '{{original_name}}'\n    {% endset %}\n    {{ exceptions.raise_compiler_error(error_msg | trim) }}\n  {% endif %}\n\n  {%- set search_name = 'snapshot_' ~ name ~ '_strategy' -%}\n\n  {% if search_name not in package_context %}\n    {% set error_msg %}\n        The specified strategy macro '{{name}}' was not found in package '{{ package_name }}'\n    {% endset %}\n    {{ exceptions.raise_compiler_error(error_msg | trim) }}\n  {% endif %}\n  {{ return(package_context[search_name]) }}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.897024
+    },
+    "macro.dbt.snapshot_hash_arguments": {
+      "unique_id": "macro.dbt.snapshot_hash_arguments",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/snapshots/strategies.sql",
+      "original_file_path": "macros/materializations/snapshots/strategies.sql",
+      "name": "snapshot_hash_arguments",
+      "macro_sql": "{% macro snapshot_hash_arguments(args) -%}\n  {{ adapter.dispatch('snapshot_hash_arguments', 'dbt')(args) }}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__snapshot_hash_arguments"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.897263
+    },
+    "macro.dbt.default__snapshot_hash_arguments": {
+      "unique_id": "macro.dbt.default__snapshot_hash_arguments",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/snapshots/strategies.sql",
+      "original_file_path": "macros/materializations/snapshots/strategies.sql",
+      "name": "default__snapshot_hash_arguments",
+      "macro_sql": "{% macro default__snapshot_hash_arguments(args) -%}\n    md5({%- for arg in args -%}\n        coalesce(cast({{ arg }} as varchar ), '')\n        {% if not loop.last %} || '|' || {% endif %}\n    {%- endfor -%})\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.897572
+    },
+    "macro.dbt.snapshot_get_time": {
+      "unique_id": "macro.dbt.snapshot_get_time",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/snapshots/strategies.sql",
+      "original_file_path": "macros/materializations/snapshots/strategies.sql",
+      "name": "snapshot_get_time",
+      "macro_sql": "{% macro snapshot_get_time() -%}\n  {{ adapter.dispatch('snapshot_get_time', 'dbt')() }}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt_snowflake.snowflake__snapshot_get_time"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.897773
+    },
+    "macro.dbt.default__snapshot_get_time": {
+      "unique_id": "macro.dbt.default__snapshot_get_time",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/snapshots/strategies.sql",
+      "original_file_path": "macros/materializations/snapshots/strategies.sql",
+      "name": "default__snapshot_get_time",
+      "macro_sql": "{% macro default__snapshot_get_time() -%}\n  {{ current_timestamp() }}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.current_timestamp"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.8979042
+    },
+    "macro.dbt.snapshot_timestamp_strategy": {
+      "unique_id": "macro.dbt.snapshot_timestamp_strategy",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/snapshots/strategies.sql",
+      "original_file_path": "macros/materializations/snapshots/strategies.sql",
+      "name": "snapshot_timestamp_strategy",
+      "macro_sql": "{% macro snapshot_timestamp_strategy(node, snapshotted_rel, current_rel, config, target_exists) %}\n    {% set primary_key = config['unique_key'] %}\n    {% set updated_at = config['updated_at'] %}\n    {% set invalidate_hard_deletes = config.get('invalidate_hard_deletes', false) %}\n\n    {#/*\n        The snapshot relation might not have an {{ updated_at }} value if the\n        snapshot strategy is changed from `check` to `timestamp`. We\n        should use a dbt-created column for the comparison in the snapshot\n        table instead of assuming that the user-supplied {{ updated_at }}\n        will be present in the historical data.\n\n        See https://github.com/dbt-labs/dbt-core/issues/2350\n    */ #}\n    {% set row_changed_expr -%}\n        ({{ snapshotted_rel }}.dbt_valid_from < {{ current_rel }}.{{ updated_at }})\n    {%- endset %}\n\n    {% set scd_id_expr = snapshot_hash_arguments([primary_key, updated_at]) %}\n\n    {% do return({\n        \"unique_key\": primary_key,\n        \"updated_at\": updated_at,\n        \"row_changed\": row_changed_expr,\n        \"scd_id\": scd_id_expr,\n        \"invalidate_hard_deletes\": invalidate_hard_deletes\n    }) %}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.snapshot_hash_arguments"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.8989959
+    },
+    "macro.dbt.snapshot_string_as_time": {
+      "unique_id": "macro.dbt.snapshot_string_as_time",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/snapshots/strategies.sql",
+      "original_file_path": "macros/materializations/snapshots/strategies.sql",
+      "name": "snapshot_string_as_time",
+      "macro_sql": "{% macro snapshot_string_as_time(timestamp) -%}\n    {{ adapter.dispatch('snapshot_string_as_time', 'dbt')(timestamp) }}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt_snowflake.snowflake__snapshot_string_as_time"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.8992279
+    },
+    "macro.dbt.default__snapshot_string_as_time": {
+      "unique_id": "macro.dbt.default__snapshot_string_as_time",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/snapshots/strategies.sql",
+      "original_file_path": "macros/materializations/snapshots/strategies.sql",
+      "name": "default__snapshot_string_as_time",
+      "macro_sql": "{% macro default__snapshot_string_as_time(timestamp) %}\n    {% do exceptions.raise_not_implemented(\n        'snapshot_string_as_time macro not implemented for adapter '+adapter.type()\n    ) %}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.8994648
+    },
+    "macro.dbt.snapshot_check_all_get_existing_columns": {
+      "unique_id": "macro.dbt.snapshot_check_all_get_existing_columns",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/snapshots/strategies.sql",
+      "original_file_path": "macros/materializations/snapshots/strategies.sql",
+      "name": "snapshot_check_all_get_existing_columns",
+      "macro_sql": "{% macro snapshot_check_all_get_existing_columns(node, target_exists) -%}\n    {%- set query_columns = get_columns_in_query(node['compiled_sql']) -%}\n    {%- if not target_exists -%}\n        {# no table yet -> return whatever the query does #}\n        {{ return([false, query_columns]) }}\n    {%- endif -%}\n    {# handle any schema changes #}\n    {%- set target_table = node.get('alias', node.get('name')) -%}\n    {%- set target_relation = adapter.get_relation(database=node.database, schema=node.schema, identifier=target_table) -%}\n    {%- set existing_cols = get_columns_in_query('select * from ' ~ target_relation) -%}\n    {%- set ns = namespace() -%} {# handle for-loop scoping with a namespace #}\n    {%- set ns.column_added = false -%}\n\n    {%- set intersection = [] -%}\n    {%- for col in query_columns -%}\n        {%- if col in existing_cols -%}\n            {%- do intersection.append(col) -%}\n        {%- else -%}\n            {% set ns.column_added = true %}\n        {%- endif -%}\n    {%- endfor -%}\n    {{ return([ns.column_added, intersection]) }}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.get_columns_in_query"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.90084
+    },
+    "macro.dbt.snapshot_check_strategy": {
+      "unique_id": "macro.dbt.snapshot_check_strategy",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/snapshots/strategies.sql",
+      "original_file_path": "macros/materializations/snapshots/strategies.sql",
+      "name": "snapshot_check_strategy",
+      "macro_sql": "{% macro snapshot_check_strategy(node, snapshotted_rel, current_rel, config, target_exists) %}\n    {% set check_cols_config = config['check_cols'] %}\n    {% set primary_key = config['unique_key'] %}\n    {% set invalidate_hard_deletes = config.get('invalidate_hard_deletes', false) %}\n    \n    {% set select_current_time -%}\n        select {{ snapshot_get_time() }} as snapshot_start\n    {%- endset %}\n\n    {#-- don't access the column by name, to avoid dealing with casing issues on snowflake #}\n    {%- set now = run_query(select_current_time)[0][0] -%}\n    {% if now is none or now is undefined -%}\n        {%- do exceptions.raise_compiler_error('Could not get a snapshot start time from the database') -%}\n    {%- endif %}\n    {% set updated_at = config.get('updated_at', snapshot_string_as_time(now)) %}\n\n    {% set column_added = false %}\n\n    {% if check_cols_config == 'all' %}\n        {% set column_added, check_cols = snapshot_check_all_get_existing_columns(node, target_exists) %}\n    {% elif check_cols_config is iterable and (check_cols_config | length) > 0 %}\n        {% set check_cols = check_cols_config %}\n    {% else %}\n        {% do exceptions.raise_compiler_error(\"Invalid value for 'check_cols': \" ~ check_cols_config) %}\n    {% endif %}\n\n    {%- set row_changed_expr -%}\n    (\n    {%- if column_added -%}\n        TRUE\n    {%- else -%}\n    {%- for col in check_cols -%}\n        {{ snapshotted_rel }}.{{ col }} != {{ current_rel }}.{{ col }}\n        or\n        (\n            (({{ snapshotted_rel }}.{{ col }} is null) and not ({{ current_rel }}.{{ col }} is null))\n            or\n            ((not {{ snapshotted_rel }}.{{ col }} is null) and ({{ current_rel }}.{{ col }} is null))\n        )\n        {%- if not loop.last %} or {% endif -%}\n    {%- endfor -%}\n    {%- endif -%}\n    )\n    {%- endset %}\n\n    {% set scd_id_expr = snapshot_hash_arguments([primary_key, updated_at]) %}\n\n    {% do return({\n        \"unique_key\": primary_key,\n        \"updated_at\": updated_at,\n        \"row_changed\": row_changed_expr,\n        \"scd_id\": scd_id_expr,\n        \"invalidate_hard_deletes\": invalidate_hard_deletes\n    }) %}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.snapshot_get_time",
+          "macro.dbt.run_query",
+          "macro.dbt.snapshot_string_as_time",
+          "macro.dbt.snapshot_check_all_get_existing_columns",
+          "macro.dbt.snapshot_hash_arguments"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.903475
+    },
+    "macro.dbt.create_columns": {
+      "unique_id": "macro.dbt.create_columns",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/snapshots/helpers.sql",
+      "original_file_path": "macros/materializations/snapshots/helpers.sql",
+      "name": "create_columns",
+      "macro_sql": "{% macro create_columns(relation, columns) %}\n  {{ adapter.dispatch('create_columns', 'dbt')(relation, columns) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__create_columns"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.908169
+    },
+    "macro.dbt.default__create_columns": {
+      "unique_id": "macro.dbt.default__create_columns",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/snapshots/helpers.sql",
+      "original_file_path": "macros/materializations/snapshots/helpers.sql",
+      "name": "default__create_columns",
+      "macro_sql": "{% macro default__create_columns(relation, columns) %}\n  {% for column in columns %}\n    {% call statement() %}\n      alter table {{ relation }} add column \"{{ column.name }}\" {{ column.data_type }};\n    {% endcall %}\n  {% endfor %}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.statement"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.90858
+    },
+    "macro.dbt.post_snapshot": {
+      "unique_id": "macro.dbt.post_snapshot",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/snapshots/helpers.sql",
+      "original_file_path": "macros/materializations/snapshots/helpers.sql",
+      "name": "post_snapshot",
+      "macro_sql": "{% macro post_snapshot(staging_relation) %}\n  {{ adapter.dispatch('post_snapshot', 'dbt')(staging_relation) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__post_snapshot"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.908818
+    },
+    "macro.dbt.default__post_snapshot": {
+      "unique_id": "macro.dbt.default__post_snapshot",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/snapshots/helpers.sql",
+      "original_file_path": "macros/materializations/snapshots/helpers.sql",
+      "name": "default__post_snapshot",
+      "macro_sql": "{% macro default__post_snapshot(staging_relation) %}\n    {# no-op #}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.908938
+    },
+    "macro.dbt.snapshot_staging_table": {
+      "unique_id": "macro.dbt.snapshot_staging_table",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/snapshots/helpers.sql",
+      "original_file_path": "macros/materializations/snapshots/helpers.sql",
+      "name": "snapshot_staging_table",
+      "macro_sql": "{% macro snapshot_staging_table(strategy, source_sql, target_relation) -%}\n  {{ adapter.dispatch('snapshot_staging_table', 'dbt')(strategy, source_sql, target_relation) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__snapshot_staging_table"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.9092312
+    },
+    "macro.dbt.default__snapshot_staging_table": {
+      "unique_id": "macro.dbt.default__snapshot_staging_table",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/snapshots/helpers.sql",
+      "original_file_path": "macros/materializations/snapshots/helpers.sql",
+      "name": "default__snapshot_staging_table",
+      "macro_sql": "{% macro default__snapshot_staging_table(strategy, source_sql, target_relation) -%}\n\n    with snapshot_query as (\n\n        {{ source_sql }}\n\n    ),\n\n    snapshotted_data as (\n\n        select *,\n            {{ strategy.unique_key }} as dbt_unique_key\n\n        from {{ target_relation }}\n        where dbt_valid_to is null\n\n    ),\n\n    insertions_source_data as (\n\n        select\n            *,\n            {{ strategy.unique_key }} as dbt_unique_key,\n            {{ strategy.updated_at }} as dbt_updated_at,\n            {{ strategy.updated_at }} as dbt_valid_from,\n            nullif({{ strategy.updated_at }}, {{ strategy.updated_at }}) as dbt_valid_to,\n            {{ strategy.scd_id }} as dbt_scd_id\n\n        from snapshot_query\n    ),\n\n    updates_source_data as (\n\n        select\n            *,\n            {{ strategy.unique_key }} as dbt_unique_key,\n            {{ strategy.updated_at }} as dbt_updated_at,\n            {{ strategy.updated_at }} as dbt_valid_from,\n            {{ strategy.updated_at }} as dbt_valid_to\n\n        from snapshot_query\n    ),\n\n    {%- if strategy.invalidate_hard_deletes %}\n\n    deletes_source_data as (\n\n        select \n            *,\n            {{ strategy.unique_key }} as dbt_unique_key\n        from snapshot_query\n    ),\n    {% endif %}\n\n    insertions as (\n\n        select\n            'insert' as dbt_change_type,\n            source_data.*\n\n        from insertions_source_data as source_data\n        left outer join snapshotted_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key\n        where snapshotted_data.dbt_unique_key is null\n           or (\n                snapshotted_data.dbt_unique_key is not null\n            and (\n                {{ strategy.row_changed }}\n            )\n        )\n\n    ),\n\n    updates as (\n\n        select\n            'update' as dbt_change_type,\n            source_data.*,\n            snapshotted_data.dbt_scd_id\n\n        from updates_source_data as source_data\n        join snapshotted_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key\n        where (\n            {{ strategy.row_changed }}\n        )\n    )\n\n    {%- if strategy.invalidate_hard_deletes -%}\n    ,\n\n    deletes as (\n    \n        select\n            'delete' as dbt_change_type,\n            source_data.*,\n            {{ snapshot_get_time() }} as dbt_valid_from,\n            {{ snapshot_get_time() }} as dbt_updated_at,\n            {{ snapshot_get_time() }} as dbt_valid_to,\n            snapshotted_data.dbt_scd_id\n    \n        from snapshotted_data\n        left join deletes_source_data as source_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key\n        where source_data.dbt_unique_key is null\n    )\n    {%- endif %}\n\n    select * from insertions\n    union all\n    select * from updates\n    {%- if strategy.invalidate_hard_deletes %}\n    union all\n    select * from deletes\n    {%- endif %}\n\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.snapshot_get_time"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.910492
+    },
+    "macro.dbt.build_snapshot_table": {
+      "unique_id": "macro.dbt.build_snapshot_table",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/snapshots/helpers.sql",
+      "original_file_path": "macros/materializations/snapshots/helpers.sql",
+      "name": "build_snapshot_table",
+      "macro_sql": "{% macro build_snapshot_table(strategy, sql) -%}\n  {{ adapter.dispatch('build_snapshot_table', 'dbt')(strategy, sql) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__build_snapshot_table"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.910764
+    },
+    "macro.dbt.default__build_snapshot_table": {
+      "unique_id": "macro.dbt.default__build_snapshot_table",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/snapshots/helpers.sql",
+      "original_file_path": "macros/materializations/snapshots/helpers.sql",
+      "name": "default__build_snapshot_table",
+      "macro_sql": "{% macro default__build_snapshot_table(strategy, sql) %}\n\n    select *,\n        {{ strategy.scd_id }} as dbt_scd_id,\n        {{ strategy.updated_at }} as dbt_updated_at,\n        {{ strategy.updated_at }} as dbt_valid_from,\n        nullif({{ strategy.updated_at }}, {{ strategy.updated_at }}) as dbt_valid_to\n    from (\n        {{ sql }}\n    ) sbq\n\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.911125
+    },
+    "macro.dbt.build_snapshot_staging_table": {
+      "unique_id": "macro.dbt.build_snapshot_staging_table",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/snapshots/helpers.sql",
+      "original_file_path": "macros/materializations/snapshots/helpers.sql",
+      "name": "build_snapshot_staging_table",
+      "macro_sql": "{% macro build_snapshot_staging_table(strategy, sql, target_relation) %}\n    {% set tmp_relation = make_temp_relation(target_relation) %}\n\n    {% set select = snapshot_staging_table(strategy, sql, target_relation) %}\n\n    {% call statement('build_snapshot_staging_relation') %}\n        {{ create_table_as(True, tmp_relation, select) }}\n    {% endcall %}\n\n    {% do return(tmp_relation) %}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.make_temp_relation",
+          "macro.dbt.snapshot_staging_table",
+          "macro.dbt.statement",
+          "macro.dbt.create_table_as"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.911747
+    },
+    "macro.dbt.materialization_snapshot_default": {
+      "unique_id": "macro.dbt.materialization_snapshot_default",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/snapshots/snapshot.sql",
+      "original_file_path": "macros/materializations/snapshots/snapshot.sql",
+      "name": "materialization_snapshot_default",
+      "macro_sql": "{% materialization snapshot, default %}\n  {%- set config = model['config'] -%}\n\n  {%- set target_table = model.get('alias', model.get('name')) -%}\n\n  {%- set strategy_name = config.get('strategy') -%}\n  {%- set unique_key = config.get('unique_key') %}\n\n  {% if not adapter.check_schema_exists(model.database, model.schema) %}\n    {% do create_schema(model.database, model.schema) %}\n  {% endif %}\n\n  {% set target_relation_exists, target_relation = get_or_create_relation(\n          database=model.database,\n          schema=model.schema,\n          identifier=target_table,\n          type='table') -%}\n\n  {%- if not target_relation.is_table -%}\n    {% do exceptions.relation_wrong_type(target_relation, 'table') %}\n  {%- endif -%}\n\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  {% set strategy_macro = strategy_dispatch(strategy_name) %}\n  {% set strategy = strategy_macro(model, \"snapshotted_data\", \"source_data\", config, target_relation_exists) %}\n\n  {% if not target_relation_exists %}\n\n      {% set build_sql = build_snapshot_table(strategy, model['compiled_sql']) %}\n      {% set final_sql = create_table_as(False, target_relation, build_sql) %}\n\n  {% else %}\n\n      {{ adapter.valid_snapshot_target(target_relation) }}\n\n      {% set staging_table = build_snapshot_staging_table(strategy, sql, target_relation) %}\n\n      -- this may no-op if the database does not require column expansion\n      {% do adapter.expand_target_column_types(from_relation=staging_table,\n                                               to_relation=target_relation) %}\n\n      {% set missing_columns = adapter.get_missing_columns(staging_table, target_relation)\n                                   | rejectattr('name', 'equalto', 'dbt_change_type')\n                                   | rejectattr('name', 'equalto', 'DBT_CHANGE_TYPE')\n                                   | rejectattr('name', 'equalto', 'dbt_unique_key')\n                                   | rejectattr('name', 'equalto', 'DBT_UNIQUE_KEY')\n                                   | list %}\n\n      {% do create_columns(target_relation, missing_columns) %}\n\n      {% set source_columns = adapter.get_columns_in_relation(staging_table)\n                                   | rejectattr('name', 'equalto', 'dbt_change_type')\n                                   | rejectattr('name', 'equalto', 'DBT_CHANGE_TYPE')\n                                   | rejectattr('name', 'equalto', 'dbt_unique_key')\n                                   | rejectattr('name', 'equalto', 'DBT_UNIQUE_KEY')\n                                   | list %}\n\n      {% set quoted_source_columns = [] %}\n      {% for column in source_columns %}\n        {% do quoted_source_columns.append(adapter.quote(column.name)) %}\n      {% endfor %}\n\n      {% set final_sql = snapshot_merge_sql(\n            target = target_relation,\n            source = staging_table,\n            insert_cols = quoted_source_columns\n         )\n      %}\n\n  {% endif %}\n\n  {% call statement('main') %}\n      {{ final_sql }}\n  {% endcall %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {% if not target_relation_exists %}\n    {% do create_indexes(target_relation) %}\n  {% endif %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {{ adapter.commit() }}\n\n  {% if staging_table is defined %}\n      {% do post_snapshot(staging_table) %}\n  {% endif %}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{% endmaterialization %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.create_schema",
+          "macro.dbt.get_or_create_relation",
+          "macro.dbt.run_hooks",
+          "macro.dbt.strategy_dispatch",
+          "macro.dbt.build_snapshot_table",
+          "macro.dbt.create_table_as",
+          "macro.dbt.build_snapshot_staging_table",
+          "macro.dbt.create_columns",
+          "macro.dbt.snapshot_merge_sql",
+          "macro.dbt.statement",
+          "macro.dbt.persist_docs",
+          "macro.dbt.create_indexes",
+          "macro.dbt.post_snapshot"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.9206789
+    },
+    "macro.dbt.materialization_test_default": {
+      "unique_id": "macro.dbt.materialization_test_default",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/tests/test.sql",
+      "original_file_path": "macros/materializations/tests/test.sql",
+      "name": "materialization_test_default",
+      "macro_sql": "{%- materialization test, default -%}\n\n  {% set relations = [] %}\n\n  {% if should_store_failures() %}\n\n    {% set identifier = model['alias'] %}\n    {% set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) %}\n    {% set target_relation = api.Relation.create(\n        identifier=identifier, schema=schema, database=database, type='table') -%} %}\n    \n    {% if old_relation %}\n        {% do adapter.drop_relation(old_relation) %}\n    {% endif %}\n    \n    {% call statement(auto_begin=True) %}\n        {{ create_table_as(False, target_relation, sql) }}\n    {% endcall %}\n    \n    {% do relations.append(target_relation) %}\n  \n    {% set main_sql %}\n        select *\n        from {{ target_relation }}\n    {% endset %}\n    \n    {{ adapter.commit() }}\n  \n  {% else %}\n\n      {% set main_sql = sql %}\n  \n  {% endif %}\n\n  {% set limit = config.get('limit') %}\n  {% set fail_calc = config.get('fail_calc') %}\n  {% set warn_if = config.get('warn_if') %}\n  {% set error_if = config.get('error_if') %}\n\n  {% call statement('main', fetch_result=True) -%}\n\n    {{ get_test_sql(main_sql, fail_calc, warn_if, error_if, limit)}}\n\n  {%- endcall %}\n  \n  {{ return({'relations': relations}) }}\n\n{%- endmaterialization -%}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.should_store_failures",
+          "macro.dbt.statement",
+          "macro.dbt.create_table_as",
+          "macro.dbt.get_test_sql"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.9236538
+    },
+    "macro.dbt.get_test_sql": {
+      "unique_id": "macro.dbt.get_test_sql",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/tests/helpers.sql",
+      "original_file_path": "macros/materializations/tests/helpers.sql",
+      "name": "get_test_sql",
+      "macro_sql": "{% macro get_test_sql(main_sql, fail_calc, warn_if, error_if, limit) -%}\n  {{ adapter.dispatch('get_test_sql', 'dbt')(main_sql, fail_calc, warn_if, error_if, limit) }}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__get_test_sql"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.9243462
+    },
+    "macro.dbt.default__get_test_sql": {
+      "unique_id": "macro.dbt.default__get_test_sql",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/tests/helpers.sql",
+      "original_file_path": "macros/materializations/tests/helpers.sql",
+      "name": "default__get_test_sql",
+      "macro_sql": "{% macro default__get_test_sql(main_sql, fail_calc, warn_if, error_if, limit) -%}\n    select\n      {{ fail_calc }} as failures,\n      {{ fail_calc }} {{ warn_if }} as should_warn,\n      {{ fail_calc }} {{ error_if }} as should_error\n    from (\n      {{ main_sql }}\n      {{ \"limit \" ~ limit if limit != none }}\n    ) dbt_internal_test\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.924779
+    },
+    "macro.dbt.get_where_subquery": {
+      "unique_id": "macro.dbt.get_where_subquery",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/tests/where_subquery.sql",
+      "original_file_path": "macros/materializations/tests/where_subquery.sql",
+      "name": "get_where_subquery",
+      "macro_sql": "{% macro get_where_subquery(relation) -%}\n    {% do return(adapter.dispatch('get_where_subquery', 'dbt')(relation)) %}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__get_where_subquery"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.925364
+    },
+    "macro.dbt.default__get_where_subquery": {
+      "unique_id": "macro.dbt.default__get_where_subquery",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/tests/where_subquery.sql",
+      "original_file_path": "macros/materializations/tests/where_subquery.sql",
+      "name": "default__get_where_subquery",
+      "macro_sql": "{% macro default__get_where_subquery(relation) -%}\n    {% set where = config.get('where', '') %}\n    {% if where %}\n        {%- set filtered -%}\n            (select * from {{ relation }} where {{ where }}) dbt_subquery\n        {%- endset -%}\n        {% do return(filtered) %}\n    {%- else -%}\n        {% do return(relation) %}\n    {%- endif -%}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.925892
+    },
+    "macro.dbt.get_quoted_csv": {
+      "unique_id": "macro.dbt.get_quoted_csv",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/models/incremental/column_helpers.sql",
+      "original_file_path": "macros/materializations/models/incremental/column_helpers.sql",
+      "name": "get_quoted_csv",
+      "macro_sql": "{% macro get_quoted_csv(column_names) %}\n    \n    {% set quoted = [] %}\n    {% for col in column_names -%}\n        {%- do quoted.append(adapter.quote(col)) -%}\n    {%- endfor %}\n\n    {%- set dest_cols_csv = quoted | join(', ') -%}\n    {{ return(dest_cols_csv) }}\n\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.927068
+    },
+    "macro.dbt.diff_columns": {
+      "unique_id": "macro.dbt.diff_columns",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/models/incremental/column_helpers.sql",
+      "original_file_path": "macros/materializations/models/incremental/column_helpers.sql",
+      "name": "diff_columns",
+      "macro_sql": "{% macro diff_columns(source_columns, target_columns) %}\n\n  {% set result = [] %}\n  {% set source_names = source_columns | map(attribute = 'column') | list %}\n  {% set target_names = target_columns | map(attribute = 'column') | list %}\n   \n   {# --check whether the name attribute exists in the target - this does not perform a data type check #}\n   {% for sc in source_columns %}\n     {% if sc.name not in target_names %}\n        {{ result.append(sc) }}\n     {% endif %}\n   {% endfor %}\n  \n  {{ return(result) }}\n\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.927835
+    },
+    "macro.dbt.diff_column_data_types": {
+      "unique_id": "macro.dbt.diff_column_data_types",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/models/incremental/column_helpers.sql",
+      "original_file_path": "macros/materializations/models/incremental/column_helpers.sql",
+      "name": "diff_column_data_types",
+      "macro_sql": "{% macro diff_column_data_types(source_columns, target_columns) %}\n  \n  {% set result = [] %}\n  {% for sc in source_columns %}\n    {% set tc = target_columns | selectattr(\"name\", \"equalto\", sc.name) | list | first %}\n    {% if tc %}\n      {% if sc.data_type != tc.data_type %}\n        {{ result.append( { 'column_name': tc.name, 'new_type': sc.data_type } ) }} \n      {% endif %}\n    {% endif %}\n  {% endfor %}\n\n  {{ return(result) }}\n\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.928701
+    },
+    "macro.dbt.get_merge_sql": {
+      "unique_id": "macro.dbt.get_merge_sql",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/models/incremental/merge.sql",
+      "original_file_path": "macros/materializations/models/incremental/merge.sql",
+      "name": "get_merge_sql",
+      "macro_sql": "{% macro get_merge_sql(target, source, unique_key, dest_columns, predicates=none) -%}\n  {{ adapter.dispatch('get_merge_sql', 'dbt')(target, source, unique_key, dest_columns, predicates) }}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt_snowflake.snowflake__get_merge_sql"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.932815
+    },
+    "macro.dbt.default__get_merge_sql": {
+      "unique_id": "macro.dbt.default__get_merge_sql",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/models/incremental/merge.sql",
+      "original_file_path": "macros/materializations/models/incremental/merge.sql",
+      "name": "default__get_merge_sql",
+      "macro_sql": "{% macro default__get_merge_sql(target, source, unique_key, dest_columns, predicates) -%}\n    {%- set predicates = [] if predicates is none else [] + predicates -%}\n    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute=\"name\")) -%}\n    {%- set update_columns = config.get('merge_update_columns', default = dest_columns | map(attribute=\"quoted\") | list) -%}\n    {%- set sql_header = config.get('sql_header', none) -%}\n\n    {% if unique_key %}\n        {% set unique_key_match %}\n            DBT_INTERNAL_SOURCE.{{ unique_key }} = DBT_INTERNAL_DEST.{{ unique_key }}\n        {% endset %}\n        {% do predicates.append(unique_key_match) %}\n    {% else %}\n        {% do predicates.append('FALSE') %}\n    {% endif %}\n\n    {{ sql_header if sql_header is not none }}\n\n    merge into {{ target }} as DBT_INTERNAL_DEST\n        using {{ source }} as DBT_INTERNAL_SOURCE\n        on {{ predicates | join(' and ') }}\n\n    {% if unique_key %}\n    when matched then update set\n        {% for column_name in update_columns -%}\n            {{ column_name }} = DBT_INTERNAL_SOURCE.{{ column_name }}\n            {%- if not loop.last %}, {%- endif %}\n        {%- endfor %}\n    {% endif %}\n\n    when not matched then insert\n        ({{ dest_cols_csv }})\n    values\n        ({{ dest_cols_csv }})\n\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.get_quoted_csv"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.9344552
+    },
+    "macro.dbt.get_delete_insert_merge_sql": {
+      "unique_id": "macro.dbt.get_delete_insert_merge_sql",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/models/incremental/merge.sql",
+      "original_file_path": "macros/materializations/models/incremental/merge.sql",
+      "name": "get_delete_insert_merge_sql",
+      "macro_sql": "{% macro get_delete_insert_merge_sql(target, source, unique_key, dest_columns) -%}\n  {{ adapter.dispatch('get_delete_insert_merge_sql', 'dbt')(target, source, unique_key, dest_columns) }}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt_snowflake.snowflake__get_delete_insert_merge_sql"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.9347892
+    },
+    "macro.dbt.default__get_delete_insert_merge_sql": {
+      "unique_id": "macro.dbt.default__get_delete_insert_merge_sql",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/models/incremental/merge.sql",
+      "original_file_path": "macros/materializations/models/incremental/merge.sql",
+      "name": "default__get_delete_insert_merge_sql",
+      "macro_sql": "{% macro default__get_delete_insert_merge_sql(target, source, unique_key, dest_columns) -%}\n\n    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute=\"name\")) -%}\n\n    {% if unique_key is not none %}\n    delete from {{ target }}\n    where ({{ unique_key }}) in (\n        select ({{ unique_key }})\n        from {{ source }}\n    );\n    {% endif %}\n\n    insert into {{ target }} ({{ dest_cols_csv }})\n    (\n        select {{ dest_cols_csv }}\n        from {{ source }}\n    )\n\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.get_quoted_csv"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.9353862
+    },
+    "macro.dbt.get_insert_overwrite_merge_sql": {
+      "unique_id": "macro.dbt.get_insert_overwrite_merge_sql",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/models/incremental/merge.sql",
+      "original_file_path": "macros/materializations/models/incremental/merge.sql",
+      "name": "get_insert_overwrite_merge_sql",
+      "macro_sql": "{% macro get_insert_overwrite_merge_sql(target, source, dest_columns, predicates, include_sql_header=false) -%}\n  {{ adapter.dispatch('get_insert_overwrite_merge_sql', 'dbt')(target, source, dest_columns, predicates, include_sql_header) }}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__get_insert_overwrite_merge_sql"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.935755
+    },
+    "macro.dbt.default__get_insert_overwrite_merge_sql": {
+      "unique_id": "macro.dbt.default__get_insert_overwrite_merge_sql",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/models/incremental/merge.sql",
+      "original_file_path": "macros/materializations/models/incremental/merge.sql",
+      "name": "default__get_insert_overwrite_merge_sql",
+      "macro_sql": "{% macro default__get_insert_overwrite_merge_sql(target, source, dest_columns, predicates, include_sql_header) -%}\n    {%- set predicates = [] if predicates is none else [] + predicates -%}\n    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute=\"name\")) -%}\n    {%- set sql_header = config.get('sql_header', none) -%}\n\n    {{ sql_header if sql_header is not none and include_sql_header }}\n\n    merge into {{ target }} as DBT_INTERNAL_DEST\n        using {{ source }} as DBT_INTERNAL_SOURCE\n        on FALSE\n\n    when not matched by source\n        {% if predicates %} and {{ predicates | join(' and ') }} {% endif %}\n        then delete\n\n    when not matched then insert\n        ({{ dest_cols_csv }})\n    values\n        ({{ dest_cols_csv }})\n\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.get_quoted_csv"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.9366431
+    },
+    "macro.dbt.is_incremental": {
+      "unique_id": "macro.dbt.is_incremental",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/models/incremental/is_incremental.sql",
+      "original_file_path": "macros/materializations/models/incremental/is_incremental.sql",
+      "name": "is_incremental",
+      "macro_sql": "{% macro is_incremental() %}\n    {#-- do not run introspective queries in parsing #}\n    {% if not execute %}\n        {{ return(False) }}\n    {% else %}\n        {% set relation = adapter.get_relation(this.database, this.schema, this.table) %}\n        {{ return(relation is not none\n                  and relation.type == 'table'\n                  and model.config.materialized == 'incremental'\n                  and not should_full_refresh()) }}\n    {% endif %}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.should_full_refresh"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.937603
+    },
+    "macro.dbt.materialization_incremental_default": {
+      "unique_id": "macro.dbt.materialization_incremental_default",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/models/incremental/incremental.sql",
+      "original_file_path": "macros/materializations/models/incremental/incremental.sql",
+      "name": "materialization_incremental_default",
+      "macro_sql": "{% materialization incremental, default -%}\n\n  {% set unique_key = config.get('unique_key') %}\n\n  {% set target_relation = this.incorporate(type='table') %}\n  {% set existing_relation = load_relation(this) %}\n  {% set tmp_relation = make_temp_relation(target_relation) %}\n  {%- set full_refresh_mode = (should_full_refresh()) -%}\n\n  {% set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') %}\n\n  {% set tmp_identifier = model['name'] + '__dbt_tmp' %}\n  {% set backup_identifier = model['name'] + \"__dbt_backup\" %}\n\n  -- the intermediate_ and backup_ relations should not already exist in the database; get_relation\n  -- will return None in that case. Otherwise, we get a relation that we can drop\n  -- later, before we try to use this name for the current operation. This has to happen before\n  -- BEGIN, in a separate transaction\n  {% set preexisting_intermediate_relation = adapter.get_relation(identifier=tmp_identifier, \n                                                                  schema=schema,\n                                                                  database=database) %}                                               \n  {% set preexisting_backup_relation = adapter.get_relation(identifier=backup_identifier,\n                                                            schema=schema,\n                                                            database=database) %}\n  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}\n  {{ drop_relation_if_exists(preexisting_backup_relation) }}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  {% set to_drop = [] %}\n\n  {# -- first check whether we want to full refresh for source view or config reasons #}\n  {% set trigger_full_refresh = (full_refresh_mode or existing_relation.is_view) %}\n\n  {% if existing_relation is none %}\n      {% set build_sql = create_table_as(False, target_relation, sql) %}\n{% elif trigger_full_refresh %}\n      {#-- Make sure the backup doesn't exist so we don't encounter issues with the rename below #}\n      {% set tmp_identifier = model['name'] + '__dbt_tmp' %}\n      {% set backup_identifier = model['name'] + '__dbt_backup' %}\n      {% set intermediate_relation = existing_relation.incorporate(path={\"identifier\": tmp_identifier}) %}\n      {% set backup_relation = existing_relation.incorporate(path={\"identifier\": backup_identifier}) %}\n\n      {% set build_sql = create_table_as(False, intermediate_relation, sql) %}\n      {% set need_swap = true %}\n      {% do to_drop.append(backup_relation) %}\n  {% else %}\n    {% do run_query(create_table_as(True, tmp_relation, sql)) %}\n    {% do adapter.expand_target_column_types(\n             from_relation=tmp_relation,\n             to_relation=target_relation) %}\n    {#-- Process schema changes. Returns dict of changes if successful. Use source columns for upserting/merging --#}\n    {% set dest_columns = process_schema_changes(on_schema_change, tmp_relation, existing_relation) %}\n    {% if not dest_columns %}\n      {% set dest_columns = adapter.get_columns_in_relation(existing_relation) %}\n    {% endif %}\n    {% set build_sql = get_delete_insert_merge_sql(target_relation, tmp_relation, unique_key, dest_columns) %}\n  \n  {% endif %}\n\n  {% call statement(\"main\") %}\n      {{ build_sql }}\n  {% endcall %}\n\n  {% if need_swap %} \n      {% do adapter.rename_relation(target_relation, backup_relation) %} \n      {% do adapter.rename_relation(intermediate_relation, target_relation) %} \n  {% endif %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {% if existing_relation is none or existing_relation.is_view or should_full_refresh() %}\n    {% do create_indexes(target_relation) %}\n  {% endif %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  -- `COMMIT` happens here\n  {% do adapter.commit() %}\n\n  {% for rel in to_drop %}\n      {% do adapter.drop_relation(rel) %}\n  {% endfor %}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{%- endmaterialization %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.load_relation",
+          "macro.dbt.make_temp_relation",
+          "macro.dbt.should_full_refresh",
+          "macro.dbt.incremental_validate_on_schema_change",
+          "macro.dbt.drop_relation_if_exists",
+          "macro.dbt.run_hooks",
+          "macro.dbt.create_table_as",
+          "macro.dbt.run_query",
+          "macro.dbt.process_schema_changes",
+          "macro.dbt.get_delete_insert_merge_sql",
+          "macro.dbt.statement",
+          "macro.dbt.persist_docs",
+          "macro.dbt.create_indexes"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.9445581
+    },
+    "macro.dbt.incremental_validate_on_schema_change": {
+      "unique_id": "macro.dbt.incremental_validate_on_schema_change",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/models/incremental/on_schema_change.sql",
+      "original_file_path": "macros/materializations/models/incremental/on_schema_change.sql",
+      "name": "incremental_validate_on_schema_change",
+      "macro_sql": "{% macro incremental_validate_on_schema_change(on_schema_change, default='ignore') %}\n   \n   {% if on_schema_change not in ['sync_all_columns', 'append_new_columns', 'fail', 'ignore'] %}\n     \n     {% set log_message = 'Invalid value for on_schema_change (%s) specified. Setting default value of %s.' % (on_schema_change, default) %}\n     {% do log(log_message) %}\n     \n     {{ return(default) }}\n\n   {% else %}\n\n     {{ return(on_schema_change) }}\n   \n   {% endif %}\n\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.951615
+    },
+    "macro.dbt.check_for_schema_changes": {
+      "unique_id": "macro.dbt.check_for_schema_changes",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/models/incremental/on_schema_change.sql",
+      "original_file_path": "macros/materializations/models/incremental/on_schema_change.sql",
+      "name": "check_for_schema_changes",
+      "macro_sql": "{% macro check_for_schema_changes(source_relation, target_relation) %}\n  \n  {% set schema_changed = False %}\n  \n  {%- set source_columns = adapter.get_columns_in_relation(source_relation) -%}\n  {%- set target_columns = adapter.get_columns_in_relation(target_relation) -%}\n  {%- set source_not_in_target = diff_columns(source_columns, target_columns) -%}\n  {%- set target_not_in_source = diff_columns(target_columns, source_columns) -%}\n\n  {% set new_target_types = diff_column_data_types(source_columns, target_columns) %}\n\n  {% if source_not_in_target != [] %}\n    {% set schema_changed = True %}\n  {% elif target_not_in_source != [] or new_target_types != [] %}\n    {% set schema_changed = True %}\n  {% elif new_target_types != [] %}\n    {% set schema_changed = True %}\n  {% endif %}\n  \n  {% set changes_dict = {\n    'schema_changed': schema_changed,\n    'source_not_in_target': source_not_in_target,\n    'target_not_in_source': target_not_in_source,\n    'source_columns': source_columns,\n    'target_columns': target_columns,\n    'new_target_types': new_target_types\n  } %}\n\n  {% set msg %}\n    In {{ target_relation }}:\n        Schema changed: {{ schema_changed }}\n        Source columns not in target: {{ source_not_in_target }}\n        Target columns not in source: {{ target_not_in_source }}\n        New column types: {{ new_target_types }}\n  {% endset %}\n  \n  {% do log(msg) %}\n\n  {{ return(changes_dict) }}\n\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.diff_columns",
+          "macro.dbt.diff_column_data_types"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.953349
+    },
+    "macro.dbt.sync_column_schemas": {
+      "unique_id": "macro.dbt.sync_column_schemas",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/models/incremental/on_schema_change.sql",
+      "original_file_path": "macros/materializations/models/incremental/on_schema_change.sql",
+      "name": "sync_column_schemas",
+      "macro_sql": "{% macro sync_column_schemas(on_schema_change, target_relation, schema_changes_dict) %}\n  \n  {%- set add_to_target_arr = schema_changes_dict['source_not_in_target'] -%}\n\n  {%- if on_schema_change == 'append_new_columns'-%}\n     {%- if add_to_target_arr | length > 0 -%}\n       {%- do alter_relation_add_remove_columns(target_relation, add_to_target_arr, none) -%}\n     {%- endif -%}\n  \n  {% elif on_schema_change == 'sync_all_columns' %}\n     {%- set remove_from_target_arr = schema_changes_dict['target_not_in_source'] -%}\n     {%- set new_target_types = schema_changes_dict['new_target_types'] -%}\n  \n     {% if add_to_target_arr | length > 0 or remove_from_target_arr | length > 0 %} \n       {%- do alter_relation_add_remove_columns(target_relation, add_to_target_arr, remove_from_target_arr) -%}\n     {% endif %}\n\n     {% if new_target_types != [] %}\n       {% for ntt in new_target_types %}\n         {% set column_name = ntt['column_name'] %}\n         {% set new_type = ntt['new_type'] %}\n         {% do alter_column_type(target_relation, column_name, new_type) %}\n       {% endfor %}\n     {% endif %}\n  \n  {% endif %}\n\n  {% set schema_change_message %}\n    In {{ target_relation }}:\n        Schema change approach: {{ on_schema_change }}\n        Columns added: {{ add_to_target_arr }}\n        Columns removed: {{ remove_from_target_arr }}\n        Data types changed: {{ new_target_types }}\n  {% endset %}\n  \n  {% do log(schema_change_message) %}\n  \n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.alter_relation_add_remove_columns",
+          "macro.dbt.alter_column_type"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.9550478
+    },
+    "macro.dbt.process_schema_changes": {
+      "unique_id": "macro.dbt.process_schema_changes",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/models/incremental/on_schema_change.sql",
+      "original_file_path": "macros/materializations/models/incremental/on_schema_change.sql",
+      "name": "process_schema_changes",
+      "macro_sql": "{% macro process_schema_changes(on_schema_change, source_relation, target_relation) %}\n    \n    {% if on_schema_change == 'ignore' %}\n\n     {{ return({}) }}\n\n    {% else %}\n    \n      {% set schema_changes_dict = check_for_schema_changes(source_relation, target_relation) %}\n      \n      {% if schema_changes_dict['schema_changed'] %}\n    \n        {% if on_schema_change == 'fail' %}\n        \n          {% set fail_msg %}\n              The source and target schemas on this incremental model are out of sync!\n              They can be reconciled in several ways: \n                - set the `on_schema_change` config to either append_new_columns or sync_all_columns, depending on your situation.\n                - Re-run the incremental model with `full_refresh: True` to update the target schema.\n                - update the schema manually and re-run the process.\n          {% endset %}\n          \n          {% do exceptions.raise_compiler_error(fail_msg) %}\n        \n        {# -- unless we ignore, run the sync operation per the config #}\n        {% else %}\n          \n          {% do sync_column_schemas(on_schema_change, target_relation, schema_changes_dict) %}\n        \n        {% endif %}\n      \n      {% endif %}\n\n      {{ return(schema_changes_dict['source_columns']) }}\n    \n    {% endif %}\n\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.check_for_schema_changes",
+          "macro.dbt.sync_column_schemas"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.956074
+    },
+    "macro.dbt.materialization_table_default": {
+      "unique_id": "macro.dbt.materialization_table_default",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/models/table/table.sql",
+      "original_file_path": "macros/materializations/models/table/table.sql",
+      "name": "materialization_table_default",
+      "macro_sql": "{% materialization table, default %}\n  {%- set identifier = model['alias'] -%}\n  {%- set tmp_identifier = model['name'] + '__dbt_tmp' -%}\n  {%- set backup_identifier = model['name'] + '__dbt_backup' -%}\n\n  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}\n  {%- set target_relation = api.Relation.create(identifier=identifier,\n                                                schema=schema,\n                                                database=database,\n                                                type='table') -%}\n  {%- set intermediate_relation = api.Relation.create(identifier=tmp_identifier,\n                                                      schema=schema,\n                                                      database=database,\n                                                      type='table') -%}\n  -- the intermediate_relation should not already exist in the database; get_relation\n  -- will return None in that case. Otherwise, we get a relation that we can drop\n  -- later, before we try to use this name for the current operation\n  {%- set preexisting_intermediate_relation = adapter.get_relation(identifier=tmp_identifier, \n                                                                   schema=schema,\n                                                                   database=database) -%}\n  /*\n      See ../view/view.sql for more information about this relation.\n  */\n  {%- set backup_relation_type = 'table' if old_relation is none else old_relation.type -%}\n  {%- set backup_relation = api.Relation.create(identifier=backup_identifier,\n                                                schema=schema,\n                                                database=database,\n                                                type=backup_relation_type) -%}\n  -- as above, the backup_relation should not already exist\n  {%- set preexisting_backup_relation = adapter.get_relation(identifier=backup_identifier,\n                                                             schema=schema,\n                                                             database=database) -%}\n\n\n  -- drop the temp relations if they exist already in the database\n  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}\n  {{ drop_relation_if_exists(preexisting_backup_relation) }}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- build model\n  {% call statement('main') -%}\n    {{ get_create_table_as_sql(False, intermediate_relation, sql) }}\n  {%- endcall %}\n\n  -- cleanup\n  {% if old_relation is not none %}\n      {{ adapter.rename_relation(old_relation, backup_relation) }}\n  {% endif %}\n\n  {{ adapter.rename_relation(intermediate_relation, target_relation) }}\n\n  {% do create_indexes(target_relation) %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {% do persist_docs(target_relation, model) %}\n\n  -- `COMMIT` happens here\n  {{ adapter.commit() }}\n\n  -- finally, drop the existing/backup relation after the commit\n  {{ drop_relation_if_exists(backup_relation) }}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n{% endmaterialization %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.drop_relation_if_exists",
+          "macro.dbt.run_hooks",
+          "macro.dbt.statement",
+          "macro.dbt.get_create_table_as_sql",
+          "macro.dbt.create_indexes",
+          "macro.dbt.persist_docs"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.9614022
+    },
+    "macro.dbt.get_create_table_as_sql": {
+      "unique_id": "macro.dbt.get_create_table_as_sql",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/models/table/create_table_as.sql",
+      "original_file_path": "macros/materializations/models/table/create_table_as.sql",
+      "name": "get_create_table_as_sql",
+      "macro_sql": "{% macro get_create_table_as_sql(temporary, relation, sql) -%}\n  {{ adapter.dispatch('get_create_table_as_sql', 'dbt')(temporary, relation, sql) }}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__get_create_table_as_sql"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.9620721
+    },
+    "macro.dbt.default__get_create_table_as_sql": {
+      "unique_id": "macro.dbt.default__get_create_table_as_sql",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/models/table/create_table_as.sql",
+      "original_file_path": "macros/materializations/models/table/create_table_as.sql",
+      "name": "default__get_create_table_as_sql",
+      "macro_sql": "{% macro default__get_create_table_as_sql(temporary, relation, sql) -%}\n  {{ return(create_table_as(temporary, relation, sql)) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.create_table_as"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.96233
+    },
+    "macro.dbt.create_table_as": {
+      "unique_id": "macro.dbt.create_table_as",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/models/table/create_table_as.sql",
+      "original_file_path": "macros/materializations/models/table/create_table_as.sql",
+      "name": "create_table_as",
+      "macro_sql": "{% macro create_table_as(temporary, relation, sql) -%}\n  {{ adapter.dispatch('create_table_as', 'dbt')(temporary, relation, sql) }}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt_snowflake.snowflake__create_table_as"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.962614
+    },
+    "macro.dbt.default__create_table_as": {
+      "unique_id": "macro.dbt.default__create_table_as",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/models/table/create_table_as.sql",
+      "original_file_path": "macros/materializations/models/table/create_table_as.sql",
+      "name": "default__create_table_as",
+      "macro_sql": "{% macro default__create_table_as(temporary, relation, sql) -%}\n  {%- set sql_header = config.get('sql_header', none) -%}\n  \n  {{ sql_header if sql_header is not none }}\n  \n  create {% if temporary: -%}temporary{%- endif %} table\n    {{ relation.include(database=(not temporary), schema=(not temporary)) }}\n  as (\n    {{ sql }}\n  );\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.963192
+    },
+    "macro.dbt.materialization_view_default": {
+      "unique_id": "macro.dbt.materialization_view_default",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/models/view/view.sql",
+      "original_file_path": "macros/materializations/models/view/view.sql",
+      "name": "materialization_view_default",
+      "macro_sql": "{%- materialization view, default -%}\n\n  {%- set identifier = model['alias'] -%}\n  {%- set tmp_identifier = model['name'] + '__dbt_tmp' -%}\n  {%- set backup_identifier = model['name'] + '__dbt_backup' -%}\n\n  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}\n  {%- set target_relation = api.Relation.create(identifier=identifier, schema=schema, database=database,\n                                                type='view') -%}\n  {%- set intermediate_relation = api.Relation.create(identifier=tmp_identifier,\n                                                      schema=schema, database=database, type='view') -%}\n  -- the intermediate_relation should not already exist in the database; get_relation\n  -- will return None in that case. Otherwise, we get a relation that we can drop\n  -- later, before we try to use this name for the current operation\n  {%- set preexisting_intermediate_relation = adapter.get_relation(identifier=tmp_identifier, \n                                                                   schema=schema,\n                                                                   database=database) -%}\n  /*\n     This relation (probably) doesn't exist yet. If it does exist, it's a leftover from\n     a previous run, and we're going to try to drop it immediately. At the end of this\n     materialization, we're going to rename the \"old_relation\" to this identifier,\n     and then we're going to drop it. In order to make sure we run the correct one of:\n       - drop view ...\n       - drop table ...\n\n     We need to set the type of this relation to be the type of the old_relation, if it exists,\n     or else \"view\" as a sane default if it does not. Note that if the old_relation does not\n     exist, then there is nothing to move out of the way and subsequentally drop. In that case,\n     this relation will be effectively unused.\n  */\n  {%- set backup_relation_type = 'view' if old_relation is none else old_relation.type -%}\n  {%- set backup_relation = api.Relation.create(identifier=backup_identifier,\n                                                schema=schema, database=database,\n                                                type=backup_relation_type) -%}\n  -- as above, the backup_relation should not already exist\n  {%- set preexisting_backup_relation = adapter.get_relation(identifier=backup_identifier,\n                                                             schema=schema,\n                                                             database=database) -%}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- drop the temp relations if they exist already in the database\n  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}\n  {{ drop_relation_if_exists(preexisting_backup_relation) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- build model\n  {% call statement('main') -%}\n    {{ create_view_as(intermediate_relation, sql) }}\n  {%- endcall %}\n\n  -- cleanup\n  -- move the existing view out of the way\n  {% if old_relation is not none %}\n    {{ adapter.rename_relation(old_relation, backup_relation) }}\n  {% endif %}\n  {{ adapter.rename_relation(intermediate_relation, target_relation) }}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {{ adapter.commit() }}\n\n  {{ drop_relation_if_exists(backup_relation) }}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{%- endmaterialization -%}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.run_hooks",
+          "macro.dbt.drop_relation_if_exists",
+          "macro.dbt.statement",
+          "macro.dbt.create_view_as",
+          "macro.dbt.persist_docs"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.968302
+    },
+    "macro.dbt.handle_existing_table": {
+      "unique_id": "macro.dbt.handle_existing_table",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/models/view/helpers.sql",
+      "original_file_path": "macros/materializations/models/view/helpers.sql",
+      "name": "handle_existing_table",
+      "macro_sql": "{% macro handle_existing_table(full_refresh, old_relation) %}\n    {{ adapter.dispatch('handle_existing_table', 'dbt')(full_refresh, old_relation) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__handle_existing_table"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.96879
+    },
+    "macro.dbt.default__handle_existing_table": {
+      "unique_id": "macro.dbt.default__handle_existing_table",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/models/view/helpers.sql",
+      "original_file_path": "macros/materializations/models/view/helpers.sql",
+      "name": "default__handle_existing_table",
+      "macro_sql": "{% macro default__handle_existing_table(full_refresh, old_relation) %}\n    {{ log(\"Dropping relation \" ~ old_relation ~ \" because it is of type \" ~ old_relation.type) }}\n    {{ adapter.drop_relation(old_relation) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.969101
+    },
+    "macro.dbt.create_or_replace_view": {
+      "unique_id": "macro.dbt.create_or_replace_view",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/models/view/create_or_replace_view.sql",
+      "original_file_path": "macros/materializations/models/view/create_or_replace_view.sql",
+      "name": "create_or_replace_view",
+      "macro_sql": "{% macro create_or_replace_view() %}\n  {%- set identifier = model['alias'] -%}\n\n  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}\n\n  {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}\n\n  {%- set target_relation = api.Relation.create(\n      identifier=identifier, schema=schema, database=database,\n      type='view') -%}\n\n  {{ run_hooks(pre_hooks) }}\n\n  -- If there's a table with the same name and we weren't told to full refresh,\n  -- that's an error. If we were told to full refresh, drop it. This behavior differs\n  -- for Snowflake and BigQuery, so multiple dispatch is used.\n  {%- if old_relation is not none and old_relation.is_table -%}\n    {{ handle_existing_table(should_full_refresh(), old_relation) }}\n  {%- endif -%}\n\n  -- build model\n  {% call statement('main') -%}\n    {{ get_create_view_as_sql(target_relation, sql) }}\n  {%- endcall %}\n\n  {{ run_hooks(post_hooks) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.run_hooks",
+          "macro.dbt.handle_existing_table",
+          "macro.dbt.should_full_refresh",
+          "macro.dbt.statement",
+          "macro.dbt.get_create_view_as_sql"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.97084
+    },
+    "macro.dbt.get_create_view_as_sql": {
+      "unique_id": "macro.dbt.get_create_view_as_sql",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/models/view/create_view_as.sql",
+      "original_file_path": "macros/materializations/models/view/create_view_as.sql",
+      "name": "get_create_view_as_sql",
+      "macro_sql": "{% macro get_create_view_as_sql(relation, sql) -%}\n  {{ adapter.dispatch('get_create_view_as_sql', 'dbt')(relation, sql) }}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__get_create_view_as_sql"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.971413
+    },
+    "macro.dbt.default__get_create_view_as_sql": {
+      "unique_id": "macro.dbt.default__get_create_view_as_sql",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/models/view/create_view_as.sql",
+      "original_file_path": "macros/materializations/models/view/create_view_as.sql",
+      "name": "default__get_create_view_as_sql",
+      "macro_sql": "{% macro default__get_create_view_as_sql(relation, sql) -%}\n  {{ return(create_view_as(relation, sql)) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.create_view_as"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.97164
+    },
+    "macro.dbt.create_view_as": {
+      "unique_id": "macro.dbt.create_view_as",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/models/view/create_view_as.sql",
+      "original_file_path": "macros/materializations/models/view/create_view_as.sql",
+      "name": "create_view_as",
+      "macro_sql": "{% macro create_view_as(relation, sql) -%}\n  {{ adapter.dispatch('create_view_as', 'dbt')(relation, sql) }}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt_snowflake.snowflake__create_view_as"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.971901
+    },
+    "macro.dbt.default__create_view_as": {
+      "unique_id": "macro.dbt.default__create_view_as",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/models/view/create_view_as.sql",
+      "original_file_path": "macros/materializations/models/view/create_view_as.sql",
+      "name": "default__create_view_as",
+      "macro_sql": "{% macro default__create_view_as(relation, sql) -%}\n  {%- set sql_header = config.get('sql_header', none) -%}\n\n  {{ sql_header if sql_header is not none }}\n  create view {{ relation }} as (\n    {{ sql }}\n  );\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.9722629
+    },
+    "macro.dbt.materialization_seed_default": {
+      "unique_id": "macro.dbt.materialization_seed_default",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/seeds/seed.sql",
+      "original_file_path": "macros/materializations/seeds/seed.sql",
+      "name": "materialization_seed_default",
+      "macro_sql": "{% materialization seed, default %}\n\n  {%- set identifier = model['alias'] -%}\n  {%- set full_refresh_mode = (should_full_refresh()) -%}\n\n  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}\n\n  {%- set exists_as_table = (old_relation is not none and old_relation.is_table) -%}\n  {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}\n\n  {%- set agate_table = load_agate_table() -%}\n  {%- do store_result('agate_table', response='OK', agate_table=agate_table) -%}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- build model\n  {% set create_table_sql = \"\" %}\n  {% if exists_as_view %}\n    {{ exceptions.raise_compiler_error(\"Cannot seed to '{}', it is a view\".format(old_relation)) }}\n  {% elif exists_as_table %}\n    {% set create_table_sql = reset_csv_table(model, full_refresh_mode, old_relation, agate_table) %}\n  {% else %}\n    {% set create_table_sql = create_csv_table(model, agate_table) %}\n  {% endif %}\n\n  {% set code = 'CREATE' if full_refresh_mode else 'INSERT' %}\n  {% set rows_affected = (agate_table.rows | length) %}\n  {% set sql = load_csv_rows(model, agate_table) %}\n\n  {% call noop_statement('main', code ~ ' ' ~ rows_affected, code, rows_affected) %}\n    {{ create_table_sql }};\n    -- dbt seed --\n    {{ sql }}\n  {% endcall %}\n\n  {% set target_relation = this.incorporate(type='table') %}\n  {% do persist_docs(target_relation, model) %}\n\n  {% if full_refresh_mode or not exists_as_table %}\n    {% do create_indexes(target_relation) %}\n  {% endif %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  -- `COMMIT` happens here\n  {{ adapter.commit() }}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{% endmaterialization %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.should_full_refresh",
+          "macro.dbt.run_hooks",
+          "macro.dbt.reset_csv_table",
+          "macro.dbt.create_csv_table",
+          "macro.dbt.load_csv_rows",
+          "macro.dbt.noop_statement",
+          "macro.dbt.persist_docs",
+          "macro.dbt.create_indexes"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.9762712
+    },
+    "macro.dbt.create_csv_table": {
+      "unique_id": "macro.dbt.create_csv_table",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/seeds/helpers.sql",
+      "original_file_path": "macros/materializations/seeds/helpers.sql",
+      "name": "create_csv_table",
+      "macro_sql": "{% macro create_csv_table(model, agate_table) -%}\n  {{ adapter.dispatch('create_csv_table', 'dbt')(model, agate_table) }}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__create_csv_table"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.98218
+    },
+    "macro.dbt.default__create_csv_table": {
+      "unique_id": "macro.dbt.default__create_csv_table",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/seeds/helpers.sql",
+      "original_file_path": "macros/materializations/seeds/helpers.sql",
+      "name": "default__create_csv_table",
+      "macro_sql": "{% macro default__create_csv_table(model, agate_table) %}\n  {%- set column_override = model['config'].get('column_types', {}) -%}\n  {%- set quote_seed_column = model['config'].get('quote_columns', None) -%}\n\n  {% set sql %}\n    create table {{ this.render() }} (\n        {%- for col_name in agate_table.column_names -%}\n            {%- set inferred_type = adapter.convert_type(agate_table, loop.index0) -%}\n            {%- set type = column_override.get(col_name, inferred_type) -%}\n            {%- set column_name = (col_name | string) -%}\n            {{ adapter.quote_seed_column(column_name, quote_seed_column) }} {{ type }} {%- if not loop.last -%}, {%- endif -%}\n        {%- endfor -%}\n    )\n  {% endset %}\n\n  {% call statement('_') -%}\n    {{ sql }}\n  {%- endcall %}\n\n  {{ return(sql) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.statement"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.9834518
+    },
+    "macro.dbt.reset_csv_table": {
+      "unique_id": "macro.dbt.reset_csv_table",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/seeds/helpers.sql",
+      "original_file_path": "macros/materializations/seeds/helpers.sql",
+      "name": "reset_csv_table",
+      "macro_sql": "{% macro reset_csv_table(model, full_refresh, old_relation, agate_table) -%}\n  {{ adapter.dispatch('reset_csv_table', 'dbt')(model, full_refresh, old_relation, agate_table) }}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__reset_csv_table"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.983781
+    },
+    "macro.dbt.default__reset_csv_table": {
+      "unique_id": "macro.dbt.default__reset_csv_table",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/seeds/helpers.sql",
+      "original_file_path": "macros/materializations/seeds/helpers.sql",
+      "name": "default__reset_csv_table",
+      "macro_sql": "{% macro default__reset_csv_table(model, full_refresh, old_relation, agate_table) %}\n    {% set sql = \"\" %}\n    {% if full_refresh %}\n        {{ adapter.drop_relation(old_relation) }}\n        {% set sql = create_csv_table(model, agate_table) %}\n    {% else %}\n        {{ adapter.truncate_relation(old_relation) }}\n        {% set sql = \"truncate table \" ~ old_relation %}\n    {% endif %}\n\n    {{ return(sql) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.create_csv_table"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.9844558
+    },
+    "macro.dbt.get_binding_char": {
+      "unique_id": "macro.dbt.get_binding_char",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/seeds/helpers.sql",
+      "original_file_path": "macros/materializations/seeds/helpers.sql",
+      "name": "get_binding_char",
+      "macro_sql": "{% macro get_binding_char() -%}\n  {{ adapter.dispatch('get_binding_char', 'dbt')() }}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__get_binding_char"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.9846568
+    },
+    "macro.dbt.default__get_binding_char": {
+      "unique_id": "macro.dbt.default__get_binding_char",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/seeds/helpers.sql",
+      "original_file_path": "macros/materializations/seeds/helpers.sql",
+      "name": "default__get_binding_char",
+      "macro_sql": "{% macro default__get_binding_char() %}\n  {{ return('%s') }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.984813
+    },
+    "macro.dbt.get_batch_size": {
+      "unique_id": "macro.dbt.get_batch_size",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/seeds/helpers.sql",
+      "original_file_path": "macros/materializations/seeds/helpers.sql",
+      "name": "get_batch_size",
+      "macro_sql": "{% macro get_batch_size() -%}\n  {{ return(adapter.dispatch('get_batch_size', 'dbt')()) }}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__get_batch_size"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.98503
+    },
+    "macro.dbt.default__get_batch_size": {
+      "unique_id": "macro.dbt.default__get_batch_size",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/seeds/helpers.sql",
+      "original_file_path": "macros/materializations/seeds/helpers.sql",
+      "name": "default__get_batch_size",
+      "macro_sql": "{% macro default__get_batch_size() %}\n  {{ return(10000) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.985185
+    },
+    "macro.dbt.get_seed_column_quoted_csv": {
+      "unique_id": "macro.dbt.get_seed_column_quoted_csv",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/seeds/helpers.sql",
+      "original_file_path": "macros/materializations/seeds/helpers.sql",
+      "name": "get_seed_column_quoted_csv",
+      "macro_sql": "{% macro get_seed_column_quoted_csv(model, column_names) %}\n  {%- set quote_seed_column = model['config'].get('quote_columns', None) -%}\n    {% set quoted = [] %}\n    {% for col in column_names -%}\n        {%- do quoted.append(adapter.quote_seed_column(col, quote_seed_column)) -%}\n    {%- endfor %}\n\n    {%- set dest_cols_csv = quoted | join(', ') -%}\n    {{ return(dest_cols_csv) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.985861
+    },
+    "macro.dbt.load_csv_rows": {
+      "unique_id": "macro.dbt.load_csv_rows",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/seeds/helpers.sql",
+      "original_file_path": "macros/materializations/seeds/helpers.sql",
+      "name": "load_csv_rows",
+      "macro_sql": "{% macro load_csv_rows(model, agate_table) -%}\n  {{ adapter.dispatch('load_csv_rows', 'dbt')(model, agate_table) }}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt_snowflake.snowflake__load_csv_rows"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.9861991
+    },
+    "macro.dbt.default__load_csv_rows": {
+      "unique_id": "macro.dbt.default__load_csv_rows",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/materializations/seeds/helpers.sql",
+      "original_file_path": "macros/materializations/seeds/helpers.sql",
+      "name": "default__load_csv_rows",
+      "macro_sql": "{% macro default__load_csv_rows(model, agate_table) %}\n\n  {% set batch_size = get_batch_size() %}\n\n  {% set cols_sql = get_seed_column_quoted_csv(model, agate_table.column_names) %}\n  {% set bindings = [] %}\n\n  {% set statements = [] %}\n\n  {% for chunk in agate_table.rows | batch(batch_size) %}\n      {% set bindings = [] %}\n\n      {% for row in chunk %}\n          {% do bindings.extend(row) %}\n      {% endfor %}\n\n      {% set sql %}\n          insert into {{ this.render() }} ({{ cols_sql }}) values\n          {% for row in chunk -%}\n              ({%- for column in agate_table.column_names -%}\n                  {{ get_binding_char() }}\n                  {%- if not loop.last%},{%- endif %}\n              {%- endfor -%})\n              {%- if not loop.last%},{%- endif %}\n          {%- endfor %}\n      {% endset %}\n\n      {% do adapter.add_query(sql, bindings=bindings, abridge_sql_log=True) %}\n\n      {% if loop.index0 == 0 %}\n          {% do statements.append(sql) %}\n      {% endif %}\n  {% endfor %}\n\n  {# Return SQL so we can render it out into the compiled files #}\n  {{ return(statements[0]) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.get_batch_size",
+          "macro.dbt.get_seed_column_quoted_csv",
+          "macro.dbt.get_binding_char"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.987911
+    },
+    "macro.dbt.generate_alias_name": {
+      "unique_id": "macro.dbt.generate_alias_name",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/get_custom_name/get_custom_alias.sql",
+      "original_file_path": "macros/get_custom_name/get_custom_alias.sql",
+      "name": "generate_alias_name",
+      "macro_sql": "{% macro generate_alias_name(custom_alias_name=none, node=none) -%}\n    {% do return(adapter.dispatch('generate_alias_name', 'dbt')(custom_alias_name, node)) %}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__generate_alias_name"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.988524
+    },
+    "macro.dbt.default__generate_alias_name": {
+      "unique_id": "macro.dbt.default__generate_alias_name",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/get_custom_name/get_custom_alias.sql",
+      "original_file_path": "macros/get_custom_name/get_custom_alias.sql",
+      "name": "default__generate_alias_name",
+      "macro_sql": "{% macro default__generate_alias_name(custom_alias_name=none, node=none) -%}\n\n    {%- if custom_alias_name is none -%}\n\n        {{ node.name }}\n\n    {%- else -%}\n\n        {{ custom_alias_name | trim }}\n\n    {%- endif -%}\n\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.988838
+    },
+    "macro.dbt.generate_schema_name": {
+      "unique_id": "macro.dbt.generate_schema_name",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/get_custom_name/get_custom_schema.sql",
+      "original_file_path": "macros/get_custom_name/get_custom_schema.sql",
+      "name": "generate_schema_name",
+      "macro_sql": "{% macro generate_schema_name(custom_schema_name=none, node=none) -%}\n    {{ return(adapter.dispatch('generate_schema_name', 'dbt')(custom_schema_name, node)) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__generate_schema_name"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.989611
+    },
+    "macro.dbt.default__generate_schema_name": {
+      "unique_id": "macro.dbt.default__generate_schema_name",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/get_custom_name/get_custom_schema.sql",
+      "original_file_path": "macros/get_custom_name/get_custom_schema.sql",
+      "name": "default__generate_schema_name",
+      "macro_sql": "{% macro default__generate_schema_name(custom_schema_name, node) -%}\n\n    {%- set default_schema = target.schema -%}\n    {%- if custom_schema_name is none -%}\n\n        {{ default_schema }}\n\n    {%- else -%}\n\n        {{ default_schema }}_{{ custom_schema_name | trim }}\n\n    {%- endif -%}\n\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.989978
+    },
+    "macro.dbt.generate_schema_name_for_env": {
+      "unique_id": "macro.dbt.generate_schema_name_for_env",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/get_custom_name/get_custom_schema.sql",
+      "original_file_path": "macros/get_custom_name/get_custom_schema.sql",
+      "name": "generate_schema_name_for_env",
+      "macro_sql": "{% macro generate_schema_name_for_env(custom_schema_name, node) -%}\n\n    {%- set default_schema = target.schema -%}\n    {%- if target.name == 'prod' and custom_schema_name is not none -%}\n\n        {{ custom_schema_name | trim }}\n\n    {%- else -%}\n\n        {{ default_schema }}\n\n    {%- endif -%}\n\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.990379
+    },
+    "macro.dbt.generate_database_name": {
+      "unique_id": "macro.dbt.generate_database_name",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/get_custom_name/get_custom_database.sql",
+      "original_file_path": "macros/get_custom_name/get_custom_database.sql",
+      "name": "generate_database_name",
+      "macro_sql": "{% macro generate_database_name(custom_database_name=none, node=none) -%}\n    {% do return(adapter.dispatch('generate_database_name', 'dbt')(custom_database_name, node)) %}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__generate_database_name"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.990991
+    },
+    "macro.dbt.default__generate_database_name": {
+      "unique_id": "macro.dbt.default__generate_database_name",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/get_custom_name/get_custom_database.sql",
+      "original_file_path": "macros/get_custom_name/get_custom_database.sql",
+      "name": "default__generate_database_name",
+      "macro_sql": "{% macro default__generate_database_name(custom_database_name=none, node=none) -%}\n    {%- set default_database = target.database -%}\n    {%- if custom_database_name is none -%}\n\n        {{ default_database }}\n\n    {%- else -%}\n\n        {{ custom_database_name }}\n\n    {%- endif -%}\n\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.99134
+    },
+    "macro.dbt.default__test_relationships": {
+      "unique_id": "macro.dbt.default__test_relationships",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/generic_test_sql/relationships.sql",
+      "original_file_path": "macros/generic_test_sql/relationships.sql",
+      "name": "default__test_relationships",
+      "macro_sql": "{% macro default__test_relationships(model, column_name, to, field) %}\n\nwith child as (\n    select {{ column_name }} as from_field\n    from {{ model }}\n    where {{ column_name }} is not null\n),\n\nparent as (\n    select {{ field }} as to_field\n    from {{ to }}\n)\n\nselect\n    from_field\n\nfrom child\nleft join parent\n    on child.from_field = parent.to_field\n\nwhere parent.to_field is null\n\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.9918878
+    },
+    "macro.dbt.default__test_not_null": {
+      "unique_id": "macro.dbt.default__test_not_null",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/generic_test_sql/not_null.sql",
+      "original_file_path": "macros/generic_test_sql/not_null.sql",
+      "name": "default__test_not_null",
+      "macro_sql": "{% macro default__test_not_null(model, column_name) %}\n\nselect *\nfrom {{ model }}\nwhere {{ column_name }} is null\n\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.9922051
+    },
+    "macro.dbt.default__test_unique": {
+      "unique_id": "macro.dbt.default__test_unique",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/generic_test_sql/unique.sql",
+      "original_file_path": "macros/generic_test_sql/unique.sql",
+      "name": "default__test_unique",
+      "macro_sql": "{% macro default__test_unique(model, column_name) %}\n\nselect\n    {{ column_name }} as unique_field,\n    count(*) as n_records\n\nfrom {{ model }}\nwhere {{ column_name }} is not null\ngroup by {{ column_name }}\nhaving count(*) > 1\n\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.992613
+    },
+    "macro.dbt.default__test_accepted_values": {
+      "unique_id": "macro.dbt.default__test_accepted_values",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/generic_test_sql/accepted_values.sql",
+      "original_file_path": "macros/generic_test_sql/accepted_values.sql",
+      "name": "default__test_accepted_values",
+      "macro_sql": "{% macro default__test_accepted_values(model, column_name, values, quote=True) %}\n\nwith all_values as (\n\n    select\n        {{ column_name }} as value_field,\n        count(*) as n_records\n\n    from {{ model }}\n    group by {{ column_name }}\n\n)\n\nselect *\nfrom all_values\nwhere value_field not in (\n    {% for value in values -%}\n        {% if quote -%}\n        '{{ value }}'\n        {%- else -%}\n        {{ value }}\n        {%- endif -%}\n        {%- if not loop.last -%},{%- endif %}\n    {%- endfor %}\n)\n\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.9934661
+    },
+    "macro.dbt.statement": {
+      "unique_id": "macro.dbt.statement",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/etc/statement.sql",
+      "original_file_path": "macros/etc/statement.sql",
+      "name": "statement",
+      "macro_sql": "{% macro statement(name=None, fetch_result=False, auto_begin=True) -%}\n  {%- if execute: -%}\n    {%- set sql = caller() -%}\n\n    {%- if name == 'main' -%}\n      {{ log('Writing runtime SQL for node \"{}\"'.format(model['unique_id'])) }}\n      {{ write(sql) }}\n    {%- endif -%}\n\n    {%- set res, table = adapter.execute(sql, auto_begin=auto_begin, fetch=fetch_result) -%}\n    {%- if name is not none -%}\n      {{ store_result(name, response=res, agate_table=table) }}\n    {%- endif -%}\n\n  {%- endif -%}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.99507
+    },
+    "macro.dbt.noop_statement": {
+      "unique_id": "macro.dbt.noop_statement",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/etc/statement.sql",
+      "original_file_path": "macros/etc/statement.sql",
+      "name": "noop_statement",
+      "macro_sql": "{% macro noop_statement(name=None, message=None, code=None, rows_affected=None, res=None) -%}\n  {%- set sql = caller() -%}\n\n  {%- if name == 'main' -%}\n    {{ log('Writing runtime SQL for node \"{}\"'.format(model['unique_id'])) }}\n    {{ write(sql) }}\n  {%- endif -%}\n\n  {%- if name is not none -%}\n    {{ store_raw_result(name, message=message, code=code, rows_affected=rows_affected, agate_table=res) }}\n  {%- endif -%}\n\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.9959009
+    },
+    "macro.dbt.run_query": {
+      "unique_id": "macro.dbt.run_query",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/etc/statement.sql",
+      "original_file_path": "macros/etc/statement.sql",
+      "name": "run_query",
+      "macro_sql": "{% macro run_query(sql) %}\n  {% call statement(\"run_query_statement\", fetch_result=true, auto_begin=false) %}\n    {{ sql }}\n  {% endcall %}\n\n  {% do return(load_result(\"run_query_statement\").table) %}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.statement"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.996313
+    },
+    "macro.dbt.convert_datetime": {
+      "unique_id": "macro.dbt.convert_datetime",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/etc/datetime.sql",
+      "original_file_path": "macros/etc/datetime.sql",
+      "name": "convert_datetime",
+      "macro_sql": "{% macro convert_datetime(date_str, date_fmt) %}\n\n  {% set error_msg -%}\n      The provided partition date '{{ date_str }}' does not match the expected format '{{ date_fmt }}'\n  {%- endset %}\n\n  {% set res = try_or_compiler_error(error_msg, modules.datetime.datetime.strptime, date_str.strip(), date_fmt) %}\n  {{ return(res) }}\n\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871656.998864
+    },
+    "macro.dbt.dates_in_range": {
+      "unique_id": "macro.dbt.dates_in_range",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/etc/datetime.sql",
+      "original_file_path": "macros/etc/datetime.sql",
+      "name": "dates_in_range",
+      "macro_sql": "{% macro dates_in_range(start_date_str, end_date_str=none, in_fmt=\"%Y%m%d\", out_fmt=\"%Y%m%d\") %}\n    {% set end_date_str = start_date_str if end_date_str is none else end_date_str %}\n\n    {% set start_date = convert_datetime(start_date_str, in_fmt) %}\n    {% set end_date = convert_datetime(end_date_str, in_fmt) %}\n\n    {% set day_count = (end_date - start_date).days %}\n    {% if day_count < 0 %}\n        {% set msg -%}\n            Partiton start date is after the end date ({{ start_date }}, {{ end_date }})\n        {%- endset %}\n\n        {{ exceptions.raise_compiler_error(msg, model) }}\n    {% endif %}\n\n    {% set date_list = [] %}\n    {% for i in range(0, day_count + 1) %}\n        {% set the_date = (modules.datetime.timedelta(days=i) + start_date) %}\n        {% if not out_fmt %}\n            {% set _ = date_list.append(the_date) %}\n        {% else %}\n            {% set _ = date_list.append(the_date.strftime(out_fmt)) %}\n        {% endif %}\n    {% endfor %}\n\n    {{ return(date_list) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.convert_datetime"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.000652
+    },
+    "macro.dbt.partition_range": {
+      "unique_id": "macro.dbt.partition_range",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/etc/datetime.sql",
+      "original_file_path": "macros/etc/datetime.sql",
+      "name": "partition_range",
+      "macro_sql": "{% macro partition_range(raw_partition_date, date_fmt='%Y%m%d') %}\n    {% set partition_range = (raw_partition_date | string).split(\",\") %}\n\n    {% if (partition_range | length) == 1 %}\n      {% set start_date = partition_range[0] %}\n      {% set end_date = none %}\n    {% elif (partition_range | length) == 2 %}\n      {% set start_date = partition_range[0] %}\n      {% set end_date = partition_range[1] %}\n    {% else %}\n      {{ exceptions.raise_compiler_error(\"Invalid partition time. Expected format: {Start Date}[,{End Date}]. Got: \" ~ raw_partition_date) }}\n    {% endif %}\n\n    {{ return(dates_in_range(start_date, end_date, in_fmt=date_fmt)) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.dates_in_range"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.001714
+    },
+    "macro.dbt.py_current_timestring": {
+      "unique_id": "macro.dbt.py_current_timestring",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/etc/datetime.sql",
+      "original_file_path": "macros/etc/datetime.sql",
+      "name": "py_current_timestring",
+      "macro_sql": "{% macro py_current_timestring() %}\n    {% set dt = modules.datetime.datetime.now() %}\n    {% do return(dt.strftime(\"%Y%m%d%H%M%S%f\")) %}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.002038
+    },
+    "macro.dbt.create_schema": {
+      "unique_id": "macro.dbt.create_schema",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/schema.sql",
+      "original_file_path": "macros/adapters/schema.sql",
+      "name": "create_schema",
+      "macro_sql": "{% macro create_schema(relation) -%}\n  {{ adapter.dispatch('create_schema', 'dbt')(relation) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__create_schema"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.00263
+    },
+    "macro.dbt.default__create_schema": {
+      "unique_id": "macro.dbt.default__create_schema",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/schema.sql",
+      "original_file_path": "macros/adapters/schema.sql",
+      "name": "default__create_schema",
+      "macro_sql": "{% macro default__create_schema(relation) -%}\n  {%- call statement('create_schema') -%}\n    create schema if not exists {{ relation.without_identifier() }}\n  {% endcall %}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.statement"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.002882
+    },
+    "macro.dbt.drop_schema": {
+      "unique_id": "macro.dbt.drop_schema",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/schema.sql",
+      "original_file_path": "macros/adapters/schema.sql",
+      "name": "drop_schema",
+      "macro_sql": "{% macro drop_schema(relation) -%}\n  {{ adapter.dispatch('drop_schema', 'dbt')(relation) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__drop_schema"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.003111
+    },
+    "macro.dbt.default__drop_schema": {
+      "unique_id": "macro.dbt.default__drop_schema",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/schema.sql",
+      "original_file_path": "macros/adapters/schema.sql",
+      "name": "default__drop_schema",
+      "macro_sql": "{% macro default__drop_schema(relation) -%}\n  {%- call statement('drop_schema') -%}\n    drop schema if exists {{ relation.without_identifier() }} cascade\n  {% endcall %}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.statement"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.003361
+    },
+    "macro.dbt.get_create_index_sql": {
+      "unique_id": "macro.dbt.get_create_index_sql",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/indexes.sql",
+      "original_file_path": "macros/adapters/indexes.sql",
+      "name": "get_create_index_sql",
+      "macro_sql": "{% macro get_create_index_sql(relation, index_dict) -%}\n  {{ return(adapter.dispatch('get_create_index_sql', 'dbt')(relation, index_dict)) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__get_create_index_sql"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.004073
+    },
+    "macro.dbt.default__get_create_index_sql": {
+      "unique_id": "macro.dbt.default__get_create_index_sql",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/indexes.sql",
+      "original_file_path": "macros/adapters/indexes.sql",
+      "name": "default__get_create_index_sql",
+      "macro_sql": "{% macro default__get_create_index_sql(relation, index_dict) -%}\n  {% do return(None) %}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.004259
+    },
+    "macro.dbt.create_indexes": {
+      "unique_id": "macro.dbt.create_indexes",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/indexes.sql",
+      "original_file_path": "macros/adapters/indexes.sql",
+      "name": "create_indexes",
+      "macro_sql": "{% macro create_indexes(relation) -%}\n  {{ adapter.dispatch('create_indexes', 'dbt')(relation) }}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__create_indexes"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.0044749
+    },
+    "macro.dbt.default__create_indexes": {
+      "unique_id": "macro.dbt.default__create_indexes",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/indexes.sql",
+      "original_file_path": "macros/adapters/indexes.sql",
+      "name": "default__create_indexes",
+      "macro_sql": "{% macro default__create_indexes(relation) -%}\n  {%- set _indexes = config.get('indexes', default=[]) -%}\n\n  {% for _index_dict in _indexes %}\n    {% set create_index_sql = get_create_index_sql(relation, _index_dict) %}\n    {% if create_index_sql %}\n      {% do run_query(create_index_sql) %}\n    {% endif %}\n  {% endfor %}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.get_create_index_sql",
+          "macro.dbt.run_query"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.0050318
+    },
+    "macro.dbt.make_temp_relation": {
+      "unique_id": "macro.dbt.make_temp_relation",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/relation.sql",
+      "original_file_path": "macros/adapters/relation.sql",
+      "name": "make_temp_relation",
+      "macro_sql": "{% macro make_temp_relation(base_relation, suffix='__dbt_tmp') %}\n  {{ return(adapter.dispatch('make_temp_relation', 'dbt')(base_relation, suffix))}}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__make_temp_relation"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.007351
+    },
+    "macro.dbt.default__make_temp_relation": {
+      "unique_id": "macro.dbt.default__make_temp_relation",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/relation.sql",
+      "original_file_path": "macros/adapters/relation.sql",
+      "name": "default__make_temp_relation",
+      "macro_sql": "{% macro default__make_temp_relation(base_relation, suffix) %}\n    {% set tmp_identifier = base_relation.identifier ~ suffix %}\n    {% set tmp_relation = base_relation.incorporate(\n                                path={\"identifier\": tmp_identifier}) -%}\n\n    {% do return(tmp_relation) %}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.007775
+    },
+    "macro.dbt.drop_relation": {
+      "unique_id": "macro.dbt.drop_relation",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/relation.sql",
+      "original_file_path": "macros/adapters/relation.sql",
+      "name": "drop_relation",
+      "macro_sql": "{% macro drop_relation(relation) -%}\n  {{ return(adapter.dispatch('drop_relation', 'dbt')(relation)) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__drop_relation"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.008037
+    },
+    "macro.dbt.default__drop_relation": {
+      "unique_id": "macro.dbt.default__drop_relation",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/relation.sql",
+      "original_file_path": "macros/adapters/relation.sql",
+      "name": "default__drop_relation",
+      "macro_sql": "{% macro default__drop_relation(relation) -%}\n  {% call statement('drop_relation', auto_begin=False) -%}\n    drop {{ relation.type }} if exists {{ relation }} cascade\n  {%- endcall %}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.statement"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.0083342
+    },
+    "macro.dbt.truncate_relation": {
+      "unique_id": "macro.dbt.truncate_relation",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/relation.sql",
+      "original_file_path": "macros/adapters/relation.sql",
+      "name": "truncate_relation",
+      "macro_sql": "{% macro truncate_relation(relation) -%}\n  {{ return(adapter.dispatch('truncate_relation', 'dbt')(relation)) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt_snowflake.snowflake__truncate_relation"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.0085871
+    },
+    "macro.dbt.default__truncate_relation": {
+      "unique_id": "macro.dbt.default__truncate_relation",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/relation.sql",
+      "original_file_path": "macros/adapters/relation.sql",
+      "name": "default__truncate_relation",
+      "macro_sql": "{% macro default__truncate_relation(relation) -%}\n  {% call statement('truncate_relation') -%}\n    truncate table {{ relation }}\n  {%- endcall %}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.statement"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.008807
+    },
+    "macro.dbt.rename_relation": {
+      "unique_id": "macro.dbt.rename_relation",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/relation.sql",
+      "original_file_path": "macros/adapters/relation.sql",
+      "name": "rename_relation",
+      "macro_sql": "{% macro rename_relation(from_relation, to_relation) -%}\n  {{ return(adapter.dispatch('rename_relation', 'dbt')(from_relation, to_relation)) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt_snowflake.snowflake__rename_relation"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.009095
+    },
+    "macro.dbt.default__rename_relation": {
+      "unique_id": "macro.dbt.default__rename_relation",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/relation.sql",
+      "original_file_path": "macros/adapters/relation.sql",
+      "name": "default__rename_relation",
+      "macro_sql": "{% macro default__rename_relation(from_relation, to_relation) -%}\n  {% set target_name = adapter.quote_as_configured(to_relation.identifier, 'identifier') %}\n  {% call statement('rename_relation') -%}\n    alter table {{ from_relation }} rename to {{ target_name }}\n  {%- endcall %}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.statement"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.009492
+    },
+    "macro.dbt.get_or_create_relation": {
+      "unique_id": "macro.dbt.get_or_create_relation",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/relation.sql",
+      "original_file_path": "macros/adapters/relation.sql",
+      "name": "get_or_create_relation",
+      "macro_sql": "{% macro get_or_create_relation(database, schema, identifier, type) -%}\n  {{ return(adapter.dispatch('get_or_create_relation', 'dbt')(database, schema, identifier, type)) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__get_or_create_relation"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.009848
+    },
+    "macro.dbt.default__get_or_create_relation": {
+      "unique_id": "macro.dbt.default__get_or_create_relation",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/relation.sql",
+      "original_file_path": "macros/adapters/relation.sql",
+      "name": "default__get_or_create_relation",
+      "macro_sql": "{% macro default__get_or_create_relation(database, schema, identifier, type) %}\n  {%- set target_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) %}\n\n  {% if target_relation %}\n    {% do return([true, target_relation]) %}\n  {% endif %}\n\n  {%- set new_relation = api.Relation.create(\n      database=database,\n      schema=schema,\n      identifier=identifier,\n      type=type\n  ) -%}\n  {% do return([false, new_relation]) %}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.010729
+    },
+    "macro.dbt.load_relation": {
+      "unique_id": "macro.dbt.load_relation",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/relation.sql",
+      "original_file_path": "macros/adapters/relation.sql",
+      "name": "load_relation",
+      "macro_sql": "{% macro load_relation(relation) %}\n  {% do return(adapter.get_relation(\n    database=relation.database,\n    schema=relation.schema,\n    identifier=relation.identifier\n  )) -%}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.011054
+    },
+    "macro.dbt.drop_relation_if_exists": {
+      "unique_id": "macro.dbt.drop_relation_if_exists",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/relation.sql",
+      "original_file_path": "macros/adapters/relation.sql",
+      "name": "drop_relation_if_exists",
+      "macro_sql": "{% macro drop_relation_if_exists(relation) %}\n  {% if relation is not none %}\n    {{ adapter.drop_relation(relation) }}\n  {% endif %}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.01132
+    },
+    "macro.dbt.current_timestamp": {
+      "unique_id": "macro.dbt.current_timestamp",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/freshness.sql",
+      "original_file_path": "macros/adapters/freshness.sql",
+      "name": "current_timestamp",
+      "macro_sql": "{% macro current_timestamp() -%}\n  {{ adapter.dispatch('current_timestamp', 'dbt')() }}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt_snowflake.snowflake__current_timestamp"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.012032
+    },
+    "macro.dbt.default__current_timestamp": {
+      "unique_id": "macro.dbt.default__current_timestamp",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/freshness.sql",
+      "original_file_path": "macros/adapters/freshness.sql",
+      "name": "default__current_timestamp",
+      "macro_sql": "{% macro default__current_timestamp() -%}\n  {{ exceptions.raise_not_implemented(\n    'current_timestamp macro not implemented for adapter '+adapter.type()) }}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.012238
+    },
+    "macro.dbt.collect_freshness": {
+      "unique_id": "macro.dbt.collect_freshness",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/freshness.sql",
+      "original_file_path": "macros/adapters/freshness.sql",
+      "name": "collect_freshness",
+      "macro_sql": "{% macro collect_freshness(source, loaded_at_field, filter) %}\n  {{ return(adapter.dispatch('collect_freshness', 'dbt')(source, loaded_at_field, filter))}}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__collect_freshness"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.012557
+    },
+    "macro.dbt.default__collect_freshness": {
+      "unique_id": "macro.dbt.default__collect_freshness",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/freshness.sql",
+      "original_file_path": "macros/adapters/freshness.sql",
+      "name": "default__collect_freshness",
+      "macro_sql": "{% macro default__collect_freshness(source, loaded_at_field, filter) %}\n  {% call statement('collect_freshness', fetch_result=True, auto_begin=False) -%}\n    select\n      max({{ loaded_at_field }}) as max_loaded_at,\n      {{ current_timestamp() }} as snapshotted_at\n    from {{ source }}\n    {% if filter %}\n    where {{ filter }}\n    {% endif %}\n  {% endcall %}\n  {{ return(load_result('collect_freshness').table) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.statement",
+          "macro.dbt.current_timestamp"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.013149
+    },
+    "macro.dbt.alter_column_comment": {
+      "unique_id": "macro.dbt.alter_column_comment",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/persist_docs.sql",
+      "original_file_path": "macros/adapters/persist_docs.sql",
+      "name": "alter_column_comment",
+      "macro_sql": "{% macro alter_column_comment(relation, column_dict) -%}\n  {{ return(adapter.dispatch('alter_column_comment', 'dbt')(relation, column_dict)) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt_snowflake.snowflake__alter_column_comment"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.014147
+    },
+    "macro.dbt.default__alter_column_comment": {
+      "unique_id": "macro.dbt.default__alter_column_comment",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/persist_docs.sql",
+      "original_file_path": "macros/adapters/persist_docs.sql",
+      "name": "default__alter_column_comment",
+      "macro_sql": "{% macro default__alter_column_comment(relation, column_dict) -%}\n  {{ exceptions.raise_not_implemented(\n    'alter_column_comment macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.014378
+    },
+    "macro.dbt.alter_relation_comment": {
+      "unique_id": "macro.dbt.alter_relation_comment",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/persist_docs.sql",
+      "original_file_path": "macros/adapters/persist_docs.sql",
+      "name": "alter_relation_comment",
+      "macro_sql": "{% macro alter_relation_comment(relation, relation_comment) -%}\n  {{ return(adapter.dispatch('alter_relation_comment', 'dbt')(relation, relation_comment)) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt_snowflake.snowflake__alter_relation_comment"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.0146601
+    },
+    "macro.dbt.default__alter_relation_comment": {
+      "unique_id": "macro.dbt.default__alter_relation_comment",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/persist_docs.sql",
+      "original_file_path": "macros/adapters/persist_docs.sql",
+      "name": "default__alter_relation_comment",
+      "macro_sql": "{% macro default__alter_relation_comment(relation, relation_comment) -%}\n  {{ exceptions.raise_not_implemented(\n    'alter_relation_comment macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.014889
+    },
+    "macro.dbt.persist_docs": {
+      "unique_id": "macro.dbt.persist_docs",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/persist_docs.sql",
+      "original_file_path": "macros/adapters/persist_docs.sql",
+      "name": "persist_docs",
+      "macro_sql": "{% macro persist_docs(relation, model, for_relation=true, for_columns=true) -%}\n  {{ return(adapter.dispatch('persist_docs', 'dbt')(relation, model, for_relation, for_columns)) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__persist_docs"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.015266
+    },
+    "macro.dbt.default__persist_docs": {
+      "unique_id": "macro.dbt.default__persist_docs",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/persist_docs.sql",
+      "original_file_path": "macros/adapters/persist_docs.sql",
+      "name": "default__persist_docs",
+      "macro_sql": "{% macro default__persist_docs(relation, model, for_relation, for_columns) -%}\n  {% if for_relation and config.persist_relation_docs() and model.description %}\n    {% do run_query(alter_relation_comment(relation, model.description)) %}\n  {% endif %}\n\n  {% if for_columns and config.persist_column_docs() and model.columns %}\n    {% do run_query(alter_column_comment(relation, model.columns)) %}\n  {% endif %}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.run_query",
+          "macro.dbt.alter_relation_comment",
+          "macro.dbt.alter_column_comment"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.015956
+    },
+    "macro.dbt.get_catalog": {
+      "unique_id": "macro.dbt.get_catalog",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/metadata.sql",
+      "original_file_path": "macros/adapters/metadata.sql",
+      "name": "get_catalog",
+      "macro_sql": "{% macro get_catalog(information_schema, schemas) -%}\n  {{ return(adapter.dispatch('get_catalog', 'dbt')(information_schema, schemas)) }}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt_snowflake.snowflake__get_catalog"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.0180612
+    },
+    "macro.dbt.default__get_catalog": {
+      "unique_id": "macro.dbt.default__get_catalog",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/metadata.sql",
+      "original_file_path": "macros/adapters/metadata.sql",
+      "name": "default__get_catalog",
+      "macro_sql": "{% macro default__get_catalog(information_schema, schemas) -%}\n\n  {% set typename = adapter.type() %}\n  {% set msg -%}\n    get_catalog not implemented for {{ typename }}\n  {%- endset %}\n\n  {{ exceptions.raise_compiler_error(msg) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.0184178
+    },
+    "macro.dbt.information_schema_name": {
+      "unique_id": "macro.dbt.information_schema_name",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/metadata.sql",
+      "original_file_path": "macros/adapters/metadata.sql",
+      "name": "information_schema_name",
+      "macro_sql": "{% macro information_schema_name(database) %}\n  {{ return(adapter.dispatch('information_schema_name', 'dbt')(database)) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__information_schema_name"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.0186722
+    },
+    "macro.dbt.default__information_schema_name": {
+      "unique_id": "macro.dbt.default__information_schema_name",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/metadata.sql",
+      "original_file_path": "macros/adapters/metadata.sql",
+      "name": "default__information_schema_name",
+      "macro_sql": "{% macro default__information_schema_name(database) -%}\n  {%- if database -%}\n    {{ database }}.INFORMATION_SCHEMA\n  {%- else -%}\n    INFORMATION_SCHEMA\n  {%- endif -%}\n{%- endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.018882
+    },
+    "macro.dbt.list_schemas": {
+      "unique_id": "macro.dbt.list_schemas",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/metadata.sql",
+      "original_file_path": "macros/adapters/metadata.sql",
+      "name": "list_schemas",
+      "macro_sql": "{% macro list_schemas(database) -%}\n  {{ return(adapter.dispatch('list_schemas', 'dbt')(database)) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt_snowflake.snowflake__list_schemas"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.019139
+    },
+    "macro.dbt.default__list_schemas": {
+      "unique_id": "macro.dbt.default__list_schemas",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/metadata.sql",
+      "original_file_path": "macros/adapters/metadata.sql",
+      "name": "default__list_schemas",
+      "macro_sql": "{% macro default__list_schemas(database) -%}\n  {% set sql %}\n    select distinct schema_name\n    from {{ information_schema_name(database) }}.SCHEMATA\n    where catalog_name ilike '{{ database }}'\n  {% endset %}\n  {{ return(run_query(sql)) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.information_schema_name",
+          "macro.dbt.run_query"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.01948
+    },
+    "macro.dbt.check_schema_exists": {
+      "unique_id": "macro.dbt.check_schema_exists",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/metadata.sql",
+      "original_file_path": "macros/adapters/metadata.sql",
+      "name": "check_schema_exists",
+      "macro_sql": "{% macro check_schema_exists(information_schema, schema) -%}\n  {{ return(adapter.dispatch('check_schema_exists', 'dbt')(information_schema, schema)) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt_snowflake.snowflake__check_schema_exists"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.019774
+    },
+    "macro.dbt.default__check_schema_exists": {
+      "unique_id": "macro.dbt.default__check_schema_exists",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/metadata.sql",
+      "original_file_path": "macros/adapters/metadata.sql",
+      "name": "default__check_schema_exists",
+      "macro_sql": "{% macro default__check_schema_exists(information_schema, schema) -%}\n  {% set sql -%}\n        select count(*)\n        from {{ information_schema.replace(information_schema_view='SCHEMATA') }}\n        where catalog_name='{{ information_schema.database }}'\n          and schema_name='{{ schema }}'\n  {%- endset %}\n  {{ return(run_query(sql)) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.run_query"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.0202801
+    },
+    "macro.dbt.list_relations_without_caching": {
+      "unique_id": "macro.dbt.list_relations_without_caching",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/metadata.sql",
+      "original_file_path": "macros/adapters/metadata.sql",
+      "name": "list_relations_without_caching",
+      "macro_sql": "{% macro list_relations_without_caching(schema_relation) %}\n  {{ return(adapter.dispatch('list_relations_without_caching', 'dbt')(schema_relation)) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt_snowflake.snowflake__list_relations_without_caching"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.020534
+    },
+    "macro.dbt.default__list_relations_without_caching": {
+      "unique_id": "macro.dbt.default__list_relations_without_caching",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/metadata.sql",
+      "original_file_path": "macros/adapters/metadata.sql",
+      "name": "default__list_relations_without_caching",
+      "macro_sql": "{% macro default__list_relations_without_caching(schema_relation) %}\n  {{ exceptions.raise_not_implemented(\n    'list_relations_without_caching macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.020757
+    },
+    "macro.dbt.get_columns_in_relation": {
+      "unique_id": "macro.dbt.get_columns_in_relation",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/columns.sql",
+      "original_file_path": "macros/adapters/columns.sql",
+      "name": "get_columns_in_relation",
+      "macro_sql": "{% macro get_columns_in_relation(relation) -%}\n  {{ return(adapter.dispatch('get_columns_in_relation', 'dbt')(relation)) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt_snowflake.snowflake__get_columns_in_relation"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.023215
+    },
+    "macro.dbt.default__get_columns_in_relation": {
+      "unique_id": "macro.dbt.default__get_columns_in_relation",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/columns.sql",
+      "original_file_path": "macros/adapters/columns.sql",
+      "name": "default__get_columns_in_relation",
+      "macro_sql": "{% macro default__get_columns_in_relation(relation) -%}\n  {{ exceptions.raise_not_implemented(\n    'get_columns_in_relation macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.0234308
+    },
+    "macro.dbt.sql_convert_columns_in_relation": {
+      "unique_id": "macro.dbt.sql_convert_columns_in_relation",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/columns.sql",
+      "original_file_path": "macros/adapters/columns.sql",
+      "name": "sql_convert_columns_in_relation",
+      "macro_sql": "{% macro sql_convert_columns_in_relation(table) -%}\n  {% set columns = [] %}\n  {% for row in table %}\n    {% do columns.append(api.Column(*row)) %}\n  {% endfor %}\n  {{ return(columns) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.0238621
+    },
+    "macro.dbt.get_columns_in_query": {
+      "unique_id": "macro.dbt.get_columns_in_query",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/columns.sql",
+      "original_file_path": "macros/adapters/columns.sql",
+      "name": "get_columns_in_query",
+      "macro_sql": "{% macro get_columns_in_query(select_sql) -%}\n  {{ return(adapter.dispatch('get_columns_in_query', 'dbt')(select_sql)) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__get_columns_in_query"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.024116
+    },
+    "macro.dbt.default__get_columns_in_query": {
+      "unique_id": "macro.dbt.default__get_columns_in_query",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/columns.sql",
+      "original_file_path": "macros/adapters/columns.sql",
+      "name": "default__get_columns_in_query",
+      "macro_sql": "{% macro default__get_columns_in_query(select_sql) %}\n    {% call statement('get_columns_in_query', fetch_result=True, auto_begin=False) -%}\n        select * from (\n            {{ select_sql }}\n        ) as __dbt_sbq\n        where false\n        limit 0\n    {% endcall %}\n\n    {{ return(load_result('get_columns_in_query').table.columns | map(attribute='name') | list) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.statement"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.024596
+    },
+    "macro.dbt.alter_column_type": {
+      "unique_id": "macro.dbt.alter_column_type",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/columns.sql",
+      "original_file_path": "macros/adapters/columns.sql",
+      "name": "alter_column_type",
+      "macro_sql": "{% macro alter_column_type(relation, column_name, new_column_type) -%}\n  {{ return(adapter.dispatch('alter_column_type', 'dbt')(relation, column_name, new_column_type)) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt_snowflake.snowflake__alter_column_type"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.024917
+    },
+    "macro.dbt.default__alter_column_type": {
+      "unique_id": "macro.dbt.default__alter_column_type",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/columns.sql",
+      "original_file_path": "macros/adapters/columns.sql",
+      "name": "default__alter_column_type",
+      "macro_sql": "{% macro default__alter_column_type(relation, column_name, new_column_type) -%}\n  {#\n    1. Create a new column (w/ temp name and correct type)\n    2. Copy data over to it\n    3. Drop the existing column (cascade!)\n    4. Rename the new column to existing column\n  #}\n  {%- set tmp_column = column_name + \"__dbt_alter\" -%}\n\n  {% call statement('alter_column_type') %}\n    alter table {{ relation }} add column {{ adapter.quote(tmp_column) }} {{ new_column_type }};\n    update {{ relation }} set {{ adapter.quote(tmp_column) }} = {{ adapter.quote(column_name) }};\n    alter table {{ relation }} drop column {{ adapter.quote(column_name) }} cascade;\n    alter table {{ relation }} rename column {{ adapter.quote(tmp_column) }} to {{ adapter.quote(column_name) }}\n  {% endcall %}\n\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.statement"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.025766
+    },
+    "macro.dbt.alter_relation_add_remove_columns": {
+      "unique_id": "macro.dbt.alter_relation_add_remove_columns",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/columns.sql",
+      "original_file_path": "macros/adapters/columns.sql",
+      "name": "alter_relation_add_remove_columns",
+      "macro_sql": "{% macro alter_relation_add_remove_columns(relation, add_columns = none, remove_columns = none) -%}\n  {{ return(adapter.dispatch('alter_relation_add_remove_columns', 'dbt')(relation, add_columns, remove_columns)) }}\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt_snowflake.snowflake__alter_relation_add_remove_columns"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.026131
+    },
+    "macro.dbt.default__alter_relation_add_remove_columns": {
+      "unique_id": "macro.dbt.default__alter_relation_add_remove_columns",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "macros/adapters/columns.sql",
+      "original_file_path": "macros/adapters/columns.sql",
+      "name": "default__alter_relation_add_remove_columns",
+      "macro_sql": "{% macro default__alter_relation_add_remove_columns(relation, add_columns, remove_columns) %}\n  \n  {% if add_columns is none %}\n    {% set add_columns = [] %}\n  {% endif %}\n  {% if remove_columns is none %}\n    {% set remove_columns = [] %}\n  {% endif %}\n  \n  {% set sql -%}\n     \n     alter {{ relation.type }} {{ relation }}\n       \n            {% for column in add_columns %}\n               add column {{ column.name }} {{ column.data_type }}{{ ',' if not loop.last }}\n            {% endfor %}{{ ',' if add_columns and remove_columns }}\n            \n            {% for column in remove_columns %}\n                drop column {{ column.name }}{{ ',' if not loop.last }}\n            {% endfor %}\n  \n  {%- endset -%}\n\n  {% do run_query(sql) %}\n\n{% endmacro %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.run_query"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.027232
+    },
+    "macro.dbt.test_unique": {
+      "unique_id": "macro.dbt.test_unique",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "tests/generic/builtin.sql",
+      "original_file_path": "tests/generic/builtin.sql",
+      "name": "test_unique",
+      "macro_sql": "{% test unique(model, column_name) %}\n    {% set macro = adapter.dispatch('test_unique', 'dbt') %}\n    {{ macro(model, column_name) }}\n{% endtest %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__test_unique"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.028012
+    },
+    "macro.dbt.test_not_null": {
+      "unique_id": "macro.dbt.test_not_null",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "tests/generic/builtin.sql",
+      "original_file_path": "tests/generic/builtin.sql",
+      "name": "test_not_null",
+      "macro_sql": "{% test not_null(model, column_name) %}\n    {% set macro = adapter.dispatch('test_not_null', 'dbt') %}\n    {{ macro(model, column_name) }}\n{% endtest %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__test_not_null"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.02833
+    },
+    "macro.dbt.test_accepted_values": {
+      "unique_id": "macro.dbt.test_accepted_values",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "tests/generic/builtin.sql",
+      "original_file_path": "tests/generic/builtin.sql",
+      "name": "test_accepted_values",
+      "macro_sql": "{% test accepted_values(model, column_name, values, quote=True) %}\n    {% set macro = adapter.dispatch('test_accepted_values', 'dbt') %}\n    {{ macro(model, column_name, values, quote) }}\n{% endtest %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__test_accepted_values"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.028734
+    },
+    "macro.dbt.test_relationships": {
+      "unique_id": "macro.dbt.test_relationships",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "tests/generic/builtin.sql",
+      "original_file_path": "tests/generic/builtin.sql",
+      "name": "test_relationships",
+      "macro_sql": "{% test relationships(model, column_name, to, field) %}\n    {% set macro = adapter.dispatch('test_relationships', 'dbt') %}\n    {{ macro(model, column_name, to, field) }}\n{% endtest %}",
+      "resource_type": "macro",
+      "tags": [],
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__test_relationships"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1643871657.029119
+    }
+  },
+  "docs": {
+    "dbt.__overview__": {
+      "unique_id": "dbt.__overview__",
+      "package_name": "dbt",
+      "root_path": "/usr/local/Cellar/dbt-snowflake/1.0.0_1/libexec/lib/python3.9/site-packages/dbt/include/global_project",
+      "path": "overview.md",
+      "original_file_path": "docs/overview.md",
+      "name": "__overview__",
+      "block_contents": "### Welcome!\n\nWelcome to the auto-generated documentation for your dbt project!\n\n### Navigation\n\nYou can use the `Project` and `Database` navigation tabs on the left side of the window to explore the models\nin your project.\n\n#### Project Tab\nThe `Project` tab mirrors the directory structure of your dbt project. In this tab, you can see all of the\nmodels defined in your dbt project, as well as models imported from dbt packages.\n\n#### Database Tab\nThe `Database` tab also exposes your models, but in a format that looks more like a database explorer. This view\nshows relations (tables and views) grouped into database schemas. Note that ephemeral models are _not_ shown\nin this interface, as they do not exist in the database.\n\n### Graph Exploration\nYou can click the blue icon on the bottom-right corner of the page to view the lineage graph of your models.\n\nOn model pages, you'll see the immediate parents and children of the model you're exploring. By clicking the `Expand`\nbutton at the top-right of this lineage pane, you'll be able to see all of the models that are used to build,\nor are built from, the model you're exploring.\n\nOnce expanded, you'll be able to use the `--select` and `--exclude` model selection syntax to filter the\nmodels in the graph. For more information on model selection, check out the [dbt docs](https://docs.getdbt.com/docs/model-selection-syntax).\n\nNote that you can also right-click on models to interactively filter and explore the graph.\n\n---\n\n### More information\n\n- [What is dbt](https://docs.getdbt.com/docs/introduction)?\n- Read the [dbt viewpoint](https://docs.getdbt.com/docs/viewpoint)\n- [Installation](https://docs.getdbt.com/docs/installation)\n- Join the [dbt Community](https://www.getdbt.com/community/) for questions and discussion"
+    }
+  },
+  "exposures": {},
+  "metrics": {},
+  "selectors": {},
+  "disabled": {},
+  "parent_map": {
+    "model.trial.my_first_dbt_model": [],
+    "model.trial.trial_model_1": [
+      "source.trial.DBT_DEV.NETFLIX"
+    ],
+    "model.trial.trial_model_2": [
+      "source.trial.DBT_DEV.SALES_RECORDS"
+    ],
+    "model.trial.my_second_dbt_model": [
+      "model.trial.my_first_dbt_model"
+    ],
+    "test.trial.unique_my_first_dbt_model_id.16e066b321": [
+      "model.trial.my_first_dbt_model"
+    ],
+    "test.trial.not_null_my_first_dbt_model_id.5fb22c2710": [
+      "model.trial.my_first_dbt_model"
+    ],
+    "test.trial.unique_my_second_dbt_model_id.57a0f8c493": [
+      "model.trial.my_second_dbt_model"
+    ],
+    "test.trial.not_null_my_second_dbt_model_id.151b76d778": [
+      "model.trial.my_second_dbt_model"
+    ],
+    "test.trial.unique_trial_model_1_show_id.6e142709e3": [
+      "model.trial.trial_model_1"
+    ],
+    "test.trial.not_null_trial_model_1_show_id.210878cb19": [
+      "model.trial.trial_model_1"
+    ],
+    "test.trial.not_null_trial_model_1_type.051dc613aa": [
+      "model.trial.trial_model_1"
+    ],
+    "test.trial.not_null_trial_model_1_title.b49e531d6d": [
+      "model.trial.trial_model_1"
+    ],
+    "test.trial.not_null_trial_model_2_country.8170348e7c": [
+      "model.trial.trial_model_2"
+    ],
+    "test.trial.not_null_trial_model_2_item_type.1e87bba840": [
+      "model.trial.trial_model_2"
+    ],
+    "test.trial.not_null_trial_model_2_year.eb13ae8f8b": [
+      "model.trial.trial_model_2"
+    ],
+    "test.trial.not_null_trial_model_2_revenue.c697e41758": [
+      "model.trial.trial_model_2"
+    ],
+    "test.trial.not_null_trial_model_2_profit.faa538228c": [
+      "model.trial.trial_model_2"
+    ],
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_COUNTRY.17f064dcca": [
+      "source.trial.DBT_DEV.SALES_RECORDS"
+    ],
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_REGION.c46072ea28": [
+      "source.trial.DBT_DEV.SALES_RECORDS"
+    ],
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_ITEM_TYPE.c5a7998d7d": [
+      "source.trial.DBT_DEV.SALES_RECORDS"
+    ],
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_SALES_CHANNEL.520c545ccf": [
+      "source.trial.DBT_DEV.SALES_RECORDS"
+    ],
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_ORDER_PRIORITY.43cf4e7e91": [
+      "source.trial.DBT_DEV.SALES_RECORDS"
+    ],
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_ORDER_DATE.2010925f09": [
+      "source.trial.DBT_DEV.SALES_RECORDS"
+    ],
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_ORDER_ID.32e037a302": [
+      "source.trial.DBT_DEV.SALES_RECORDS"
+    ],
+    "test.trial.source_unique_DBT_DEV_SALES_RECORDS_ORDER_ID.ab6b427de3": [
+      "source.trial.DBT_DEV.SALES_RECORDS"
+    ],
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_SHIP_DATE.e673d5b4ac": [
+      "source.trial.DBT_DEV.SALES_RECORDS"
+    ],
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_UNITS_SOLD.77de2d383d": [
+      "source.trial.DBT_DEV.SALES_RECORDS"
+    ],
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_UNIT_PRICE.05e957ffb2": [
+      "source.trial.DBT_DEV.SALES_RECORDS"
+    ],
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_UNIT_COST.b8df1b66e1": [
+      "source.trial.DBT_DEV.SALES_RECORDS"
+    ],
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_TOTAL_REVENUE.8e69c2eab1": [
+      "source.trial.DBT_DEV.SALES_RECORDS"
+    ],
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_TOTAL_COST.3bb1c46f03": [
+      "source.trial.DBT_DEV.SALES_RECORDS"
+    ],
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_TOTAL_PROFIT.5ed94e9968": [
+      "source.trial.DBT_DEV.SALES_RECORDS"
+    ],
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_SHOW_ID.7e52ca1dfe": [
+      "source.trial.DBT_DEV.NETFLIX"
+    ],
+    "test.trial.source_unique_DBT_DEV_NETFLIX_SHOW_ID.7bfa71959b": [
+      "source.trial.DBT_DEV.NETFLIX"
+    ],
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_TYPE.0f2dec921a": [
+      "source.trial.DBT_DEV.NETFLIX"
+    ],
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_TITLE.79ce9afc04": [
+      "source.trial.DBT_DEV.NETFLIX"
+    ],
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_DIRECTOR.864f8a60ed": [
+      "source.trial.DBT_DEV.NETFLIX"
+    ],
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_CAST.349d8bdc95": [
+      "source.trial.DBT_DEV.NETFLIX"
+    ],
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_COUNTRY.157f099785": [
+      "source.trial.DBT_DEV.NETFLIX"
+    ],
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_DATE_ADDED.e0e5bb0d1e": [
+      "source.trial.DBT_DEV.NETFLIX"
+    ],
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_RELEASE_YEAR.c4edf1469a": [
+      "source.trial.DBT_DEV.NETFLIX"
+    ],
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_RATING.c4cde59a63": [
+      "source.trial.DBT_DEV.NETFLIX"
+    ],
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_DURATION.6083a101be": [
+      "source.trial.DBT_DEV.NETFLIX"
+    ],
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_LISTED_IN.6ba1de80d3": [
+      "source.trial.DBT_DEV.NETFLIX"
+    ],
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_DESCRIPTION.05a82efe6f": [
+      "source.trial.DBT_DEV.NETFLIX"
+    ],
+    "source.trial.DBT_DEV.SALES_RECORDS": [],
+    "source.trial.DBT_DEV.NETFLIX": []
+  },
+  "child_map": {
+    "model.trial.my_first_dbt_model": [
+      "model.trial.my_second_dbt_model",
+      "test.trial.not_null_my_first_dbt_model_id.5fb22c2710",
+      "test.trial.unique_my_first_dbt_model_id.16e066b321"
+    ],
+    "model.trial.trial_model_1": [
+      "test.trial.not_null_trial_model_1_show_id.210878cb19",
+      "test.trial.not_null_trial_model_1_title.b49e531d6d",
+      "test.trial.not_null_trial_model_1_type.051dc613aa",
+      "test.trial.unique_trial_model_1_show_id.6e142709e3"
+    ],
+    "model.trial.trial_model_2": [
+      "test.trial.not_null_trial_model_2_country.8170348e7c",
+      "test.trial.not_null_trial_model_2_item_type.1e87bba840",
+      "test.trial.not_null_trial_model_2_profit.faa538228c",
+      "test.trial.not_null_trial_model_2_revenue.c697e41758",
+      "test.trial.not_null_trial_model_2_year.eb13ae8f8b"
+    ],
+    "model.trial.my_second_dbt_model": [
+      "test.trial.not_null_my_second_dbt_model_id.151b76d778",
+      "test.trial.unique_my_second_dbt_model_id.57a0f8c493"
+    ],
+    "test.trial.unique_my_first_dbt_model_id.16e066b321": [],
+    "test.trial.not_null_my_first_dbt_model_id.5fb22c2710": [],
+    "test.trial.unique_my_second_dbt_model_id.57a0f8c493": [],
+    "test.trial.not_null_my_second_dbt_model_id.151b76d778": [],
+    "test.trial.unique_trial_model_1_show_id.6e142709e3": [],
+    "test.trial.not_null_trial_model_1_show_id.210878cb19": [],
+    "test.trial.not_null_trial_model_1_type.051dc613aa": [],
+    "test.trial.not_null_trial_model_1_title.b49e531d6d": [],
+    "test.trial.not_null_trial_model_2_country.8170348e7c": [],
+    "test.trial.not_null_trial_model_2_item_type.1e87bba840": [],
+    "test.trial.not_null_trial_model_2_year.eb13ae8f8b": [],
+    "test.trial.not_null_trial_model_2_revenue.c697e41758": [],
+    "test.trial.not_null_trial_model_2_profit.faa538228c": [],
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_COUNTRY.17f064dcca": [],
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_REGION.c46072ea28": [],
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_ITEM_TYPE.c5a7998d7d": [],
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_SALES_CHANNEL.520c545ccf": [],
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_ORDER_PRIORITY.43cf4e7e91": [],
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_ORDER_DATE.2010925f09": [],
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_ORDER_ID.32e037a302": [],
+    "test.trial.source_unique_DBT_DEV_SALES_RECORDS_ORDER_ID.ab6b427de3": [],
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_SHIP_DATE.e673d5b4ac": [],
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_UNITS_SOLD.77de2d383d": [],
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_UNIT_PRICE.05e957ffb2": [],
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_UNIT_COST.b8df1b66e1": [],
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_TOTAL_REVENUE.8e69c2eab1": [],
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_TOTAL_COST.3bb1c46f03": [],
+    "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_TOTAL_PROFIT.5ed94e9968": [],
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_SHOW_ID.7e52ca1dfe": [],
+    "test.trial.source_unique_DBT_DEV_NETFLIX_SHOW_ID.7bfa71959b": [],
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_TYPE.0f2dec921a": [],
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_TITLE.79ce9afc04": [],
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_DIRECTOR.864f8a60ed": [],
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_CAST.349d8bdc95": [],
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_COUNTRY.157f099785": [],
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_DATE_ADDED.e0e5bb0d1e": [],
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_RELEASE_YEAR.c4edf1469a": [],
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_RATING.c4cde59a63": [],
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_DURATION.6083a101be": [],
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_LISTED_IN.6ba1de80d3": [],
+    "test.trial.source_not_null_DBT_DEV_NETFLIX_DESCRIPTION.05a82efe6f": [],
+    "source.trial.DBT_DEV.SALES_RECORDS": [
+      "model.trial.trial_model_2",
+      "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_COUNTRY.17f064dcca",
+      "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_ITEM_TYPE.c5a7998d7d",
+      "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_ORDER_DATE.2010925f09",
+      "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_ORDER_ID.32e037a302",
+      "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_ORDER_PRIORITY.43cf4e7e91",
+      "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_REGION.c46072ea28",
+      "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_SALES_CHANNEL.520c545ccf",
+      "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_SHIP_DATE.e673d5b4ac",
+      "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_TOTAL_COST.3bb1c46f03",
+      "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_TOTAL_PROFIT.5ed94e9968",
+      "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_TOTAL_REVENUE.8e69c2eab1",
+      "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_UNITS_SOLD.77de2d383d",
+      "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_UNIT_COST.b8df1b66e1",
+      "test.trial.source_not_null_DBT_DEV_SALES_RECORDS_UNIT_PRICE.05e957ffb2",
+      "test.trial.source_unique_DBT_DEV_SALES_RECORDS_ORDER_ID.ab6b427de3"
+    ],
+    "source.trial.DBT_DEV.NETFLIX": [
+      "model.trial.trial_model_1",
+      "test.trial.source_not_null_DBT_DEV_NETFLIX_CAST.349d8bdc95",
+      "test.trial.source_not_null_DBT_DEV_NETFLIX_COUNTRY.157f099785",
+      "test.trial.source_not_null_DBT_DEV_NETFLIX_DATE_ADDED.e0e5bb0d1e",
+      "test.trial.source_not_null_DBT_DEV_NETFLIX_DESCRIPTION.05a82efe6f",
+      "test.trial.source_not_null_DBT_DEV_NETFLIX_DIRECTOR.864f8a60ed",
+      "test.trial.source_not_null_DBT_DEV_NETFLIX_DURATION.6083a101be",
+      "test.trial.source_not_null_DBT_DEV_NETFLIX_LISTED_IN.6ba1de80d3",
+      "test.trial.source_not_null_DBT_DEV_NETFLIX_RATING.c4cde59a63",
+      "test.trial.source_not_null_DBT_DEV_NETFLIX_RELEASE_YEAR.c4edf1469a",
+      "test.trial.source_not_null_DBT_DEV_NETFLIX_SHOW_ID.7e52ca1dfe",
+      "test.trial.source_not_null_DBT_DEV_NETFLIX_TITLE.79ce9afc04",
+      "test.trial.source_not_null_DBT_DEV_NETFLIX_TYPE.0f2dec921a",
+      "test.trial.source_unique_DBT_DEV_NETFLIX_SHOW_ID.7bfa71959b"
+    ]
+  }
+}

--- a/tests/dbt/data/trial_v4/results.json
+++ b/tests/dbt/data/trial_v4/results.json
@@ -1,0 +1,492 @@
+[
+  {
+    "dataset": {
+      "documentation": {
+        "datasetDocumentations": [],
+        "fieldDocumentations": [
+          {
+            "documentation": "SHOW_ID. SALES_RECORDS",
+            "fieldPath": "show_id"
+          },
+          {
+            "documentation": "TYPE. SALES_RECORDS",
+            "fieldPath": "type"
+          },
+          {
+            "documentation": "TITLE. SALES_RECORDS",
+            "fieldPath": "title"
+          },
+          {
+            "documentation": "DIRECTOR. SALES_RECORDS",
+            "fieldPath": "director"
+          },
+          {
+            "documentation": "CAST. SALES_RECORDS",
+            "fieldPath": "cast"
+          },
+          {
+            "documentation": "COUNTRY. SALES_RECORDS",
+            "fieldPath": "country"
+          },
+          {
+            "documentation": "DATE_ADDED. SALES_RECORDS",
+            "fieldPath": "date_added"
+          },
+          {
+            "documentation": "RELEASE_YEAR. SALES_RECORDS",
+            "fieldPath": "release_year"
+          },
+          {
+            "documentation": "RATING. SALES_RECORDS",
+            "fieldPath": "rating"
+          },
+          {
+            "documentation": "DURATION. SALES_RECORDS",
+            "fieldPath": "duration"
+          },
+          {
+            "documentation": "LISTED_IN. SALES_RECORDS",
+            "fieldPath": "listed_in"
+          },
+          {
+            "documentation": "DESCRIPTION. SALES_RECORDS",
+            "fieldPath": "description"
+          }
+        ]
+      },
+      "logicalId": {
+        "account": "metaphor",
+        "name": "dev_db.dbt_dev.netflix",
+        "platform": "SNOWFLAKE"
+      }
+    },
+    "eventHeader": {
+      "time": "2000-01-01T00:00:00+00:00"
+    }
+  },
+  {
+    "dataset": {
+      "documentation": {
+        "datasetDocumentations": [],
+        "fieldDocumentations": [
+          {
+            "documentation": "REGION. SALES_RECORDS",
+            "fieldPath": "region"
+          },
+          {
+            "documentation": "COUNTRY. SALES_RECORDS",
+            "fieldPath": "country"
+          },
+          {
+            "documentation": "ITEM_TYPE. SALES_RECORDS",
+            "fieldPath": "item_type"
+          },
+          {
+            "documentation": "SALES_CHANNEL. SALES_RECORDS",
+            "fieldPath": "sales_channel"
+          },
+          {
+            "documentation": "ORDER_PRIORITY. SALES_RECORDS",
+            "fieldPath": "order_priority"
+          },
+          {
+            "documentation": "ORDER_DATE. SALES_RECORDS",
+            "fieldPath": "order_date"
+          },
+          {
+            "documentation": "ORDER_ID. SALES_RECORDS",
+            "fieldPath": "order_id"
+          },
+          {
+            "documentation": "SHIP_DATE. SALES_RECORDS",
+            "fieldPath": "ship_date"
+          },
+          {
+            "documentation": "UNITS_SOLD. SALES_RECORDS",
+            "fieldPath": "units_sold"
+          },
+          {
+            "documentation": "UNIT_PRICE. SALES_RECORDS",
+            "fieldPath": "unit_price"
+          },
+          {
+            "documentation": "UNIT_COST. SALES_RECORDS",
+            "fieldPath": "unit_cost"
+          },
+          {
+            "documentation": "TOTAL_REVENUE. SALES_RECORDS",
+            "fieldPath": "total_revenue"
+          },
+          {
+            "documentation": "TOTAL_COST. SALES_RECORDS",
+            "fieldPath": "total_cost"
+          },
+          {
+            "documentation": "TOTAL_PROFIT. SALES_RECORDS",
+            "fieldPath": "total_profit"
+          }
+        ]
+      },
+      "logicalId": {
+        "account": "metaphor",
+        "name": "dev_db.dbt_dev.sales_records",
+        "platform": "SNOWFLAKE"
+      }
+    },
+    "eventHeader": {
+      "time": "2000-01-01T00:00:00+00:00"
+    }
+  },
+  {
+    "eventHeader": {
+      "time": "2000-01-01T00:00:00+00:00"
+    },
+    "virtualView": {
+      "dbtModel": {
+        "compiledSql": "/*\n    Welcome to your first dbt model!\n    Did you know that you can also configure models directly within SQL files?\n    This will override configurations stated in dbt_project.yml\n\n    Try changing \"table\" to \"view\" below\n*/\n\nwith source_data as (\n\n    select 1 as id\n    union all\n    select null as id\n\n)\n\nselect *\nfrom source_data\n\n/*\n    Uncomment the line below to remove records with null `id` values\n*/\n\n-- where id is not null",
+        "description": "A starter dbt model, my_first_dbt_model",
+        "docsUrl": "http://localhost:8080/#!/model/model.trial.my_first_dbt_model",
+        "fields": [
+          {
+            "description": "The primary key for this table, auto generated id",
+            "fieldPath": "id",
+            "nativeType": "Not Set"
+          }
+        ],
+        "materialization": {
+          "targetDataset": "DATASET~247B510D516CDED91920F071DFA249D3",
+          "type": "VIEW"
+        },
+        "owners": [
+          "PERSON~8B6974C32BFCBBF6AB3930E1B7A17846"
+        ],
+        "packageName": "trial",
+        "rawSql": "/*\n    Welcome to your first dbt model!\n    Did you know that you can also configure models directly within SQL files?\n    This will override configurations stated in dbt_project.yml\n\n    Try changing \"table\" to \"view\" below\n*/\n\nwith source_data as (\n\n    select 1 as id\n    union all\n    select null as id\n\n)\n\nselect *\nfrom source_data\n\n/*\n    Uncomment the line below to remove records with null `id` values\n*/\n\n-- where id is not null",
+        "tags": [],
+        "tests": [
+          {
+            "columns": [
+              "id"
+            ],
+            "dependsOnMacros": [
+              "macro.dbt.test_unique",
+              "macro.dbt.get_where_subquery"
+            ],
+            "name": "unique_my_first_dbt_model_id",
+            "sql": "\n    \n    \n\nselect\n    id as unique_field,\n    count(*) as n_records\n\nfrom DEV_DB.DBT_YI.my_first_dbt_model\nwhere id is not null\ngroup by id\nhaving count(*) > 1\n\n\n",
+            "uniqueId": "test.trial.unique_my_first_dbt_model_id.16e066b321"
+          },
+          {
+            "columns": [
+              "id"
+            ],
+            "dependsOnMacros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery"
+            ],
+            "name": "not_null_my_first_dbt_model_id",
+            "sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_YI.my_first_dbt_model\nwhere id is null\n\n\n",
+            "uniqueId": "test.trial.not_null_my_first_dbt_model_id.5fb22c2710"
+          }
+        ],
+        "url": "https://github.com/MetaphorData/dbt/tree/main/trial/models/example/my_first_dbt_model.sql"
+      },
+      "logicalId": {
+        "name": "trial.my_first_dbt_model",
+        "type": "DBT_MODEL"
+      }
+    }
+  },
+  {
+    "eventHeader": {
+      "time": "2000-01-01T00:00:00+00:00"
+    },
+    "virtualView": {
+      "dbtModel": {
+        "compiledSql": "-- Use the `ref` function to select from other models\n\nselect *\nfrom DEV_DB.DBT_YI.my_first_dbt_model\nwhere id = 1",
+        "description": "A starter dbt model, my_second_dbt_model",
+        "docsUrl": "http://localhost:8080/#!/model/model.trial.my_second_dbt_model",
+        "fields": [
+          {
+            "description": "The primary key for this table, referencing the primary key in 'my_first_dbt_model'",
+            "fieldPath": "id",
+            "nativeType": "Not Set"
+          }
+        ],
+        "materialization": {
+          "targetDataset": "DATASET~B37021135716845A9E70E7DB38409493",
+          "type": "VIEW"
+        },
+        "owners": [
+          "PERSON~8B6974C32BFCBBF6AB3930E1B7A17846"
+        ],
+        "packageName": "trial",
+        "rawSql": "-- Use the `ref` function to select from other models\n\nselect *\nfrom {{ ref('my_first_dbt_model') }}\nwhere id = 1",
+        "sourceDatasets": [],
+        "sourceModels": [
+          "VIRTUAL_VIEW~6792928812BBC200D2459741CFE02D9D"
+        ],
+        "tags": [],
+        "tests": [
+          {
+            "columns": [
+              "id"
+            ],
+            "dependsOnMacros": [
+              "macro.dbt.test_unique",
+              "macro.dbt.get_where_subquery"
+            ],
+            "name": "unique_my_second_dbt_model_id",
+            "sql": "\n    \n    \n\nselect\n    id as unique_field,\n    count(*) as n_records\n\nfrom DEV_DB.DBT_YI.my_second_dbt_model\nwhere id is not null\ngroup by id\nhaving count(*) > 1\n\n\n",
+            "uniqueId": "test.trial.unique_my_second_dbt_model_id.57a0f8c493"
+          },
+          {
+            "columns": [
+              "id"
+            ],
+            "dependsOnMacros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery"
+            ],
+            "name": "not_null_my_second_dbt_model_id",
+            "sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_YI.my_second_dbt_model\nwhere id is null\n\n\n",
+            "uniqueId": "test.trial.not_null_my_second_dbt_model_id.151b76d778"
+          }
+        ],
+        "url": "https://github.com/MetaphorData/dbt/tree/main/trial/models/example/my_second_dbt_model.sql"
+      },
+      "logicalId": {
+        "name": "trial.my_second_dbt_model",
+        "type": "DBT_MODEL"
+      }
+    }
+  },
+  {
+    "eventHeader": {
+      "time": "2000-01-01T00:00:00+00:00"
+    },
+    "virtualView": {
+      "dbtModel": {
+        "compiledSql": "\n\nselect show_id, type, title, country, release_year \nfrom DEV_DB.DBT_DEV.NETFLIX",
+        "description": "First trial model, mapping columns from NETFLIX source table",
+        "docsUrl": "http://localhost:8080/#!/model/model.trial.trial_model_1",
+        "fields": [
+          {
+            "description": "The show id, primary key for this table",
+            "fieldPath": "show_id",
+            "nativeType": "Not Set"
+          },
+          {
+            "description": "The type of the show, e.g. Movie or TV Show",
+            "fieldPath": "type",
+            "nativeType": "Not Set"
+          },
+          {
+            "description": "The title of the show",
+            "fieldPath": "title",
+            "nativeType": "Not Set"
+          },
+          {
+            "description": "The country where the show was originated from",
+            "fieldPath": "country",
+            "nativeType": "Not Set"
+          },
+          {
+            "description": "The year the show was released",
+            "fieldPath": "release_year",
+            "nativeType": "Not Set"
+          }
+        ],
+        "materialization": {
+          "targetDataset": "DATASET~5722262F1FBB214FFDCC55801C26B4C5",
+          "type": "TABLE"
+        },
+        "owners": [
+          "PERSON~8B6974C32BFCBBF6AB3930E1B7A17846"
+        ],
+        "packageName": "trial",
+        "rawSql": "{{ config(materialized='table') }}\n\nselect show_id, type, title, country, release_year \nfrom {{ source('DBT_DEV', 'NETFLIX') }}",
+        "sourceDatasets": [
+          "DATASET~0A27263039022A2F145CAB8A63CB2D58"
+        ],
+        "sourceModels": [],
+        "tags": [],
+        "tests": [
+          {
+            "columns": [
+              "show_id"
+            ],
+            "dependsOnMacros": [
+              "macro.dbt.test_unique",
+              "macro.dbt.get_where_subquery"
+            ],
+            "name": "unique_trial_model_1_show_id",
+            "sql": "\n    \n    \n\nselect\n    show_id as unique_field,\n    count(*) as n_records\n\nfrom DEV_DB.DBT_YI.trial_model_1\nwhere show_id is not null\ngroup by show_id\nhaving count(*) > 1\n\n\n",
+            "uniqueId": "test.trial.unique_trial_model_1_show_id.6e142709e3"
+          },
+          {
+            "columns": [
+              "show_id"
+            ],
+            "dependsOnMacros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery"
+            ],
+            "name": "not_null_trial_model_1_show_id",
+            "sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_YI.trial_model_1\nwhere show_id is null\n\n\n",
+            "uniqueId": "test.trial.not_null_trial_model_1_show_id.210878cb19"
+          },
+          {
+            "columns": [
+              "type"
+            ],
+            "dependsOnMacros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery"
+            ],
+            "name": "not_null_trial_model_1_type",
+            "sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_YI.trial_model_1\nwhere type is null\n\n\n",
+            "uniqueId": "test.trial.not_null_trial_model_1_type.051dc613aa"
+          },
+          {
+            "columns": [
+              "title"
+            ],
+            "dependsOnMacros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery"
+            ],
+            "name": "not_null_trial_model_1_title",
+            "sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_YI.trial_model_1\nwhere title is null\n\n\n",
+            "uniqueId": "test.trial.not_null_trial_model_1_title.b49e531d6d"
+          }
+        ],
+        "url": "https://github.com/MetaphorData/dbt/tree/main/trial/models/example/trial_model_1.sql"
+      },
+      "logicalId": {
+        "name": "trial.trial_model_1",
+        "type": "DBT_MODEL"
+      }
+    }
+  },
+  {
+    "eventHeader": {
+      "time": "2000-01-01T00:00:00+00:00"
+    },
+    "virtualView": {
+      "dbtModel": {
+        "compiledSql": "\n\nselect country, item_type, \n  year(order_date) as year, \n  sum(total_revenue) as revenue, \n  sum(total_profit) as profit\nfrom DEV_DB.DBT_DEV.SALES_RECORDS\ngroup by country, item_type, year(order_date)\norder by revenue desc",
+        "description": "Second trial model, get statistics from SALES_RECORDS table",
+        "docsUrl": "http://localhost:8080/#!/model/model.trial.trial_model_2",
+        "fields": [
+          {
+            "description": "The country where the sales records are from",
+            "fieldPath": "country",
+            "nativeType": "Not Set"
+          },
+          {
+            "description": "The type of the item, e.g. clothes, household, etc",
+            "fieldPath": "item_type",
+            "nativeType": "Not Set"
+          },
+          {
+            "description": "The year that the aggregated sales statistics is for",
+            "fieldPath": "year",
+            "nativeType": "Not Set"
+          },
+          {
+            "description": "The total revenue aggregated over the country + item_type + year",
+            "fieldPath": "revenue",
+            "nativeType": "Not Set"
+          },
+          {
+            "description": "The total profit aggregated over the country + item_type + year",
+            "fieldPath": "profit",
+            "nativeType": "Not Set"
+          }
+        ],
+        "materialization": {
+          "targetDataset": "DATASET~66B1D302AA901F954BC9BFE19824D86D",
+          "type": "TABLE"
+        },
+        "owners": [
+          "PERSON~8B6974C32BFCBBF6AB3930E1B7A17846"
+        ],
+        "packageName": "trial",
+        "rawSql": "{{ config(materialized='table', alias='sales_summary') }}\n\nselect country, item_type, \n  year(order_date) as year, \n  sum(total_revenue) as revenue, \n  sum(total_profit) as profit\nfrom {{ source('DBT_DEV', 'SALES_RECORDS') }}\ngroup by country, item_type, year(order_date)\norder by revenue desc",
+        "sourceDatasets": [
+          "DATASET~C931554DBA0604DA498A2E772F3D6FEF"
+        ],
+        "sourceModels": [],
+        "tags": [],
+        "tests": [
+          {
+            "columns": [
+              "country"
+            ],
+            "dependsOnMacros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery"
+            ],
+            "name": "not_null_trial_model_2_country",
+            "sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_YI.sales_summary\nwhere country is null\n\n\n",
+            "uniqueId": "test.trial.not_null_trial_model_2_country.8170348e7c"
+          },
+          {
+            "columns": [
+              "item_type"
+            ],
+            "dependsOnMacros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery"
+            ],
+            "name": "not_null_trial_model_2_item_type",
+            "sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_YI.sales_summary\nwhere item_type is null\n\n\n",
+            "uniqueId": "test.trial.not_null_trial_model_2_item_type.1e87bba840"
+          },
+          {
+            "columns": [
+              "year"
+            ],
+            "dependsOnMacros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery"
+            ],
+            "name": "not_null_trial_model_2_year",
+            "sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_YI.sales_summary\nwhere year is null\n\n\n",
+            "uniqueId": "test.trial.not_null_trial_model_2_year.eb13ae8f8b"
+          },
+          {
+            "columns": [
+              "revenue"
+            ],
+            "dependsOnMacros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery"
+            ],
+            "name": "not_null_trial_model_2_revenue",
+            "sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_YI.sales_summary\nwhere revenue is null\n\n\n",
+            "uniqueId": "test.trial.not_null_trial_model_2_revenue.c697e41758"
+          },
+          {
+            "columns": [
+              "profit"
+            ],
+            "dependsOnMacros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery"
+            ],
+            "name": "not_null_trial_model_2_profit",
+            "sql": "\n    \n    \n\nselect *\nfrom DEV_DB.DBT_YI.sales_summary\nwhere profit is null\n\n\n",
+            "uniqueId": "test.trial.not_null_trial_model_2_profit.faa538228c"
+          }
+        ],
+        "url": "https://github.com/MetaphorData/dbt/tree/main/trial/models/example/trial_model_2.sql"
+      },
+      "logicalId": {
+        "name": "trial.trial_model_2",
+        "type": "DBT_MODEL"
+      }
+    }
+  }
+]

--- a/tests/dbt/test_extractor.py
+++ b/tests/dbt/test_extractor.py
@@ -38,6 +38,15 @@ async def test_trial_project_v3(test_root_dir):
 
 
 @pytest.mark.asyncio
+async def test_trial_project_v4(test_root_dir):
+    await _test_project(
+        test_root_dir + "/dbt/data/trial_v4",
+        "http://localhost:8080",
+        "https://github.com/MetaphorData/dbt/tree/main/trial",
+    )
+
+
+@pytest.mark.asyncio
 async def test_ride_share_project(test_root_dir):
     await _test_project(test_root_dir + "/dbt/data/ride_share")
 


### PR DESCRIPTION
### 🤔 Why?

[dbt 1.0](https://docs.getdbt.com/docs/guides/migration-guide/upgrading-to-1-0-0) introduced some breaking changes, the current parser won't work

### 🤓 What?

- forked the manifest parser to v3 and v4, to support incompatible schema
- refactor the catalog parser to a separate file too

### 🧪 Tested?

The existing parser tests all passed. Added the v4 parser tests using json generated with dbt 1.0
