### PR TITLE
Redshift crawler index of out bound issue [sc-6687]

### DIFF
--- a/metaphor/postgresql/extractor.py
+++ b/metaphor/postgresql/extractor.py
@@ -306,10 +306,16 @@ class PostgreSQLExtractor(BaseExtractor):
             elif native_type == "double precision":
                 precision = 53
             elif native_type == "numeric" and type_str != "numeric":
-                precision = float(type_str.split("(")[1].split(",")[0])
+                try:
+                    precision = float(type_str.split("(")[1].split(",")[0])
+                except IndexError:
+                    logger.warning(f"Failed to parse precision from {type_str}.")
 
             if native_type == "character varying" or native_type == "character":
-                max_length = float(type_str.split("(")[1].strip(")"))
+                try:
+                    max_length = float(type_str.split("(")[1].strip(")"))
+                except IndexError:
+                    logger.warning(f"Failed to parse max_length from {type_str}.")
 
             return precision, max_length
 

--- a/metaphor/postgresql/extractor.py
+++ b/metaphor/postgresql/extractor.py
@@ -302,9 +302,9 @@ class PostgreSQLExtractor(BaseExtractor):
             elif native_type == "bigint":
                 precision = 64.0
             elif native_type == "real":
-                precision = 24
+                precision = 24.0
             elif native_type == "double precision":
-                precision = 53
+                precision = 53.0
             elif native_type == "numeric" and type_str != "numeric":
                 try:
                     precision = float(type_str.split("(")[1].split(",")[0])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.23"
+version = "0.10.24"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/postgresql/test_extractor.py
+++ b/tests/postgresql/test_extractor.py
@@ -1,0 +1,40 @@
+from metaphor.postgresql.extractor import PostgreSQLExtractor
+
+
+def test_parse_max_length():
+    assert PostgreSQLExtractor._parse_max_length("foo") is None
+    assert PostgreSQLExtractor._parse_max_length("foo(a)") is None
+    assert PostgreSQLExtractor._parse_max_length("foo(10)") == 10
+
+
+def test_parse_precision():
+    assert PostgreSQLExtractor._parse_precision("foo") is None
+    assert PostgreSQLExtractor._parse_precision("foo(a,10)") is None
+    assert PostgreSQLExtractor._parse_precision("foo(,10)") is None
+    assert PostgreSQLExtractor._parse_precision("foo(10,b)") == 10
+    assert PostgreSQLExtractor._parse_precision("foo(10,)") == 10
+
+
+def test_parse_format_type():
+    assert PostgreSQLExtractor._parse_format_type("foo", "foo") == (None, None)
+    assert PostgreSQLExtractor._parse_format_type("integer", "foo") == (32.0, None)
+    assert PostgreSQLExtractor._parse_format_type("smallint", "foo") == (16.0, None)
+    assert PostgreSQLExtractor._parse_format_type("bigint", "foo") == (64.0, None)
+    assert PostgreSQLExtractor._parse_format_type("real", "foo") == (24.0, None)
+    assert PostgreSQLExtractor._parse_format_type("double precision", "foo") == (
+        53.0,
+        None,
+    )
+    assert PostgreSQLExtractor._parse_format_type("numeric", "foo") == (None, None)
+    assert PostgreSQLExtractor._parse_format_type("numeric", "numeric(10,1)") == (
+        10,
+        None,
+    )
+    assert PostgreSQLExtractor._parse_format_type("numeric", "numeric") == (None, None)
+    assert PostgreSQLExtractor._parse_format_type("character", "character(10)") == (
+        None,
+        10,
+    )
+    assert PostgreSQLExtractor._parse_format_type(
+        "character varying", "character varying(10)"
+    ) == (None, 10)


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

When parsing precision, max_length from `fotmat_type` could cause `IndexError` for some reason. According to the document, `character varying` and `character` should be at least 1.

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

- Add try-catch to safely parse `format_type`.

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

n/a

<!--
  Describe how the change was tested end-to-end.
-->
