### PR TITLE
fix profiler import

### DIFF
--- a/metaphor/postgresql/profile/extractor.py
+++ b/metaphor/postgresql/profile/extractor.py
@@ -1,7 +1,7 @@
+import asyncio
 import traceback
 from typing import Collection, Iterable, List
 
-from black import asyncio
 from metaphor.models.metadata_change_event import (
     Dataset,
     DatasetFieldStatistics,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.43"
+version = "0.10.44"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
### 🤔 Why?

Error `Runtime.ImportModuleError: Unable to import module 'functions.redshift.profile.handler': No module named 'black'`

### 🤓 What?

- Fix PostgreSQL profiler import

### 🧪 Tested?

local crawler run 
