### PR TITLE
remove flakehell

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,8 @@
+[flake8]
+ignore = E203,E501,W503
+exclude =
+    venv,
+    __pycache__,
+    metaphor/dbt/generated,
+    **/.pytest_cache
+max-complexity = 12

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Lint & Type Check
         run: |
           poetry install -E all
-          poetry run flakehell lint
+          poetry run flake8
           poetry run black --check .
           poetry run isort --check .
           poetry run mypy .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,19 +34,16 @@ repos:
           - types-pytz
 
   - repo: https://github.com/pycqa/bandit
-    rev: 1.7.0
+    rev: 1.7.2
     hooks:
       - id: bandit
         args: ['--skip=B101,B303,B608']
 
-  - repo: local
+  - repo: https://github.com/pycqa/flake8
+    rev: 4.0.1
     hooks:
-      - id: flakehell
-        name: flakehell
-        entry: flakehell lint
-        language: python
-        pass_filenames: false
-        always_run: true
+      - id: flake8
+        args: ['--ignore=E203,E501,W503']
 
   - repo: local
     hooks:

--- a/metaphor/common/entity_id.py
+++ b/metaphor/common/entity_id.py
@@ -32,7 +32,7 @@ class EntityId:
 
     def __str__(self) -> str:
         json = encode_canonical_json(EventUtil.clean_nones(self.logicalId.to_dict()))
-        return f"{self.type.name}~{hashlib.md5(json).hexdigest().upper()}"
+        return f"{self.type.name}~{hashlib.md5(json).hexdigest().upper()}"  # nosec B303: md5
 
     def __hash__(self):
         return hash(str(self))

--- a/metaphor/dbt/manifest_parser_v3.py
+++ b/metaphor/dbt/manifest_parser_v3.py
@@ -13,7 +13,7 @@ from metaphor.models.metadata_change_event import (
 )
 from pydantic.utils import unique_list
 
-from metaphor.common.entity_id import dataset_fullname, to_dataset_entity_id
+from metaphor.common.entity_id import EntityId, dataset_fullname, to_dataset_entity_id
 from metaphor.common.logger import get_logger
 
 from .generated.dbt_manifest_v3 import (
@@ -93,7 +93,7 @@ class ManifestParserV3:
         tests: Dict[str, TEST_NODE_TYPE],
         models: Dict[str, MODEL_NODE_TYPE],
     ) -> None:
-        source_map = {}
+        source_map: Dict[str, EntityId] = {}
         for key, source in sources.items():
             assert source.database is not None
             source_map[key] = to_dataset_entity_id(
@@ -102,7 +102,7 @@ class ManifestParserV3:
                 self._account,
             )
 
-        macro_map = {}
+        macro_map: Dict[str, DbtMacro] = {}
         for key, macro in macros.items():
             arguments = (
                 [
@@ -127,79 +127,14 @@ class ManifestParserV3:
                 depends_on_macros=macro.depends_on.macros if macro.depends_on else None,
             )
 
+        # initialize all virtual views to be used in cross-references
         for _, model in models.items():
             init_virtual_view(self._virtual_views, model.unique_id)
 
-        for key, model in models.items():
-            virtual_view = init_virtual_view(self._virtual_views, model.unique_id)
-            virtual_view.dbt_model = DbtModel(
-                package_name=model.package_name,
-                description=model.description,
-                url=build_source_code_url(
-                    self._project_source_url, model.original_file_path
-                ),
-                tags=model.tags,
-                raw_sql=model.raw_sql,
-                fields=[],
-            )
-            dbt_model = virtual_view.dbt_model
+        for _, model in models.items():
+            self._parse_model(model, source_map, macro_map)
 
-            if isinstance(model, CompiledModelNode):
-                dbt_model.compiled_sql = model.compiled_sql
-
-            dbt_model.owners = get_model_owner_ids(model)
-
-            assert model.config is not None and model.database is not None
-            materialized = model.config.materialized
-
-            if materialized:
-                try:
-                    materialization_type = DbtMaterializationType[materialized.upper()]
-                except KeyError:
-                    materialization_type = DbtMaterializationType.OTHER
-
-                dbt_model.materialization = DbtMaterialization(
-                    type=materialization_type,
-                    target_dataset=str(
-                        to_dataset_entity_id(
-                            dataset_fullname(
-                                model.database, model.schema_, model.alias or model.name
-                            ),
-                            self._platform,
-                            self._account,
-                        )
-                    ),
-                )
-
-            if model.columns is not None:
-                for col in model.columns.values():
-                    column_name = col.name.lower()
-                    field = init_field(dbt_model.fields, column_name)
-                    field.description = col.description
-                    field.native_type = col.data_type or "Not Set"
-
-            if model.depends_on is not None:
-                if model.depends_on.nodes:
-                    dbt_model.source_models = unique_list(
-                        [
-                            get_virtual_view_id(self._virtual_views[n].logical_id)
-                            for n in model.depends_on.nodes
-                            if n.startswith("model.")
-                        ]
-                    )
-
-                    dbt_model.source_datasets = unique_list(
-                        [
-                            str(source_map[n])
-                            for n in model.depends_on.nodes
-                            if n.startswith("source.")
-                        ]
-                    )
-
-                if model.depends_on.macros:
-                    dbt_model.macros = [macro_map[n] for n in model.depends_on.macros]
-
-        for key, test in tests.items():
+        for _, test in tests.items():
             # check test is referring a model
             if test.depends_on is None or not test.depends_on.nodes:
                 continue
@@ -225,3 +160,77 @@ class ManifestParserV3:
                 dbt_test.sql = test.compiled_sql
 
             init_dbt_tests(self._virtual_views, model_unique_id).append(dbt_test)
+
+    def _parse_model(
+        self,
+        model: MODEL_NODE_TYPE,
+        source_map: Dict[str, EntityId],
+        macro_map: Dict[str, DbtMacro],
+    ):
+        virtual_view = init_virtual_view(self._virtual_views, model.unique_id)
+        virtual_view.dbt_model = DbtModel(
+            package_name=model.package_name,
+            description=model.description,
+            url=build_source_code_url(
+                self._project_source_url, model.original_file_path
+            ),
+            tags=model.tags,
+            raw_sql=model.raw_sql,
+            fields=[],
+        )
+        dbt_model = virtual_view.dbt_model
+
+        if isinstance(model, CompiledModelNode):
+            dbt_model.compiled_sql = model.compiled_sql
+
+        dbt_model.owners = get_model_owner_ids(model)
+
+        assert model.config is not None and model.database is not None
+        materialized = model.config.materialized
+
+        if materialized:
+            try:
+                materialization_type = DbtMaterializationType[materialized.upper()]
+            except KeyError:
+                materialization_type = DbtMaterializationType.OTHER
+
+            dbt_model.materialization = DbtMaterialization(
+                type=materialization_type,
+                target_dataset=str(
+                    to_dataset_entity_id(
+                        dataset_fullname(
+                            model.database, model.schema_, model.alias or model.name
+                        ),
+                        self._platform,
+                        self._account,
+                    )
+                ),
+            )
+
+        if model.columns is not None:
+            for col in model.columns.values():
+                column_name = col.name.lower()
+                field = init_field(dbt_model.fields, column_name)
+                field.description = col.description
+                field.native_type = col.data_type or "Not Set"
+
+        if model.depends_on is not None:
+            if model.depends_on.nodes:
+                dbt_model.source_models = unique_list(
+                    [
+                        get_virtual_view_id(self._virtual_views[n].logical_id)
+                        for n in model.depends_on.nodes
+                        if n.startswith("model.")
+                    ]
+                )
+
+                dbt_model.source_datasets = unique_list(
+                    [
+                        str(source_map[n])
+                        for n in model.depends_on.nodes
+                        if n.startswith("source.")
+                    ]
+                )
+
+            if model.depends_on.macros:
+                dbt_model.macros = [macro_map[n] for n in model.depends_on.macros]

--- a/metaphor/dbt/manifest_parser_v4.py
+++ b/metaphor/dbt/manifest_parser_v4.py
@@ -13,7 +13,7 @@ from metaphor.models.metadata_change_event import (
 )
 from pydantic.utils import unique_list
 
-from metaphor.common.entity_id import dataset_fullname, to_dataset_entity_id
+from metaphor.common.entity_id import EntityId, dataset_fullname, to_dataset_entity_id
 from metaphor.common.logger import get_logger
 
 from .generated.dbt_manifest_v4 import (
@@ -92,7 +92,7 @@ class ManifestParserV4:
         tests: Dict[str, TEST_NODE_TYPE],
         models: Dict[str, MODEL_NODE_TYPE],
     ) -> None:
-        source_map = {}
+        source_map: Dict[str, EntityId] = {}
         for key, source in sources.items():
             assert source.database is not None
             source_map[key] = to_dataset_entity_id(
@@ -101,7 +101,7 @@ class ManifestParserV4:
                 self._account,
             )
 
-        macro_map = {}
+        macro_map: Dict[str, DbtMacro] = {}
         for key, macro in macros.items():
             arguments = (
                 [
@@ -126,79 +126,14 @@ class ManifestParserV4:
                 depends_on_macros=macro.depends_on.macros if macro.depends_on else None,
             )
 
+        # initialize all virtual views to be used in cross-references
         for _, model in models.items():
             init_virtual_view(self._virtual_views, model.unique_id)
 
-        for key, model in models.items():
-            virtual_view = init_virtual_view(self._virtual_views, model.unique_id)
-            virtual_view.dbt_model = DbtModel(
-                package_name=model.package_name,
-                description=model.description,
-                url=build_source_code_url(
-                    self._project_source_url, model.original_file_path
-                ),
-                tags=model.tags,
-                raw_sql=model.raw_sql,
-                fields=[],
-            )
-            dbt_model = virtual_view.dbt_model
+        for _, model in models.items():
+            self._parse_model(model, source_map, macro_map)
 
-            if isinstance(model, CompiledModelNode):
-                dbt_model.compiled_sql = model.compiled_sql
-
-            dbt_model.owners = get_model_owner_ids(model)
-
-            assert model.config is not None and model.database is not None
-            materialized = model.config.materialized
-
-            if materialized:
-                try:
-                    materialization_type = DbtMaterializationType[materialized.upper()]
-                except KeyError:
-                    materialization_type = DbtMaterializationType.OTHER
-
-                dbt_model.materialization = DbtMaterialization(
-                    type=materialization_type,
-                    target_dataset=str(
-                        to_dataset_entity_id(
-                            dataset_fullname(
-                                model.database, model.schema_, model.alias or model.name
-                            ),
-                            self._platform,
-                            self._account,
-                        )
-                    ),
-                )
-
-            if model.columns is not None:
-                for col in model.columns.values():
-                    column_name = col.name.lower()
-                    field = init_field(dbt_model.fields, column_name)
-                    field.description = col.description
-                    field.native_type = col.data_type or "Not Set"
-
-            if model.depends_on is not None:
-                if model.depends_on.nodes:
-                    dbt_model.source_models = unique_list(
-                        [
-                            get_virtual_view_id(self._virtual_views[n].logical_id)
-                            for n in model.depends_on.nodes
-                            if n.startswith("model.")
-                        ]
-                    )
-
-                    dbt_model.source_datasets = unique_list(
-                        [
-                            str(source_map[n])
-                            for n in model.depends_on.nodes
-                            if n.startswith("source.")
-                        ]
-                    )
-
-                if model.depends_on.macros:
-                    dbt_model.macros = [macro_map[n] for n in model.depends_on.macros]
-
-        for key, test in tests.items():
+        for _, test in tests.items():
             # check test is referring a model
             if test.depends_on is None or not test.depends_on.nodes:
                 continue
@@ -224,3 +159,77 @@ class ManifestParserV4:
                 dbt_test.sql = test.compiled_sql
 
             init_dbt_tests(self._virtual_views, model_unique_id).append(dbt_test)
+
+    def _parse_model(
+        self,
+        model: MODEL_NODE_TYPE,
+        source_map: Dict[str, EntityId],
+        macro_map: Dict[str, DbtMacro],
+    ):
+        virtual_view = init_virtual_view(self._virtual_views, model.unique_id)
+        virtual_view.dbt_model = DbtModel(
+            package_name=model.package_name,
+            description=model.description,
+            url=build_source_code_url(
+                self._project_source_url, model.original_file_path
+            ),
+            tags=model.tags,
+            raw_sql=model.raw_sql,
+            fields=[],
+        )
+        dbt_model = virtual_view.dbt_model
+
+        if isinstance(model, CompiledModelNode):
+            dbt_model.compiled_sql = model.compiled_sql
+
+        dbt_model.owners = get_model_owner_ids(model)
+
+        assert model.config is not None and model.database is not None
+        materialized = model.config.materialized
+
+        if materialized:
+            try:
+                materialization_type = DbtMaterializationType[materialized.upper()]
+            except KeyError:
+                materialization_type = DbtMaterializationType.OTHER
+
+            dbt_model.materialization = DbtMaterialization(
+                type=materialization_type,
+                target_dataset=str(
+                    to_dataset_entity_id(
+                        dataset_fullname(
+                            model.database, model.schema_, model.alias or model.name
+                        ),
+                        self._platform,
+                        self._account,
+                    )
+                ),
+            )
+
+        if model.columns is not None:
+            for col in model.columns.values():
+                column_name = col.name.lower()
+                field = init_field(dbt_model.fields, column_name)
+                field.description = col.description
+                field.native_type = col.data_type or "Not Set"
+
+        if model.depends_on is not None:
+            if model.depends_on.nodes:
+                dbt_model.source_models = unique_list(
+                    [
+                        get_virtual_view_id(self._virtual_views[n].logical_id)
+                        for n in model.depends_on.nodes
+                        if n.startswith("model.")
+                    ]
+                )
+
+                dbt_model.source_datasets = unique_list(
+                    [
+                        str(source_map[n])
+                        for n in model.depends_on.nodes
+                        if n.startswith("source.")
+                    ]
+                )
+
+            if model.depends_on.macros:
+                dbt_model.macros = [macro_map[n] for n in model.depends_on.macros]

--- a/poetry.lock
+++ b/poetry.lock
@@ -274,7 +274,7 @@ test = ["pytest (>=6.2.0)", "pytest-cov", "pytest-subtests", "pytest-xdist", "pr
 
 [[package]]
 name = "datamodel-code-generator"
-version = "0.11.18"
+version = "0.11.19"
 description = "Datamodel Code Generator"
 category = "dev"
 optional = false
@@ -333,14 +333,6 @@ dnspython = ">=1.15.0"
 idna = ">=2.0.0"
 
 [[package]]
-name = "entrypoints"
-version = "0.4"
-description = "Discover and load entry points from installed packages."
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[[package]]
 name = "fastjsonschema"
 version = "2.15.3"
 description = "Fastest Python implementation of JSON schema"
@@ -353,37 +345,17 @@ devel = ["colorama", "jsonschema", "json-spec", "pylint", "pytest", "pytest-benc
 
 [[package]]
 name = "flake8"
-version = "3.9.0"
+version = "4.0.1"
 description = "the modular source code checker: pep8 pyflakes and co"
 category = "dev"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+python-versions = ">=3.6"
 
 [package.dependencies]
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+importlib-metadata = {version = "<4.3", markers = "python_version < \"3.8\""}
 mccabe = ">=0.6.0,<0.7.0"
-pycodestyle = ">=2.7.0,<2.8.0"
-pyflakes = ">=2.3.0,<2.4.0"
-
-[[package]]
-name = "flakehell"
-version = "0.9.0"
-description = "Flake8 wrapper to make it nice and configurable"
-category = "dev"
-optional = false
-python-versions = ">=3.5"
-
-[package.dependencies]
-colorama = "*"
-entrypoints = "*"
-flake8 = ">=3.8.0"
-pygments = "*"
-toml = "*"
-urllib3 = "*"
-
-[package.extras]
-docs = ["alabaster", "pygments-github-lexers", "recommonmark", "sphinx"]
-dev = ["dlint", "flake8-2020", "flake8-aaa", "flake8-absolute-import", "flake8-alfred", "flake8-annotations-complexity", "flake8-bandit", "flake8-black", "flake8-broken-line", "flake8-bugbear", "flake8-builtins", "flake8-coding", "flake8-cognitive-complexity", "flake8-commas", "flake8-comprehensions", "flake8-debugger", "flake8-django", "flake8-docstrings", "flake8-eradicate", "flake8-executable", "flake8-expression-complexity", "flake8-fixme", "flake8-functions", "flake8-future-import", "flake8-import-order", "flake8-isort", "flake8-logging-format", "flake8-mock", "flake8-mutable", "flake8-mypy", "flake8-pep3101", "flake8-pie", "flake8-print", "flake8-printf-formatting", "flake8-pyi", "flake8-pytest", "flake8-pytest-style", "flake8-quotes", "flake8-requirements", "flake8-rst-docstrings", "flake8-scrapy", "flake8-spellcheck", "flake8-sql", "flake8-strict", "flake8-string-format", "flake8-tidy-imports", "flake8-todo", "flake8-use-fstring", "flake8-variables-names", "isort", "mccabe", "pandas-vet", "pep8-naming", "pylint", "pytest", "typing-extensions", "wemake-python-styleguide"]
+pycodestyle = ">=2.8.0,<2.9.0"
+pyflakes = ">=2.4.0,<2.5.0"
 
 [[package]]
 name = "freezegun"
@@ -750,11 +722,11 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "importlib-metadata"
-version = "4.10.1"
+version = "4.2.0"
 description = "Read metadata from Python packages"
 category = "dev"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.6"
 
 [package.dependencies]
 typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
@@ -762,8 +734,7 @@ zipp = ">=0.5"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-perf = ["ipython"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "inflect"
@@ -1110,11 +1081,11 @@ pyasn1 = ">=0.4.6,<0.5.0"
 
 [[package]]
 name = "pycodestyle"
-version = "2.7.0"
+version = "2.8.0"
 description = "Python style guide checker"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "pycparser"
@@ -1150,19 +1121,11 @@ email = ["email-validator (>=1.0.3)"]
 
 [[package]]
 name = "pyflakes"
-version = "2.3.1"
+version = "2.4.0"
 description = "passive checker of Python programs"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[[package]]
-name = "pygments"
-version = "2.11.2"
-description = "Pygments is a syntax highlighting package written in Python."
-category = "dev"
-optional = false
-python-versions = ">=3.5"
 
 [[package]]
 name = "pyjwt"
@@ -1684,7 +1647,7 @@ tableau = ["tableauserverclient"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<3.11"  # See https://github.com/googleapis/python-bigquery/issues/856
-content-hash = "d8deae3a6cd86a4fdd532568533484968ace8165d251a23bb0b12b153c7600e3"
+content-hash = "ac0ccb0b2af3af3126ae870f76cbca803e4902e6530d7c2065a27dd543459223"
 
 [metadata.files]
 anyio = [
@@ -1883,8 +1846,8 @@ cryptography = [
     {file = "cryptography-36.0.1.tar.gz", hash = "sha256:53e5c1dc3d7a953de055d77bef2ff607ceef7a2aac0353b5d630ab67f7423638"},
 ]
 datamodel-code-generator = [
-    {file = "datamodel-code-generator-0.11.18.tar.gz", hash = "sha256:8b9dff10c3002f09aaf861523265c54ebcdc80668848e1716be0efba6535f783"},
-    {file = "datamodel_code_generator-0.11.18-py3-none-any.whl", hash = "sha256:6466b590a2c16fd721714944f6d12e625707a5f06174144cf20d6701c5d363ae"},
+    {file = "datamodel-code-generator-0.11.19.tar.gz", hash = "sha256:39874c017bbedc5fc9b93c332f3f213d299c9af2995e3870aaa2db8a661098e2"},
+    {file = "datamodel_code_generator-0.11.19-py3-none-any.whl", hash = "sha256:26a62a1f99c7c8148b808e3e67e82c762cc9f7bbe036fb4c2798352460d68e38"},
 ]
 dnspython = [
     {file = "dnspython-2.2.0-py3-none-any.whl", hash = "sha256:081649da27ced5e75709a1ee542136eaba9842a0fe4c03da4fb0a3d3ed1f3c44"},
@@ -1894,21 +1857,13 @@ email-validator = [
     {file = "email_validator-1.1.3-py2.py3-none-any.whl", hash = "sha256:5675c8ceb7106a37e40e2698a57c056756bf3f272cfa8682a4f87ebd95d8440b"},
     {file = "email_validator-1.1.3.tar.gz", hash = "sha256:aa237a65f6f4da067119b7df3f13e89c25c051327b2b5b66dc075f33d62480d7"},
 ]
-entrypoints = [
-    {file = "entrypoints-0.4-py3-none-any.whl", hash = "sha256:f174b5ff827504fd3cd97cc3f8649f3693f51538c7e4bdf3ef002c8429d42f9f"},
-    {file = "entrypoints-0.4.tar.gz", hash = "sha256:b706eddaa9218a19ebcd67b56818f05bb27589b1ca9e8d797b74affad4ccacd4"},
-]
 fastjsonschema = [
     {file = "fastjsonschema-2.15.3-py3-none-any.whl", hash = "sha256:ddb0b1d8243e6e3abb822bd14e447a89f4ab7439342912d590444831fa00b6a0"},
     {file = "fastjsonschema-2.15.3.tar.gz", hash = "sha256:0a572f0836962d844c1fc435e200b2e4f4677e4e6611a2e3bdd01ba697c275ec"},
 ]
 flake8 = [
-    {file = "flake8-3.9.0-py2.py3-none-any.whl", hash = "sha256:12d05ab02614b6aee8df7c36b97d1a3b2372761222b19b58621355e82acddcff"},
-    {file = "flake8-3.9.0.tar.gz", hash = "sha256:78873e372b12b093da7b5e5ed302e8ad9e988b38b063b61ad937f26ca58fc5f0"},
-]
-flakehell = [
-    {file = "flakehell-0.9.0-py3-none-any.whl", hash = "sha256:48a3a9b46136240e52b3b32a78a0826c45f6dcf7d980c30f758c1db5b1439c0b"},
-    {file = "flakehell-0.9.0.tar.gz", hash = "sha256:208836d8d24194d50cfa4c1fc99f681f3c537cc232edcd06455abc2971460893"},
+    {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
+    {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
 ]
 freezegun = [
     {file = "freezegun-1.1.0-py2.py3-none-any.whl", hash = "sha256:2ae695f7eb96c62529f03a038461afe3c692db3465e215355e1bb4b0ab408712"},
@@ -2111,8 +2066,8 @@ idna = [
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.10.1-py3-none-any.whl", hash = "sha256:899e2a40a8c4a1aec681feef45733de8a6c58f3f6a0dbed2eb6574b4387a77b6"},
-    {file = "importlib_metadata-4.10.1.tar.gz", hash = "sha256:951f0d8a5b7260e9db5e41d429285b5f451e928479f19d80818878527d36e95e"},
+    {file = "importlib_metadata-4.2.0-py3-none-any.whl", hash = "sha256:057e92c15bc8d9e8109738a48db0ccb31b4d9d5cfbee5a8670879a30be66304b"},
+    {file = "importlib_metadata-4.2.0.tar.gz", hash = "sha256:b7e52a1f8dec14a75ea73e0891f3060099ca1d8e6a462a4dff11c3e119ea1b31"},
 ]
 inflect = [
     {file = "inflect-5.4.0-py3-none-any.whl", hash = "sha256:2eb3f9a481e12849370d5a74acc546cc128d79df6e483928aa78b5bb18244ef6"},
@@ -2346,8 +2301,8 @@ pyasn1-modules = [
     {file = "pyasn1_modules-0.2.8-py3.7.egg", hash = "sha256:c29a5e5cc7a3f05926aff34e097e84f8589cd790ce0ed41b67aed6857b26aafd"},
 ]
 pycodestyle = [
-    {file = "pycodestyle-2.7.0-py2.py3-none-any.whl", hash = "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068"},
-    {file = "pycodestyle-2.7.0.tar.gz", hash = "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"},
+    {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
+    {file = "pycodestyle-2.8.0.tar.gz", hash = "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"},
 ]
 pycparser = [
     {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
@@ -2420,12 +2375,8 @@ pydantic = [
     {file = "pydantic-1.9.0.tar.gz", hash = "sha256:742645059757a56ecd886faf4ed2441b9c0cd406079c2b4bee51bcc3fbcd510a"},
 ]
 pyflakes = [
-    {file = "pyflakes-2.3.1-py2.py3-none-any.whl", hash = "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3"},
-    {file = "pyflakes-2.3.1.tar.gz", hash = "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"},
-]
-pygments = [
-    {file = "Pygments-2.11.2-py3-none-any.whl", hash = "sha256:44238f1b60a76d78fc8ca0528ee429702aae011c265fe6a8dd8b63049ae41c65"},
-    {file = "Pygments-2.11.2.tar.gz", hash = "sha256:4e426f72023d88d03b2fa258de560726ce890ff3b630f88c21cbb8b2503b8c6a"},
+    {file = "pyflakes-2.4.0-py2.py3-none-any.whl", hash = "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"},
+    {file = "pyflakes-2.4.0.tar.gz", hash = "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c"},
 ]
 pyjwt = [
     {file = "PyJWT-2.3.0-py3-none-any.whl", hash = "sha256:e0c4bb8d9f0af0c7f5b1ec4c5036309617d03d56932877f2f7a0beeb5318322f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.25"
+version = "0.10.26"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]
@@ -62,8 +62,7 @@ tableau = ["tableauserverclient"]
 bandit = "^1.7.2"
 black = "^22.1"
 datamodel-code-generator = { extras = ["http"], version = "^0.11.14" }
-flakehell = "^0.9.0"
-flake8 = "3.9.0"
+flake8 = "^4.0.1"
 freezegun = "^1.1.0"
 isort = "^5.8.0"
 mypy = "^0.931"
@@ -77,6 +76,9 @@ types-requests = "^2.25.0"
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
+
 [tool.black]
 exclude = "^/(metaphor/dbt/generated/.+)"
 
@@ -88,25 +90,10 @@ extend_skip = [
   "dbt_catalog.py"
 ]
 
-[tool.flakehell]
-format = "colored"
-
-[tool.flakehell.plugins]
-pycodestyle = ["+*", "-E203", "-E501", "-W503"]
-pyflakes = ["+*"]
-
-[tool.flakehell.exceptions."metaphor/dbt/generated/"]
-pycodestyle = ["-*"]
-pyflakes = ["-*"]
-
-[tool.flakehell.exceptions."**/site-packages/*.py"]
-pycodestyle = ["-*"]
-pyflakes = ["-*"]
-
 [tool.mypy]
 ignore_missing_imports = true
 plugins = ["pydantic.mypy"]
 
 [tool.bandit]
 exclude_dirs = ["venv"]
-skips = ['B101', 'B303', 'B608']
+skips = ['B101', 'B608']


### PR DESCRIPTION
### 🤔 Why?

[flakehell](https://github.com/life4/flakehell) has been archived, and no more updates since a year ago. And it also doesn't work well with the latest flake8, preventing us from updating flake8 version. The included tests pycodestyle  and pyflakes are supported by flake8 out of the box.

### 🤓 What?

- use plain flake8 to replace flakehell, also update its version
- fix flake8 detected issues, e.g. code too complex for dbt parse, restructure the codes
- update pre-commit hook and CI

### 🧪 Tested?

pre-commit hook is working fine and much faster than before, since the flake8 hook checks the updated files, not the entire directory. 
