### PR TITLE
Redshift lineage should use entity IDs for sourceDatasets [sc-6830]

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Each connector is placed under its own directory under [metaphor](./metaphor) an
 | [metaphor.metabase](metaphor/metabase/README.md)                   | Dashboard, lineage                       |
 | [metaphor.postgresql](metaphor/postgresql/README.md)               | Schema, description, statistics          |
 | [metaphor.redshift](metaphor/redshift/README.md)                   | Schema, description, statistics          |
+| [metaphor.redshift.lineage](metaphor/redshift/lineage/README.md)   | Lineage                                  |
+| [metaphor.redshift.profile](metaphor/redshift/profile/README.md)   | Data profile                             |
 | [metaphor.redshift.usage](metaphor/redshift/usage/README.md)       | Usage                                    |
 | [metaphor.snowflake](metaphor/snowflake/README.md)                 | Schema, description, statistics          |
 | [metaphor.snowflake.profile](metaphor/snowflake/profile/README.md) | Data profile                             |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.36"
+version = "0.10.37"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/redshift/lineage/data/result.json
+++ b/tests/redshift/lineage/data/result.json
@@ -8,8 +8,8 @@
       },
       "upstream": {
         "sourceDatasets": [
-          "test.public.s1",
-          "test.public.s2"
+          "DATASET~CFCE7386EFABDA3E3ED4DCD5B69083FC",
+          "DATASET~B077275BCBF5E69AD0DBFCAE3F7E47E4"
         ],
         "transformation": "q1"
       }
@@ -27,7 +27,7 @@
       },
       "upstream": {
         "sourceDatasets": [
-          "test.public.s1"
+          "DATASET~CFCE7386EFABDA3E3ED4DCD5B69083FC"
         ],
         "transformation": "q2"
       }

--- a/tests/redshift/lineage/data/result_view.json
+++ b/tests/redshift/lineage/data/result_view.json
@@ -8,8 +8,8 @@
       },
       "upstream": {
         "sourceDatasets": [
-          "test.public.s1",
-          "test.public.s2"
+          "DATASET~CFCE7386EFABDA3E3ED4DCD5B69083FC",
+          "DATASET~B077275BCBF5E69AD0DBFCAE3F7E47E4"
         ]
       }
     },
@@ -26,7 +26,7 @@
       },
       "upstream": {
         "sourceDatasets": [
-          "test.public.s1"
+          "DATASET~CFCE7386EFABDA3E3ED4DCD5B69083FC"
         ]
       }
     },


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

As title.

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

- Use entity IDs for source datasets.
- Small refactor.
<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

- Fix tests.
- Run redshift lineage connector successfully, manually checked output.
<!--
  Describe how the change was tested end-to-end.
-->
