### PR TITLE
Redshift crawler still needs permission to actual schema [sc-6686]

### DIFF
--- a/metaphor/postgresql/extractor.py
+++ b/metaphor/postgresql/extractor.py
@@ -108,7 +108,7 @@ class PostgreSQLExtractor(BaseExtractor):
         results = await conn.fetch(
             """
             SELECT schemaname, tablename AS name, pgd.description, pgc.reltuples::bigint AS row_count,
-                pg_total_relation_size('"' || schemaname || '"."' || tablename || '"') AS table_size,
+                pg_total_relation_size(pgc.oid) AS table_size,
                 'TABLE' as table_type
             FROM pg_catalog.pg_tables t
             LEFT JOIN pg_class pgc
@@ -118,7 +118,7 @@ class PostgreSQLExtractor(BaseExtractor):
             WHERE schemaname !~ '^pg_' AND schemaname != 'information_schema'
             UNION
             SELECT schemaname, viewname AS name, pgd.description, pgc.reltuples::bigint AS row_count,
-                pg_total_relation_size('"' || schemaname || '"."' || viewname || '"') AS table_size,
+                pg_total_relation_size(pgc.oid) AS table_size,
                 'VIEW' as table_type
             FROM pg_catalog.pg_views v
             LEFT JOIN pg_class pgc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.22"
+version = "0.10.23"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

Cannot run Redshift crawler with minimum privilege.

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

- `pg_total_relation_size` needs extra permission when parameter is table name. Use object ID of relation to solving this problem.

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

- Run Redshift crawler with an ordinary user successfully
- Run PostgresSQL crawler successfully with the correct result.

<!--
  Describe how the change was tested end-to-end.
-->
