### PR TITLE
Add application to snowflake connector [sc-6880]

### DIFF
--- a/metaphor/snowflake/auth.py
+++ b/metaphor/snowflake/auth.py
@@ -87,6 +87,7 @@ def connect(config: SnowflakeAuthConfig) -> snowflake.connector.SnowflakeConnect
             user=config.user,
             private_key=pkb,
             database=config.default_database,
+            application=METAPHOR_DATA_SNOWFLAKE_CONNECTOR,
             session_parameters={
                 "QUERY_TAG": config.query_tag,
             },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.41"
+version = "0.10.42"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
### 🤔 Why?

Forgot we have two snowflake auth method

### 🤓 What?

- Add `application` name to all snowflake auth connections

### 🧪 Tested?

locally run the crawler
