### PR TITLE
Ignore any Snowflake dataset/schema/table that contains a dot in its name

### DIFF
--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -116,6 +116,13 @@ class SnowflakeExtractor(BaseExtractor):
                 logger.info(f"Ignore {full_name} due to filter config")
                 continue
 
+            # TODO: Support dots in database/schema/table name
+            if "." in database or "." in schema or "." in name:
+                logger.info(
+                    f"Ignore {full_name} due to dot in database, schema, or table name"
+                )
+                continue
+
             self._datasets[full_name] = self._init_dataset(
                 full_name, table_type, comment, row_count, table_bytes
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.60"
+version = "0.10.61"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

While it's possible to use dots in Snowflake dataset/schema/table names, it breaks many of the assumptions in the connector. 

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

This is a temporary workaround by ignoring these tables. The proper fix will require a major refactoring of `LogicalDatasetID` to include database, schema, and table name as separate fields.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Manually tested against production.
