### PR TITLE
FileNotFoundError for crawlers [sc-6870]

### DIFF
--- a/metaphor/common/storage.py
+++ b/metaphor/common/storage.py
@@ -52,9 +52,14 @@ class LocalStorage(BaseStorage):
             fp.write(payload)
 
     def list_files(self, path: str, suffix: Optional[str]) -> List[str]:
+        directory = os.path.expanduser(path)
+        if not os.path.isdir(directory):
+            logger.error(f"path {path} is not a directory")
+            return []
+
         return [
-            os.path.join(path, file)
-            for file in os.listdir(path)
+            os.path.join(directory, file)
+            for file in os.listdir(directory)
             if suffix is None or file.endswith(suffix)
         ]
 

--- a/tests/common/test_storage.py
+++ b/tests/common/test_storage.py
@@ -1,4 +1,7 @@
-from metaphor.common.storage import S3Storage
+import os
+import tempfile
+
+from metaphor.common.storage import LocalStorage, S3Storage
 
 
 def test_parse_s3_uri():
@@ -15,3 +18,14 @@ def test_parse_s3_uri():
     bucket, key = s3_storage.parse_s3_uri("s3://buc/")
     assert bucket == "buc"
     assert key == ""
+
+
+def test_local_storage(test_root_dir):
+    storage = LocalStorage()
+
+    # non-exist directory
+    assert storage.list_files("foo/bar/abc123", ".json") == []
+
+    # mkstemp may create more than 1 temp files
+    _, temp_file = tempfile.mkstemp(suffix=".tmp")
+    assert len(storage.list_files(os.path.dirname(temp_file), ".tmp")) > 0


### PR DESCRIPTION
### 🤔 Why?

Local storage threw an error when the directory doesn't exist, also it doesn't expand `~`

### 🤓 What?

- Add directory expansion and existence check. 

### 🧪 Tested?

Tested locally 
unit test