### PR TITLE
Do not crawl BQ partitioned tables [sc-6868]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.39"
+version = "0.10.40"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/bigquery/usage/data/sample_log.json
+++ b/tests/bigquery/usage/data/sample_log.json
@@ -147,7 +147,7 @@
           "granted": true
         }
       ],
-      "resourceName": "projects/metaphor-data/datasets/foo_1/tables/event_desc",
+      "resourceName": "projects/metaphor-data/datasets/foo_1/tables/event_desc$1234",
       "metadata": {
         "tableDataRead": {
           "fields": ["event_name", "description"],
@@ -233,6 +233,45 @@
           "fields": ["event_name", "description"],
           "reason": "JOB",
           "jobName": "projects/metaphor-data/jobs/bquxjob_44f8d21_17e36399705"
+        },
+        "@type": "type.googleapis.com/google.cloud.audit.BigQueryAuditMetadata"
+      }
+    }
+  },{
+    "logName": "dummy",
+    "resource": {
+      "type": "bigquery_dataset",
+      "labels": {
+        "project_id": "metaphor-data",
+        "dataset_id": "foo_1"
+      }
+    },
+    "insertId": "-27fffyepstux",
+    "severity": "INFO",
+    "timestamp": "2022-01-07T16:55:32.457930Z",
+    "protoPayload": {
+      "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+      "status": {},
+      "authenticationInfo": { "principalEmail": "dev@metaphor.io" },
+      "requestMetadata": {
+        "callerIp": "127.0.0.1",
+        "callerSuppliedUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36,gzip(gfe),gzip(gfe)"
+      },
+      "serviceName": "bigquery.googleapis.com",
+      "methodName": "google.cloud.bigquery.v2.JobService.InsertJob",
+      "authorizationInfo": [
+        {
+          "resource": "projects/metaphor-data/datasets/foo_1/tables/bar_1",
+          "permission": "bigquery.tables.getData",
+          "granted": true
+        }
+      ],
+      "resourceName": "projects/metaphor-data/datasets/_foo_1/tables/bar_1",
+      "metadata": {
+        "tableDataRead": {
+          "fields": ["event_dimensions.hostname", "event_name"],
+          "reason": "JOB",
+          "jobName": "projects/metaphor-data/jobs/bquxjob_629dc54_17e357780b7"
         },
         "@type": "type.googleapis.com/google.cloud.audit.BigQueryAuditMetadata"
       }


### PR DESCRIPTION
### 🤔 Why?

Sometimes the BQ logs TableResources contains table names with partition attached, it may also contain temporary tables. Need to do sanitization before we collect the data.

### 🤓 What?

- strip table partition and skip temporary tables in BQ usage crawler
- add logging to show progress

### 🧪 Tested?

unit tests to cover those cases
tested against production env
