### PR TITLE
Set quoted_identifiers_ignore_case explicitly to avoid case conversion for quoted identifiers

### DIFF
--- a/metaphor/snowflake/auth.py
+++ b/metaphor/snowflake/auth.py
@@ -57,6 +57,7 @@ def connect(config: SnowflakeAuthConfig) -> snowflake.connector.SnowflakeConnect
             application=METAPHOR_DATA_SNOWFLAKE_CONNECTOR,
             session_parameters={
                 "QUERY_TAG": config.query_tag,
+                "quoted_identifiers_ignore_case": False,
             },
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.52"
+version = "0.10.53"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
### 🤔 Why?

Sometimes the snowflake session param `quoted_identifiers_ignore_case` https://docs.snowflake.com/en/sql-reference/identifiers-syntax.html#controlling-case-using-the-quoted-identifiers-ignore-case-parameter is set to True by server, causing quoted identifier to be converted to UPPERCASE. This causes error when matching the entities.

### 🤓 What?

- explicitly set quoted_identifiers_ignore_case = False when creating snowflake session. 

### 🧪 Tested?

tested against snowflake instances.

