### PR TITLE
Handle pagination is S3 list objects [sc-6783]

### DIFF
--- a/metaphor/common/storage.py
+++ b/metaphor/common/storage.py
@@ -94,12 +94,11 @@ class S3Storage(BaseStorage):
     def list_files(self, path: str, suffix: Optional[str]) -> List[str]:
         bucket, key = S3Storage.parse_s3_uri(path)
 
-        objects = []
         resp = self._client.list_objects_v2(
             Bucket=bucket,
             Prefix=key,
         )
-        objects.extend(resp.get("Contents", []))
+        objects = resp.get("Contents", [])
 
         while resp["IsTruncated"]:
             resp = self._client.list_objects_v2(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.35"
+version = "0.10.36"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
### 🤔 Why?

the previous implementation of S3 list-objects doesn't support pagination, so if there are more than 1000 items in the bucket sub-directory, some items won't be fetched.

### 🤓 What?

- add pagination support in `list_files`

### 🧪 Tested?

- tested locally against dev s3 bucket, used small batch size to force pagination, works well.
