### PR TITLE
BigQuery profiler should remove job if assertion failed [sc-6754]

### DIFF
--- a/metaphor/bigquery/profile/extractor.py
+++ b/metaphor/bigquery/profile/extractor.py
@@ -102,10 +102,13 @@ class BigQueryProfileExtractor(BigQueryExtractor):
     ) -> Dataset:
         def job_callback(job: QueryJob, schema: DatasetSchema, dataset: Dataset):
             # The profiling result should only have one row
-            assert job.result().total_rows == 1
-
-            results = [res for res in next(job.result())]
-            BigQueryProfileExtractor._parse_result(results, schema, dataset)
+            if job.result().total_rows != 1:
+                logger.warning(
+                    f"Skip {table}, the profiling result is more than one row"
+                )
+            else:
+                results = [res for res in next(job.result())]
+                BigQueryProfileExtractor._parse_result(results, schema, dataset)
             jobs.remove(job.job_id)
 
         dataset = BigQueryProfileExtractor._init_dataset(


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

Assert profiling query results could cause the crawler to run forever.

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

- Remove assertion

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

Manually run connector successfully.

<!--
  Describe how the change was tested end-to-end.
-->
