### PR TITLE
Optimize Snowflake profiler performance

### DIFF
--- a/metaphor/snowflake/profile/config.py
+++ b/metaphor/snowflake/profile/config.py
@@ -7,7 +7,33 @@ from metaphor.snowflake.config import SnowflakeRunConfig
 
 
 @dataclass
+class ColumnStatistics:
+    # Compute null and non-null counts
+    null_count: bool = True
+
+    # Compute unique value counts
+    unique_count: bool = False
+
+    # Compute min value
+    min_value: bool = True
+
+    # Compute max value
+    max_value: bool = True
+
+    # Compute average value
+    avg_value: bool = False
+
+    # Compute standard deviation
+    std_dev: bool = False
+
+
+@dataclass
 class SnowflakeProfileRunConfig(SnowflakeRunConfig):
+
+    # Compute specific types of statistics for each column
+    column_statistics: ColumnStatistics = field(
+        default_factory=lambda: ColumnStatistics()
+    )
 
     # Include views in profiling
     include_views: bool = False

--- a/metaphor/snowflake/utils.py
+++ b/metaphor/snowflake/utils.py
@@ -86,7 +86,6 @@ def async_execute(
 
             if results_processor is None:
                 results_map[key] = results
-                print(f"result for {key}")
             else:
                 results_processor(key, results)
 

--- a/metaphor/snowflake/utils.py
+++ b/metaphor/snowflake/utils.py
@@ -86,6 +86,7 @@ def async_execute(
 
             if results_processor is None:
                 results_map[key] = results
+                print(f"result for {key}")
             else:
                 results_processor(key, results)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.66"
+version = "0.10.68"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.65"
+version = "0.10.66"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/snowflake/profile/config.yml
+++ b/tests/snowflake/profile/config.yml
@@ -3,6 +3,13 @@ account: account
 user: user
 password: password
 default_database: database
+column_statistics:
+  null_count: true
+  unique_count: true
+  min_value: true
+  max_value: true
+  avg_value: true
+  std_dev: true
 filter:
   includes:
     foo:

--- a/tests/snowflake/profile/test_config.py
+++ b/tests/snowflake/profile/test_config.py
@@ -1,6 +1,9 @@
 from metaphor.common.base_config import OutputConfig
 from metaphor.common.filter import DatasetFilter
-from metaphor.snowflake.profile.config import SnowflakeProfileRunConfig
+from metaphor.snowflake.profile.config import (
+    ColumnStatistics,
+    SnowflakeProfileRunConfig,
+)
 
 
 def test_yaml_config(test_root_dir):
@@ -13,6 +16,14 @@ def test_yaml_config(test_root_dir):
         user="user",
         password="password",
         default_database="database",
+        column_statistics=ColumnStatistics(
+            null_count=True,
+            unique_count=True,
+            min_value=True,
+            max_value=True,
+            avg_value=True,
+            std_dev=True,
+        ),
         filter=DatasetFilter(includes={"foo": None, "bar": None}, excludes=None),
         output=OutputConfig(),
     )


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

The current profiler can take an exceedingly long time to run against a large number of tables.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

This PR introduced 2 optimizations:
1. Make profiling of each type of column statistics configurable and disable the expensive statistics (unique count, average, standard deviation)  by default.
2. Batch process the entire `information_schema.columns` instead of issuing individual queries for each table. This reduces the time from 10+ minutes to 10s for 1000 tables.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Finished profiling against 1500 tables within 10 mins, instead of hours w/o the optimization.
