### PR TITLE
Add more context to BQ profiler when waiting on jobs to complete [sc-6765]

### DIFF
--- a/metaphor/bigquery/profile/extractor.py
+++ b/metaphor/bigquery/profile/extractor.py
@@ -119,10 +119,16 @@ class BigQueryProfileExtractor(BigQueryExtractor):
                 try:
                     results = [res for res in next(job.result())]
                     BigQueryProfileExtractor._parse_result(results, schema, dataset)
+                    1 / 0
                 except AssertionError as error:
                     logger.error(f"Assertion failed during process results, {error}")
-                except:  # noqa: E722
-                    logger.error("Unknown error during process results")
+                except StopIteration as error:
+                    logger.error(f"Invalid result, {error}")
+                except (IndexError, ValueError, TypeError) as error:
+                    logger.error(f"Unknown error during process results, {error}")
+                except BaseException as error:
+                    jobs.remove(job.job_id)
+                    raise error
 
             # Always remove job from the set, because the job(future) is fulfill
             jobs.remove(job.job_id)

--- a/metaphor/bigquery/profile/extractor.py
+++ b/metaphor/bigquery/profile/extractor.py
@@ -88,8 +88,14 @@ class BigQueryProfileExtractor(BigQueryExtractor):
 
         datasets = [self._profile_table(client, table, jobs) for table in tables]
 
+        counter = 0
         while jobs:
-            logger.info("waiting for jobs to finish ... sleeping for 1s")
+            finished = len(datasets) - len(jobs)
+            if counter % 10 == 0:
+                logger.info(
+                    f"{finished} job done, waiting for {len(jobs)} jobs to finish ..."
+                )
+            counter += 1
             sleep(1)
 
         return datasets
@@ -101,14 +107,24 @@ class BigQueryProfileExtractor(BigQueryExtractor):
         jobs: Set[QueryJob],
     ) -> Dataset:
         def job_callback(job: QueryJob, schema: DatasetSchema, dataset: Dataset):
+            exception = job.exception()
             # The profiling result should only have one row
             if job.result().total_rows != 1:
                 logger.warning(
                     f"Skip {table}, the profiling result is more than one row"
                 )
+            elif exception:
+                logger.error(f"Skip {table}, Google Client error: {exception}")
             else:
-                results = [res for res in next(job.result())]
-                BigQueryProfileExtractor._parse_result(results, schema, dataset)
+                try:
+                    results = [res for res in next(job.result())]
+                    BigQueryProfileExtractor._parse_result(results, schema, dataset)
+                except AssertionError as error:
+                    logger.error(f"Assertion failed during process results, {error}")
+                except:  # noqa: E722
+                    logger.error("Unknown error during process results")
+
+            # Always remove job from the set, because the job(future) is fulfill
             jobs.remove(job.job_id)
 
         dataset = BigQueryProfileExtractor._init_dataset(
@@ -207,7 +223,7 @@ class BigQueryProfileExtractor(BigQueryExtractor):
                 )
             )
 
-        assert index == len(results)
+        assert index == len(results), "index should match number of results"
 
     # See https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#numeric_types
     @staticmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.30"
+version = "0.10.31"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

Currently, connector logs every second when waiting on jobs to complete and did not have enough context about the processing status.

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

- Log every 10 seconds but wake up every second to check if all jobs are completed
- Log number of jobs left and done.
- Handle Google cloud client API error, log the error and skip the table.
- Prevent the connector would keep running forever by properly handling exceptions in the callback.




<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

Manually raise an exception in `parse_result`, the connector complete as normal.

<!--
  Describe how the change was tested end-to-end.
-->
