### PR TITLE
Add application to snowflake connector [sc-6880]

### DIFF
--- a/metaphor/snowflake/auth.py
+++ b/metaphor/snowflake/auth.py
@@ -15,6 +15,10 @@ except ImportError:
     raise
 
 
+METAPHOR_DATA = "MetaphorData"
+METAPHOR_DATA_SNOWFLAKE_CONNECTOR = "MetaphorData_SnowflakeConnector"
+
+
 @deserialize
 @dataclass
 class SnowflakeKeyPairAuthConfig:
@@ -42,7 +46,7 @@ class SnowflakeAuthConfig(BaseConfig):
     default_database: Optional[str] = None
 
     # the query tags for each snowflake query the connector issues
-    query_tag: Optional[str] = "MetaphorData"
+    query_tag: Optional[str] = METAPHOR_DATA
 
 
 def connect(config: SnowflakeAuthConfig) -> snowflake.connector.SnowflakeConnection:
@@ -53,6 +57,7 @@ def connect(config: SnowflakeAuthConfig) -> snowflake.connector.SnowflakeConnect
             user=config.user,
             password=config.password,
             database=config.default_database,
+            application=METAPHOR_DATA_SNOWFLAKE_CONNECTOR,
             session_parameters={
                 "QUERY_TAG": config.query_tag,
             },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.40"
+version = "0.10.41"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
### 🤔 Why?

For best practice mentioned in https://drive.google.com/file/d/16V4DH5t5YUiv2ABD_i57gGL1QHm4tki9/view, we should set `application='PartnerName_ToolName’`

### 🤓 What?

- add application name in the snowflake connection

### 🧪 Tested?

tested the snowflake crawler locally against metaphor instance.
