### PR TITLE
Use pydantic.parse_obj_as

### DIFF
--- a/metaphor/common/base_config.py
+++ b/metaphor/common/base_config.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 import yaml
+from pydantic import parse_obj_as
 from pydantic.dataclasses import dataclass
 from smart_open import open
 
@@ -29,4 +30,4 @@ class BaseConfig:
     def from_yaml_file(cls, path: str) -> "BaseConfig":
         with open(path, encoding="utf8") as fin:
             obj = yaml.safe_load(fin.read())
-            return cls(**obj)
+            return parse_obj_as(cls, obj)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.46"
+version = "0.10.47"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/common/test_config.py
+++ b/tests/common/test_config.py
@@ -1,4 +1,5 @@
 import pytest
+from pydantic import ValidationError
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.api_sink import ApiSinkConfig
@@ -18,12 +19,12 @@ def test_yaml_config(test_root_dir):
 
 
 def test_yaml_config_with_missing_config(test_root_dir):
-    with pytest.raises(TypeError):
+    with pytest.raises(ValidationError):
         BaseConfig.from_yaml_file(f"{test_root_dir}/common/configs/missing.yml")
 
 
 def test_yaml_config_with_extra_config(test_root_dir):
-    with pytest.raises(TypeError):
+    with pytest.raises(ValidationError):
         BaseConfig.from_yaml_file(f"{test_root_dir}/common/configs/extend.yml")
 
 


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

It is better to use `parse_obj_as`, instead of using dataclass constructor.
<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

- Use `pydantic.parse_obj_as` after yaml loaded.
<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

Run a connector successfully.
<!--
  Describe how the change was tested end-to-end.
-->
