### PR TITLE
Redshift profiler overflow [sc-6825]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.36"
+version = "0.10.38"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/postgresql/profile/test_extractor.py
+++ b/tests/postgresql/profile/test_extractor.py
@@ -39,8 +39,8 @@ def test_build_profiling_query():
 
     expected = (
         'SELECT COUNT(1), COUNT(DISTINCT "id"), COUNT(DISTINCT "price"), '
-        'COUNT("price"), MIN("price"), MAX("price"), AVG("price"), '
-        'COUNT(DISTINCT "year"), COUNT("year"), MIN("year"), MAX("year"), AVG("year") '
+        'COUNT("price"), MIN("price"), MAX("price"), AVG("price"::double precision), '
+        'COUNT(DISTINCT "year"), COUNT("year"), MIN("year"), MAX("year"), AVG("year"::double precision) '
         "FROM foo"
     )
 
@@ -59,7 +59,7 @@ def test_build_profiling_query_with_sampling():
 
     expected = (
         'SELECT COUNT(1), COUNT(DISTINCT "id"), COUNT(DISTINCT "price"), '
-        'COUNT("price"), MIN("price"), MAX("price"), AVG("price") '
+        'COUNT("price"), MIN("price"), MAX("price"), AVG("price"::double precision) '
         "FROM foo WHERE random() < 0.01"
     )
 


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

Redshift profiler gets `ERROR:metaphor.common.extractor:Numeric data overflow (addition)`. Root cause most likely is calculating the average when the sum of column exceeds `bigint` range.

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

- Cast to float before calculating the average.
- Handle some SQL errors to keep the connecter finished smoothly.

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

Run connector locally.
<!--
  Describe how the change was tested end-to-end.
-->
