### PR TITLE
Add PostgreSQL usage crawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,25 +37,27 @@ Similarly, you can also install the package using `requirements.txt` or `pyproje
 
 Each connector is placed under its own directory under [metaphor](./metaphor) and extends the `metaphor.common.BaseExtractor` class.
 
-| Connector                                                          | Metadata                                 |
-|--------------------------------------------------------------------|------------------------------------------|  
-| [metaphor.bigquery](metaphor/bigquery/README.md)                   | Schema, description, statistics          |
-| [metaphor.bigquery.lineage](metaphor/bigquery/lineage/README.md)   | Lineage                                  |
-| [metaphor.bigquery.profile](metaphor/bigquery/profile/README.md)   | Data profile                             |
-| [metaphor.bigquery.usage](metaphor/bigquery/usage/README.md)       | Data usage                               |
-| [metaphor.dbt](metaphor/dbt/README.md)                             | dbt model, test, lineage                 |
-| [metaphor.google_directory](metaphor/google_directory/README.md)   | User profile                             |
-| [metaphor.looker](metaphor/looker/README.md)                       | Looker view, explore, dashboard, lineage |
-| [metaphor.metabase](metaphor/metabase/README.md)                   | Dashboard, lineage                       |
-| [metaphor.postgresql](metaphor/postgresql/README.md)               | Schema, description, statistics          |
-| [metaphor.redshift](metaphor/redshift/README.md)                   | Schema, description, statistics          |
-| [metaphor.redshift.lineage](metaphor/redshift/lineage/README.md)   | Lineage                                  |
-| [metaphor.redshift.profile](metaphor/redshift/profile/README.md)   | Data profile                             |
-| [metaphor.redshift.usage](metaphor/redshift/usage/README.md)       | Usage                                    |
-| [metaphor.snowflake](metaphor/snowflake/README.md)                 | Schema, description, statistics          |
-| [metaphor.snowflake.profile](metaphor/snowflake/profile/README.md) | Data profile                             |
-| [metaphor.snowflake.usage](metaphor/snowflake/usage/README.md)     | Data usage                               |
-| [metaphor.tableau](metaphor/tableau/README.md)                     | Dashboard, lineage                       |
+| Connector                                                             | Metadata                                 |
+|-----------------------------------------------------------------------|------------------------------------------|  
+| [metaphor.bigquery](metaphor/bigquery/README.md)                      | Schema, description, statistics          |
+| [metaphor.bigquery.lineage](metaphor/bigquery/lineage/README.md)      | Lineage                                  |
+| [metaphor.bigquery.profile](metaphor/bigquery/profile/README.md)      | Data profile                             |
+| [metaphor.bigquery.usage](metaphor/bigquery/usage/README.md)          | Data usage                               |
+| [metaphor.dbt](metaphor/dbt/README.md)                                | dbt model, test, lineage                 |
+| [metaphor.google_directory](metaphor/google_directory/README.md)      | User profile                             |
+| [metaphor.looker](metaphor/looker/README.md)                          | Looker view, explore, dashboard, lineage |
+| [metaphor.metabase](metaphor/metabase/README.md)                      | Dashboard, lineage                       |
+| [metaphor.postgresql](metaphor/postgresql/README.md)                  | Schema, description, statistics          |
+| [metaphor.postgresql.profile](metaphor/postgresql/profile/README.md)  | Data profile                             |
+| [metaphor.postgresql.usage](metaphor/postgresql/usage/README.md)      | Usage                                    |
+| [metaphor.redshift](metaphor/redshift/README.md)                      | Schema, description, statistics          |
+| [metaphor.redshift.lineage](metaphor/redshift/lineage/README.md)      | Lineage                                  |
+| [metaphor.redshift.profile](metaphor/redshift/profile/README.md)      | Data profile                             |
+| [metaphor.redshift.usage](metaphor/redshift/usage/README.md)          | Usage                                    |
+| [metaphor.snowflake](metaphor/snowflake/README.md)                    | Schema, description, statistics          |
+| [metaphor.snowflake.profile](metaphor/snowflake/profile/README.md)    | Data profile                             |
+| [metaphor.snowflake.usage](metaphor/snowflake/usage/README.md)        | Data usage                               |
+| [metaphor.tableau](metaphor/tableau/README.md)                        | Dashboard, lineage                       |
 
 ## Development
 

--- a/metaphor/common/usage_util.py
+++ b/metaphor/common/usage_util.py
@@ -47,9 +47,8 @@ class UsageUtil:
         return dataset
 
     @staticmethod
-    def update_table_and_columns_usage(
+    def update_table_usage(
         usage: DatasetUsage,
-        columns: List[str],
         start_time: datetime,
         utc_now: datetime,
     ):
@@ -67,6 +66,15 @@ class UsageUtil:
 
         if start_time > utc_now - timedelta(365):
             usage.query_counts.last365_days.count += 1
+
+    @staticmethod
+    def update_table_and_columns_usage(
+        usage: DatasetUsage,
+        columns: List[str],
+        start_time: datetime,
+        utc_now: datetime,
+    ):
+        UsageUtil.update_table_usage(usage, start_time, utc_now)
 
         for column_name in columns:
             if start_time > utc_now - timedelta(1):
@@ -108,9 +116,7 @@ class UsageUtil:
             query_counts.append(FieldQueryCount(field=column, count=1.0))
 
     @staticmethod
-    def calculate_statistics(datasets: Collection[Dataset]) -> None:
-        """Calculate statistics for the extracted usage info"""
-
+    def calculate_table_statstics(datasets: Collection[Dataset]) -> None:
         UsageUtil.calculate_table_percentile(
             datasets, lambda dataset: dataset.usage.query_counts.last24_hours
         )
@@ -130,6 +136,11 @@ class UsageUtil:
         UsageUtil.calculate_table_percentile(
             datasets, lambda dataset: dataset.usage.query_counts.last365_days
         )
+
+    @staticmethod
+    def calculate_statistics(datasets: Collection[Dataset]) -> None:
+        """Calculate statistics for the extracted usage info"""
+        UsageUtil.calculate_table_statstics(datasets)
 
         for dataset in datasets:
             UsageUtil.calculate_column_percentile(

--- a/metaphor/common/usage_util.py
+++ b/metaphor/common/usage_util.py
@@ -47,8 +47,9 @@ class UsageUtil:
         return dataset
 
     @staticmethod
-    def update_table_usage(
+    def update_table_and_columns_usage(
         usage: DatasetUsage,
+        columns: List[str],
         start_time: datetime,
         utc_now: datetime,
     ):
@@ -66,15 +67,6 @@ class UsageUtil:
 
         if start_time > utc_now - timedelta(365):
             usage.query_counts.last365_days.count += 1
-
-    @staticmethod
-    def update_table_and_columns_usage(
-        usage: DatasetUsage,
-        columns: List[str],
-        start_time: datetime,
-        utc_now: datetime,
-    ):
-        UsageUtil.update_table_usage(usage, start_time, utc_now)
 
         for column_name in columns:
             if start_time > utc_now - timedelta(1):
@@ -116,7 +108,9 @@ class UsageUtil:
             query_counts.append(FieldQueryCount(field=column, count=1.0))
 
     @staticmethod
-    def calculate_table_statstics(datasets: Collection[Dataset]) -> None:
+    def calculate_statistics(datasets: Collection[Dataset]) -> None:
+        """Calculate statistics for the extracted usage info"""
+
         UsageUtil.calculate_table_percentile(
             datasets, lambda dataset: dataset.usage.query_counts.last24_hours
         )
@@ -136,11 +130,6 @@ class UsageUtil:
         UsageUtil.calculate_table_percentile(
             datasets, lambda dataset: dataset.usage.query_counts.last365_days
         )
-
-    @staticmethod
-    def calculate_statistics(datasets: Collection[Dataset]) -> None:
-        """Calculate statistics for the extracted usage info"""
-        UsageUtil.calculate_table_statstics(datasets)
 
         for dataset in datasets:
             UsageUtil.calculate_column_percentile(

--- a/metaphor/postgresql/usage/README.md
+++ b/metaphor/postgresql/usage/README.md
@@ -1,0 +1,19 @@
+# PostgreSQL Usage Statistics Connector
+
+This connector extracts usage statistics from a PostgreSQL database using [asyncpg](https://github.com/MagicStack/asyncpg) library.
+
+## Config File
+
+The config file inherits all the required and optional fields from the general PostgreSQL connector [Config File](../README.md#config-file).
+
+## Testing
+
+Follow the [Installation](../../README.md) instructions to install `metaphor-connectors` in your environment (or virtualenv). Make sure to include either `all` or `postgresql` extra.
+
+To test the connector locally, change the config file to output to a local path and run the following command
+
+```shell
+python -m metaphor.postgresql.usage <config_file>
+```
+
+Manually verify the output after the run finishes.

--- a/metaphor/postgresql/usage/__main__.py
+++ b/metaphor/postgresql/usage/__main__.py
@@ -1,0 +1,6 @@
+from metaphor.common.cli import cli_main
+
+from .extractor import PostgreSQLUsageExtractor
+
+if __name__ == "__main__":
+    cli_main("PostgreSQL usage metadata extractor", PostgreSQLUsageExtractor)

--- a/metaphor/postgresql/usage/config.py
+++ b/metaphor/postgresql/usage/config.py
@@ -1,0 +1,8 @@
+from pydantic.dataclasses import dataclass
+
+from metaphor.redshift.config import PostgreSQLRunConfig
+
+
+@dataclass
+class PostgreSQLUsageRunConfig(PostgreSQLRunConfig):
+    pass

--- a/metaphor/postgresql/usage/extractor.py
+++ b/metaphor/postgresql/usage/extractor.py
@@ -1,0 +1,66 @@
+from typing import Collection
+
+from metaphor.models.metadata_change_event import DataPlatform
+
+from metaphor.common.entity_id import dataset_fullname
+from metaphor.common.event_util import ENTITY_TYPES
+from metaphor.common.logger import get_logger
+from metaphor.common.usage_util import UsageUtil
+from metaphor.postgresql.extractor import PostgreSQLExtractor
+from metaphor.postgresql.usage.config import PostgreSQLUsageRunConfig
+
+logger = get_logger(__name__)
+
+
+USAGE_SQL = """
+SELECT schemaname, relname, seq_scan FROM pg_stat_user_tables
+"""
+
+
+class PostgreSQLUsageExtractor(PostgreSQLExtractor):
+    """PostgreSQL usage metadata extractor"""
+
+    @staticmethod
+    def config_class():
+        return PostgreSQLUsageRunConfig
+
+    async def extract(
+        self, config: PostgreSQLUsageRunConfig
+    ) -> Collection[ENTITY_TYPES]:
+        assert isinstance(config, PostgreSQLExtractor.config_class())
+        logger.info(f"Fetching usage metadata from PostgreSQL host {config.host}")
+
+        dataset_filter = config.filter.normalize()
+
+        databases = (
+            await self._fetch_databases(config)
+            if dataset_filter.includes is None
+            else list(dataset_filter.includes.keys())
+        )
+
+        datasets = []
+
+        for db in databases:
+            conn = await self._connect_database(config, db)
+            try:
+                results = await conn.fetch(USAGE_SQL)
+                for row in results:
+                    schema = row["schemaname"]
+                    table_name = row["relname"]
+                    read_count = row["seq_scan"]
+                    full_name = dataset_fullname(db, schema, table_name)
+
+                    if not dataset_filter.include_table(db, schema, table_name):
+                        logger.info(f"Ignore {full_name} due to filter config")
+                        continue
+
+                    dataset = UsageUtil.init_dataset(
+                        None, full_name, DataPlatform.POSTGRESQL
+                    )
+                    dataset.usage.query_counts.last365_days.count = float(read_count)
+                    datasets.append(dataset)
+            finally:
+                await conn.close()
+
+        UsageUtil.calculate_table_statstics(datasets)
+        return datasets

--- a/metaphor/postgresql/usage/extractor.py
+++ b/metaphor/postgresql/usage/extractor.py
@@ -57,10 +57,12 @@ class PostgreSQLUsageExtractor(PostgreSQLExtractor):
                     dataset = UsageUtil.init_dataset(
                         None, full_name, DataPlatform.POSTGRESQL
                     )
+                    dataset.usage.query_counts.last30_days.count = float(read_count)
+                    dataset.usage.query_counts.last90_days.count = float(read_count)
                     dataset.usage.query_counts.last365_days.count = float(read_count)
                     datasets.append(dataset)
             finally:
                 await conn.close()
 
-        UsageUtil.calculate_table_statstics(datasets)
+        UsageUtil.calculate_statistics(datasets)
         return datasets

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.49"
+version = "0.10.50"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.48"
+version = "0.10.49"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

To extract usage metadata from PostgreSQL database.

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

PostgreSQL did not record queries in the database but it can be configured to log to a file. We did not use the log parsing approach because it is more complicated to specify the log path or the log format.

PostgresSQL has a built-in [statistic collector](https://www.postgresql.org/docs/12/monitoring-stats.html#PG-STAT-ALL-TABLES-VIEW). We can easily extract basic usage metadata from it. 

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

Local run connector successfully.
<!--
  Describe how the change was tested end-to-end.
-->
