### PR TITLE
update sql-metadata and pre-commit versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,9 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v4.1.0
     hooks:
+      - id: check-toml
       - id: check-yaml
 
   - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
@@ -37,7 +38,7 @@ repos:
     rev: 1.7.2
     hooks:
       - id: bandit
-        args: ['--skip=B101,B303,B608']
+        args: ['--skip=B101,B608']
 
   - repo: https://github.com/pycqa/flake8
     rev: 4.0.1

--- a/metaphor/looker/lookml_parser.py
+++ b/metaphor/looker/lookml_parser.py
@@ -1,6 +1,7 @@
 import glob
 import logging
 import os
+import re
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Set, Tuple
 
@@ -102,46 +103,59 @@ def _get_upstream_datasets(
         logger.error(f"Refer to non-existing view {view_name}")
         return set()
 
+    if "upstream_dataset_ids" in raw_view:
+        return raw_view["upstream_dataset_ids"]
+
+    upstreams = set()
     if "derived_table" in raw_view:
         # https://docs.looker.com/data-modeling/learning-lookml/derived-tables
         derived_table = raw_view["derived_table"]
 
         if "sql" in derived_table:
-            return _extract_upstream_datasets_from_sql(
-                derived_table["sql"], raw_views, connection
+            upstreams.update(
+                _extract_upstream_datasets_from_sql(
+                    derived_table["sql"], raw_views, connection
+                )
             )
 
         if "explore_source" in derived_table:
-            return _get_upstream_datasets(
-                derived_table["explore_source"]["name"], raw_views, connection
+            upstreams.update(
+                _get_upstream_datasets(
+                    derived_table["explore_source"]["name"], raw_views, connection
+                )
             )
+    else:
+        source_name = raw_view.get("sql_table_name", view_name)
+        upstreams.add(_to_dataset_id(source_name, connection))
 
-        return set()
-
-    source_name = raw_view.get("sql_table_name", view_name)
-    return {_to_dataset_id(source_name, connection)}
+    raw_view["upstream_dataset_ids"] = upstreams
+    return upstreams
 
 
 def _extract_upstream_datasets_from_sql(
     sql: str, raw_views: Dict[str, Dict], connection: LookerConnectionConfig
 ) -> Set[EntityId]:
-    upstream: Set[EntityId] = set()
+    upstreams: Set[EntityId] = set()
     try:
+        # replace the referenced view name with real view name
+        sql = re.sub(r"\${(.+\.SQL_TABLE_NAME)}", r"\1", sql)
+
+        # parse SQL tables
         tables = sql_metadata.Parser(sql).tables
+        for table in tables:
+            if table.endswith(".SQL_TABLE_NAME"):
+                # Selecting from another derived table
+                # https://docs.looker.com/data-modeling/learning-lookml/sql-and-referring-to-lookml
+                view_name = table.split(".")[0]
+                upstreams.update(
+                    _get_upstream_datasets(view_name, raw_views, connection)
+                )
+            else:
+                upstreams.add(_to_dataset_id(table, connection))
     except Exception as e:
         logger.warning(f"Failed to parse SQL:\n{sql}\n\nError:{e}")
-        return upstream
 
-    for table in tables:
-        if table.endswith(".SQL_TABLE_NAME"):
-            # Selecting from another derived table
-            # https://docs.looker.com/data-modeling/learning-lookml/sql-and-referring-to-lookml
-            view_name = table.split(".")[0]
-            upstream.update(_get_upstream_datasets(view_name, raw_views, connection))
-        else:
-            upstream.add(_to_dataset_id(table, connection))
-
-    return upstream
+    return upstreams
 
 
 def fullname(model: str, name: str) -> str:

--- a/metaphor/looker/lookml_parser.py
+++ b/metaphor/looker/lookml_parser.py
@@ -137,7 +137,7 @@ def _extract_upstream_datasets_from_sql(
 ) -> Set[EntityId]:
     upstreams: Set[EntityId] = set()
     try:
-        # replace the referenced view name with real view name
+        # strip the brackets around referenced view name
         sql = re.sub(r"\${(.+\.SQL_TABLE_NAME)}", r"\1", sql)
 
         # parse SQL tables

--- a/poetry.lock
+++ b/poetry.lock
@@ -1468,7 +1468,7 @@ secure-local-storage = ["keyring (!=16.1.0,<24.0.0)"]
 
 [[package]]
 name = "sql-metadata"
-version = "2.2.2"
+version = "2.3.0"
 description = "Uses tokenized query returned by python-sqlparse and generates query metadata"
 category = "main"
 optional = true
@@ -1647,7 +1647,7 @@ tableau = ["tableauserverclient"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<3.11"  # See https://github.com/googleapis/python-bigquery/issues/856
-content-hash = "ac0ccb0b2af3af3126ae870f76cbca803e4902e6530d7c2065a27dd543459223"
+content-hash = "dc0db3b68fa7869fdced636bb2987f15a3c468dda1d858c558a6055d029046fc"
 
 [metadata.files]
 anyio = [
@@ -2605,8 +2605,8 @@ snowflake-connector-python = [
     {file = "snowflake_connector_python-2.7.4-cp39-cp39-win_amd64.whl", hash = "sha256:345f08b90cf460ab96c7aaef316f5c3ba4cba23ba37514efbd811a20a4818752"},
 ]
 sql-metadata = [
-    {file = "sql_metadata-2.2.2-py3-none-any.whl", hash = "sha256:eba267a433c1163968ccbc622d4ef24c1dd87f9417978d5b76420e55abbb7252"},
-    {file = "sql_metadata-2.2.2.tar.gz", hash = "sha256:c2ed1e0c6d2e454d7314a7138223d6644c31d213c404df7170bb990a233d9f2e"},
+    {file = "sql_metadata-2.3.0-py3-none-any.whl", hash = "sha256:fdb62bd1aa44e37b30237fb992a68e9a0c01f9f69303590272c6861a27c4f59c"},
+    {file = "sql_metadata-2.3.0.tar.gz", hash = "sha256:eed8c98e7a1bb719ff1f78227c05e07ad61ddec5d5f81e5014179edd28b77cac"},
 ]
 sqlparse = [
     {file = "sqlparse-0.4.2-py3-none-any.whl", hash = "sha256:48719e356bb8b42991bdbb1e8b83223757b93789c00910a616a071910ca4a64d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ requests = "^2.25.1"
 slack-sdk = { version = "^3.5.1", optional = true }
 smart-open = "^5.0.0"
 snowflake-connector-python = { version = "~=2.7.0", optional = true }
-sql-metadata = { version = "2.2.2", optional = true }
+sql-metadata = { version = "2.3.0", optional = true }
 tableauserverclient = { version = "^0.17.0", optional = true }
 
 [tool.poetry.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.26"
+version = "0.10.27"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
### 🤔 Why?

Bring versions up to date. Latest sql-metadata has improved alias handling.

### 🤓 What?

- update sql-metadata and pre-commit versions
- latest version of sql-metadata seems more strict on table names and skipped names like `${abc.xyz}` instead of stripping the `${}` automatically as the previous version does. Being strict is reasonable from SQL parsing perspective, but for lkml SQL references, we have to strip the brackets ourselves.
- A little optimization by storing the view upstream with the raw view, so we don't need to parse it again during cross-referencing.

### 🧪 Tested?

Fixed unit tests. 
Run locally against metaphor looker instance.

