### PR TITLE
Snowflake usage crawler error [sc-7154]

### DIFF
--- a/metaphor/snowflake/usage/extractor.py
+++ b/metaphor/snowflake/usage/extractor.py
@@ -1,12 +1,10 @@
 import logging
 import math
-from dataclasses import field
 from datetime import datetime
-from typing import Collection, Dict, List, Optional, Tuple
+from typing import Collection, Dict, List, Tuple
 
 from metaphor.models.metadata_change_event import DataPlatform, Dataset
-from pydantic import parse_raw_as
-from pydantic.dataclasses import dataclass
+from pydantic import BaseModel, Field, parse_raw_as
 
 from metaphor.common.event_util import ENTITY_TYPES
 from metaphor.common.extractor import BaseExtractor
@@ -24,21 +22,16 @@ logger = get_logger(__name__)
 logging.getLogger("Parser").setLevel(logging.CRITICAL)
 
 
-@dataclass
-class AccessedObjectColumn:
+class AccessedObjectColumn(BaseModel):
     columnId: int
     columnName: str
 
 
-@dataclass
-class AccessedObject:
+class AccessedObject(BaseModel):
     objectDomain: str = ""
     objectName: str = ""
     objectId: int = 0
-    stageKind: Optional[str] = None
-    columns: List[AccessedObjectColumn] = field(default_factory=lambda: list())
-    location: Optional[str] = None
-    locations: Optional[List[str]] = None
+    columns: List[AccessedObjectColumn] = Field(default_factory=lambda: list())
 
 
 DEFAULT_EXCLUDED_DATABASES: DatabaseFilter = {"SNOWFLAKE": None}

--- a/metaphor/snowflake/usage/extractor.py
+++ b/metaphor/snowflake/usage/extractor.py
@@ -33,7 +33,7 @@ class AccessedObjectColumn:
 @dataclass
 class AccessedObject:
     objectDomain: str = ""
-    objectName: str = "None"
+    objectName: str = ""
     objectId: int = 0
     stageKind: Optional[str] = None
     columns: List[AccessedObjectColumn] = field(default_factory=lambda: list())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.53"
+version = "0.10.54"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/snowflake/usage/test_parser.py
+++ b/tests/snowflake/usage/test_parser.py
@@ -1,3 +1,4 @@
+import json
 from typing import List
 
 from metaphor.models.metadata_change_event import (
@@ -6,11 +7,12 @@ from metaphor.models.metadata_change_event import (
     QueryCount,
     QueryCounts,
 )
+from pydantic import parse_raw_as
 
 from metaphor.common.event_util import EventUtil
 from metaphor.common.filter import DatasetFilter
 from metaphor.common.utils import start_of_day
-from metaphor.snowflake.usage.extractor import SnowflakeUsageExtractor
+from metaphor.snowflake.usage.extractor import AccessedObject, SnowflakeUsageExtractor
 from tests.test_utils import load_json
 
 
@@ -81,3 +83,28 @@ def test_parse_access_log(test_root_dir):
     assert results == load_json(
         test_root_dir + "/snowflake/usage/data/parse_query_log_result.json"
     )
+
+
+def test_pydantic_dataclass():
+    data = [
+        {
+            "objectDomain": "Stage",
+            "objectId": 1,
+            "objectName": "DEV.SANDBOX.FOO",
+            "stageKind": "Internal Named",
+        },
+        {
+            "locations": [
+                "s3://datawriterprd-us-east-1/ad46b6f2-3966-404d-8c4f-b1011db05aaa/"
+            ]
+        },
+        {
+            "columns": [{"columnId": 12, "columnName": "BAR"}],
+            "objectDomain": "Table",
+            "objectId": 111,
+            "objectName": "DEV.GO.GATORS",
+        },
+    ]
+
+    result = parse_raw_as(List[AccessedObject], json.dumps(data))
+    assert len(result) == 3


### PR DESCRIPTION
### 🤔 Why?

pydantic validation does not allow unexpected fields in a model. Previous python build-in dataclass simply ignores extra fields. 

The Snowflake access history has different object structures https://docs.snowflake.com/en/user-guide/access-history.html , especially when it's copying for a STAGE or a local file. 

### 🤓 What?

- Add potential fields of access history log in the model as optional with default None
- Check for only table/view `objectDomain` before further processing

### 🧪 Tested?

tested against snowflake instances.
