### PR TITLE
Missing BQ lineage for views [sc-6663]

### DIFF
--- a/metaphor/bigquery/extractor.py
+++ b/metaphor/bigquery/extractor.py
@@ -1,12 +1,8 @@
-import json
 import logging
 from typing import Any, List, Mapping, Sequence, Union
 
-from smart_open import open
-
 try:
     import google.cloud.bigquery as bigquery
-    from google.oauth2 import service_account
 except ImportError:
     print("Please install metaphor[bigquery] extra\n")
     raise
@@ -25,24 +21,12 @@ from metaphor.models.metadata_change_event import (
 )
 
 from metaphor.bigquery.config import BigQueryRunConfig
+from metaphor.bigquery.utils import build_client
 from metaphor.common.event_util import EventUtil
 from metaphor.common.extractor import BaseExtractor
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-
-
-def build_client(config: BigQueryRunConfig) -> bigquery.Client:
-    with open(config.key_path) as fin:
-        credentials = service_account.Credentials.from_service_account_info(
-            json.load(fin),
-            scopes=["https://www.googleapis.com/auth/cloud-platform"],
-        )
-
-        return bigquery.Client(
-            credentials=credentials,
-            project=config.project_id if config.project_id else credentials.project_id,
-        )
 
 
 class BigQueryExtractor(BaseExtractor):

--- a/metaphor/bigquery/lineage/README.md
+++ b/metaphor/bigquery/lineage/README.md
@@ -22,7 +22,7 @@ See [Access Control](https://cloud.google.com/logging/docs/access-control#consol
 The config file inherits all the required and optional fields from the general BigQuery connector [Config File](../README.md#config-file). In addition, you can specify the following configurations:
 
 ```yaml
-# (Optional) Whether to enable parsing view query to find upstream of the view, default True
+# # (Optional) Whether to enable parsing view definition to build view lineage, default True
 enable_view_lineage: <boolean>
 
 # (Optional) Whether to enable parsing audit log to find table lineage information, default True
@@ -37,7 +37,7 @@ batch_size: <batch_size>
 
 ## Testing
 
-Follow the [Installation](../../README.md) instructions to install `metaphor-connectors` in your environment (or virtualenv). Make sure to include either `all` or `bigquery` extra.
+Follow the [Installation](../../../README.md) instructions to install `metaphor-connectors` in your environment (or virtualenv). Make sure to include either `all` or `bigquery` extra.
 
 To test the connector locally, change the config file to output to a local path and run the following command
 

--- a/metaphor/bigquery/lineage/README.md
+++ b/metaphor/bigquery/lineage/README.md
@@ -22,6 +22,12 @@ See [Access Control](https://cloud.google.com/logging/docs/access-control#consol
 The config file inherits all the required and optional fields from the general BigQuery connector [Config File](../README.md#config-file). In addition, you can specify the following configurations:
 
 ```yaml
+# (Optional) Whether to enable parsing view query to find upstream of the view, default True
+enable_view_lineage: <boolean>
+
+# (Optional) Whether to enable parsing audit log to find table lineage information, default True
+enable_lineage_from_log: <boolean>
+
 # (Optional) Number of days of logs to extract for lineage analysis. Default to 30.
 lookback_days: <days>
 

--- a/metaphor/bigquery/lineage/config.py
+++ b/metaphor/bigquery/lineage/config.py
@@ -7,6 +7,12 @@ from metaphor.bigquery.config import BigQueryRunConfig
 @deserialize
 @dataclass
 class BigQueryLineageRunConfig(BigQueryRunConfig):
+    # Whether to enable parsing view query to find upstream of the view, default True
+    enable_view_lineage: bool = True
+
+    # Whether to enable parsing audit log to find table lineage information, default True
+    enable_lineage_from_log: bool = True
+
     lookback_days: int = 30
 
     batch_size: int = 1000

--- a/metaphor/bigquery/utils.py
+++ b/metaphor/bigquery/utils.py
@@ -5,7 +5,10 @@ from typing import Any, Optional
 
 from smart_open import open
 
+from metaphor.bigquery.config import BigQueryRunConfig
+
 try:
+    import google.cloud.bigquery as bigquery
     from google.cloud import logging_v2
     from google.oauth2 import service_account
 except ImportError:
@@ -19,6 +22,19 @@ except ImportError:
 # from google.cloud.logging_v2 import ProtobufEntry
 # LogEntry = ProtobufEntry
 LogEntry = Any
+
+
+def build_client(config: BigQueryRunConfig) -> bigquery.Client:
+    with open(config.key_path) as fin:
+        credentials = service_account.Credentials.from_service_account_info(
+            json.load(fin),
+            scopes=["https://www.googleapis.com/auth/cloud-platform"],
+        )
+
+        return bigquery.Client(
+            credentials=credentials,
+            project=config.project_id if config.project_id else credentials.project_id,
+        )
 
 
 def build_logging_client(key_path: str, project_id: Optional[str]) -> logging_v2.Client:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.19"
+version = "0.10.20"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]
@@ -47,7 +47,7 @@ all = [
   "sql-metadata",
   "tableauserverclient",
 ]
-bigquery = ["google-cloud-bigquery", "google-cloud-logging"]
+bigquery = ["google-cloud-bigquery", "google-cloud-logging", "sql-metadata"]
 dbt = []
 google_directory = ["google-api-python-client", "google-auth-oauthlib"]
 looker = ["lkml", "looker-sdk", "sql-metadata"]

--- a/tests/bigquery/lineage/config.yml
+++ b/tests/bigquery/lineage/config.yml
@@ -1,5 +1,7 @@
 ---
 key_path: key_path
 project_id: project_id
+enable_view_lineage: true
+enable_lineage_from_log: false
 lookback_days: 10
 output: {}

--- a/tests/bigquery/lineage/data/view_result.json
+++ b/tests/bigquery/lineage/data/view_result.json
@@ -1,0 +1,20 @@
+[
+  {
+    "dataset": {
+      "entityType": "DATASET",
+      "logicalId": {
+        "name": "project1.dataset1.table1",
+        "platform": "BIGQUERY"
+      },
+      "upstream": {
+        "sourceDatasets": [
+          "DATASET~A6BA6F986B360A57CF65200F29F5B251"
+        ],
+        "transformation": "select * from FOO"
+      }
+    },
+    "eventHeader": {
+      "time": "2000-01-01T00:00:00+00:00"
+    }
+  }
+]

--- a/tests/bigquery/lineage/test_config.py
+++ b/tests/bigquery/lineage/test_config.py
@@ -10,6 +10,8 @@ def test_yaml_config(test_root_dir):
     assert config == BigQueryLineageRunConfig(
         key_path="key_path",
         project_id="project_id",
+        enable_view_lineage=True,
+        enable_lineage_from_log=False,
         lookback_days=10,
         batch_size=1000,
         output=OutputConfig(),

--- a/tests/bigquery/lineage/test_extractor.py
+++ b/tests/bigquery/lineage/test_extractor.py
@@ -1,27 +1,40 @@
+import json
+from datetime import datetime
 from unittest.mock import patch
 
 import pytest
 from freezegun import freeze_time
+from google.cloud.bigquery import SchemaField
 
 from metaphor.bigquery.lineage.config import BigQueryLineageRunConfig
 from metaphor.bigquery.lineage.extractor import BigQueryLineageExtractor
 from metaphor.common.base_config import OutputConfig
 from metaphor.common.event_util import EventUtil
 from tests.bigquery.load_entries import load_entries
+from tests.bigquery.test_extractor import (
+    mock_dataset,
+    mock_get_table,
+    mock_list_datasets,
+    mock_list_tables,
+    mock_table,
+    mock_table_full,
+)
 from tests.test_utils import load_json
 
 
-def mock_list_entries(mock_build_client, entries):
+def mock_list_entries(mock_build_log_client, entries):
     def side_effect(page_size, filter_):
         return entries
 
-    mock_build_client.return_value.list_entries.side_effect = side_effect
+    mock_build_log_client.return_value.list_entries.side_effect = side_effect
 
 
 @pytest.mark.asyncio
 @freeze_time("2022-01-27")
-async def test_extractor(test_root_dir):
-    config = BigQueryLineageRunConfig(output=OutputConfig(), key_path="fake_file")
+async def test_log_extractor(test_root_dir):
+    config = BigQueryLineageRunConfig(
+        output=OutputConfig(), key_path="fake_file", enable_view_lineage=False
+    )
     extractor = BigQueryLineageExtractor()
 
     entries = load_entries(test_root_dir + "/bigquery/lineage/data/sample_log.json")
@@ -36,3 +49,61 @@ async def test_extractor(test_root_dir):
         events = [EventUtil.trim_event(e) for e in await extractor.extract(config)]
 
     assert events == load_json(test_root_dir + "/bigquery/lineage/data/result.json")
+
+
+@pytest.mark.asyncio
+@freeze_time("2000-01-01")
+async def test_view_extractor(test_root_dir):
+    config = BigQueryLineageRunConfig(
+        output=OutputConfig(),
+        key_path="fake_file",
+        project_id="fake_project",
+        enable_lineage_from_log=False,
+    )
+    extractor = BigQueryLineageExtractor()
+
+    # @patch doesn't work for async func in py3.7: https://bugs.python.org/issue36996
+    with patch("metaphor.bigquery.lineage.extractor.build_client") as mock_build_client:
+        mock_build_client.return_value.project = "project1"
+
+        mock_list_datasets(mock_build_client, [mock_dataset("dataset1")])
+
+        mock_list_tables(
+            mock_build_client,
+            {
+                "dataset1": [
+                    mock_table("dataset1", "table1"),
+                ],
+            },
+        )
+
+        mock_get_table(
+            mock_build_client,
+            {
+                ("dataset1", "table1"): mock_table_full(
+                    dataset_id="dataset1",
+                    table_id="table1",
+                    table_type="VIEW",
+                    description="description",
+                    schema=[
+                        SchemaField(
+                            name="f1",
+                            field_type="FLOAT",
+                            description="d1",
+                            mode="REPEATED",
+                        )
+                    ],
+                    view_query="select * from FOO",
+                    modified=datetime.fromisoformat("2000-01-02"),
+                    num_bytes=512 * 1024,
+                    num_rows=1000,
+                ),
+            },
+        )
+
+        events = [EventUtil.trim_event(e) for e in await extractor.extract(config)]
+
+    print(json.dumps(events))
+    assert events == load_json(
+        f"{test_root_dir}/bigquery/lineage/data/view_result.json"
+    )


### PR DESCRIPTION
### 🤔 Why?

The BigQuery view should have upstream lineage pointing to the queried tables, but the current lineage crawler doesn't handle that.

### 🤓 What?

- Fetch BQ view definition and parse the SQL to get upstream tables. 
- Make two toggles in BQ lineage config for enabling view lineage and log lineage

### 🧪 Tested?

unit tests
tested locally against metaphor BQ instance, view lineage is correct
