### PR TITLE
Bigquery profiler syntax error [sc-6749]

### DIFF
--- a/metaphor/bigquery/profile/extractor.py
+++ b/metaphor/bigquery/profile/extractor.py
@@ -115,12 +115,13 @@ class BigQueryProfileExtractor(BigQueryExtractor):
         row_count = bq_table.num_rows
         schema = self._parse_schema(bq_table)
 
+        logger.debug(f"building query for {table}")
         sql = self._build_profiling_query(schema, table, row_count, self._sampling)
         job = client.query(sql)
 
         jobs.add(job.job_id)
         job.add_done_callback(partial(job_callback, schema=schema, dataset=dataset))
-        logger.info(f"Job dispatch for {table}")
+        logger.info(f"Job dispatched for {table}")
         return dataset
 
     @staticmethod
@@ -138,17 +139,17 @@ class BigQueryProfileExtractor(BigQueryExtractor):
             nullable = field.nullable
 
             if data_type != "RECORD":
-                query.append(f", COUNT(DISTINCT {column})")
+                query.append(f", COUNT(DISTINCT `{column}`)")
 
             if nullable:
-                query.append(f", COUNTIF({column} is NULL)")
+                query.append(f", COUNTIF(`{column}` is NULL)")
 
             if BigQueryProfileExtractor._is_numeric(data_type):
                 query.extend(
                     [
-                        f", MIN({column})",
-                        f", MAX({column})",
-                        f", AVG({column})",
+                        f", MIN(`{column}`)",
+                        f", MAX(`{column}`)",
+                        f", AVG(`{column}`)",
                     ]
                 )
 
@@ -158,6 +159,7 @@ class BigQueryProfileExtractor(BigQueryExtractor):
             logger.info(f"Enable table sampling for table: {table_ref}")
             query.append(f" TABLESAMPLE SYSTEM ({int(sampling.percentage)} PERCENT)")
 
+        logger.debug(query)
         return "".join(query)
 
     @staticmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.26"
+version = "0.10.27"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/bigquery/profile/test_extractor.py
+++ b/tests/bigquery/profile/test_extractor.py
@@ -26,9 +26,9 @@ def test_build_profiling_query():
     table = TableReference(DatasetReference("project", "dataset_id"), "table_id")
 
     expected = (
-        "SELECT COUNT(1), COUNT(DISTINCT id), COUNT(DISTINCT price), "
-        "COUNTIF(price is NULL), MIN(price), MAX(price), AVG(price), "
-        "COUNTIF(json is NULL) "
+        "SELECT COUNT(1), COUNT(DISTINCT `id`), COUNT(DISTINCT `price`), "
+        "COUNTIF(`price` is NULL), MIN(`price`), MAX(`price`), AVG(`price`), "
+        "COUNTIF(`json` is NULL) "
         "FROM `project.dataset_id.table_id`"
     )
 
@@ -51,8 +51,8 @@ def test_build_profiling_query_with_sampling():
     table = TableReference(DatasetReference("project", "dataset_id"), "table_id")
 
     expected = (
-        "SELECT COUNT(1), COUNT(DISTINCT id), COUNT(DISTINCT price), "
-        "COUNTIF(price is NULL), MIN(price), MAX(price), AVG(price) "
+        "SELECT COUNT(1), COUNT(DISTINCT `id`), COUNT(DISTINCT `price`), "
+        "COUNTIF(`price` is NULL), MIN(`price`), MAX(`price`), AVG(`price`) "
         "FROM `project.dataset_id.table_id` TABLESAMPLE SYSTEM (50 PERCENT)"
     )
 


### PR DESCRIPTION
### 🤔 Why?

Possibly due to column naming being a reserved keyword of BQ

### 🤓 What?

- escape all column names 

### 🧪 Tested?

updated unit tests
run locally against metaphor BQ instance