### PR TITLE
Simplify Power BI connector setup by using read-only admin APIs exclusively

### DIFF
--- a/metaphor/power_bi/README.md
+++ b/metaphor/power_bi/README.md
@@ -1,22 +1,23 @@
-# PowerBI Connector
+# Power BI Connector
 
-This connector extracts technical metadata from PowerBI workspaces using [Power BI REST APIs](https://docs.microsoft.com/en-us/rest/api/power-bi/).
+This connector extracts technical metadata from Power BI workspaces using [Read-only Power BI admin APIs](https://docs.microsoft.com/en-us/power-bi/enterprise/read-only-apis-service-principal-authentication).
 
 ## Setup
 
 We recommend creating a dedicated Azure AD Application and a dedicated security group for the connector to use.
 
-1. Follow [Microsoft doc](https://docs.microsoft.com/en-us/power-bi/developer/embedded/embed-service-principal) to create an app and a security group. Add the app's [service principal](https://docs.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals#service-principal-object) to the security group.
+1. Follow Step 1 & 2 in [this doc](https://docs.microsoft.com/en-us/power-bi/developer/embedded/embed-service-principal) to create an Azure AD app, the client secret, and add the app's service principal to a new security group.
 
-> Note: Make sure the app did not have any extra Power BI permission granted. See Step 3 of this [doc](https://docs.microsoft.com/en-us/power-bi/admin/read-only-apis-service-principal-authentication#method) for more details.
+> Note: Make sure to NOT add any Power BI Service permissions to the app. Doing so will lead to authentication errors when calling the APIs. See [this notice](https://docs.microsoft.com/en-us/power-bi/enterprise/read-only-apis-service-principal-authentication#:~:text=Make%20sure%20there%20are%20no%20Power%20BI%20admin%2Dconsent%2Drequired%20permissions%20set%20on%20this%20application.%20For%20more%20information%2C%20see%20Managing%20consent%20to%20applications%20and%20evaluating%20consent%20requests.) for more details.
 
-2. Log into [PowerBI Admin Poral](https://app.powerbi.com/admin-portal/tenantSettings), enable the following settings for the security group created in the previous step: 
-    - Allow service principals to use Power BI APIs
+2. Log into [Power BI Admin Portal](https://app.powerbi.com/admin-portal/tenantSettings) as a Power BI admin, enable the following settings under **Admin API settings** for the security group created in the previous step:
     - Allow service principals to use read-only Power BI admin APIs
     - Enhance admin APIs responses with detailed metadata
+    - Enhance admin APIs responses with DAX and mashup expressions
 
-3. Add the security group or service principal to all workspaces of interest. See: [Add the service principal to your workspace](https://docs.microsoft.com/en-us/power-bi/developer/embedded/embed-service-principal#step-4---add-the-service-principal-to-your-workspace)
+For example,
 
+![](https://docs.microsoft.com/en-us/power-bi/enterprise/media/read-only-apis-service-principal-auth/allow-service-principals-tenant-setting.png)
 
 ## Config File
 
@@ -25,7 +26,7 @@ Create a YAML config file based on the following template.
 ### Required Configurations
 
 ```yaml
-tenant_id: <tenant_id>  # The PowerBI tenant ID
+tenant_id: <tenant_id>  # The Power BI tenant ID
 
 client_id: <client_id>  # The Azure Application client id
 
@@ -38,7 +39,7 @@ output:
 
 ### Optional Configurations
 
-By default, the connector will connect all workspaces under a tenant (organization). You can explicit configure workspaces you want to connect.
+By default, the connector will connect all workspaces under a tenant (organization). You can explicitly configure workspaces you want to connect.
 
 ```yaml
 workspaces:
@@ -57,9 +58,3 @@ python -m metaphor.power_bi <config_file>
 ```
 
 Manually verify the output after the command finishes.
-
-## Troubleshooting
-
-1. `GET https://api.powerbi.com/v1.0/myorg/groups failed`: Make sure the security group is given access to "Power BI APIs" in Power BI Admin Portal.
-2. `API is not accessible for application`: Make sure the security group is given access to "Read-only Power BI admin APIs" in Power BI Admin Portal.
-3. `PowerBINotAuthorizedException`: Make sure to add the security principal to the Power BI workspaces.

--- a/metaphor/power_bi/README.md
+++ b/metaphor/power_bi/README.md
@@ -6,11 +6,13 @@ This connector extracts technical metadata from Power BI workspaces using [Read-
 
 We recommend creating a dedicated Azure AD Application and a dedicated security group for the connector to use.
 
-1. Follow Step 1 & 2 in [this doc](https://docs.microsoft.com/en-us/power-bi/developer/embedded/embed-service-principal) to create an Azure AD app, the client secret, and add the app's service principal to a new security group.
+1. Follow Step 1 of [this doc](https://docs.microsoft.com/en-us/power-bi/developer/embedded/embed-service-principal#step-1---create-an-azure-ad-app) to create an Azure AD app and a client secret.
 
 > Note: Make sure to NOT add any Power BI Service permissions to the app. Doing so will lead to authentication errors when calling the APIs. See [this notice](https://docs.microsoft.com/en-us/power-bi/enterprise/read-only-apis-service-principal-authentication#:~:text=Make%20sure%20there%20are%20no%20Power%20BI%20admin%2Dconsent%2Drequired%20permissions%20set%20on%20this%20application.%20For%20more%20information%2C%20see%20Managing%20consent%20to%20applications%20and%20evaluating%20consent%20requests.) for more details.
 
-2. Log into [Power BI Admin Portal](https://app.powerbi.com/admin-portal/tenantSettings) as a Power BI admin, enable the following settings under **Admin API settings** for the security group created in the previous step:
+2. Follow [this doc](https://docs.microsoft.com/en-us/azure/active-directory/fundamentals/active-directory-groups-create-azure-portal#create-a-basic-group-and-add-members) to create a security group and add the app's service principal as a member.
+
+3. Log into [Power BI Admin Portal](https://app.powerbi.com/admin-portal/tenantSettings) as a Power BI admin, enable the following settings under **Admin API settings** for the security group created in the previous step:
     - Allow service principals to use read-only Power BI admin APIs
     - Enhance admin APIs responses with detailed metadata
     - Enhance admin APIs responses with DAX and mashup expressions

--- a/metaphor/power_bi/README.md
+++ b/metaphor/power_bi/README.md
@@ -6,7 +6,7 @@ This connector extracts technical metadata from Power BI workspaces using [Read-
 
 We recommend creating a dedicated Azure AD Application and a dedicated security group for the connector to use.
 
-1. Follow Step 1 of [this doc](https://docs.microsoft.com/en-us/power-bi/developer/embedded/embed-service-principal#step-1---create-an-azure-ad-app) to create an Azure AD app and a client secret.
+1. Follow [Step 1 of this doc](https://docs.microsoft.com/en-us/power-bi/developer/embedded/embed-service-principal#step-1---create-an-azure-ad-app) to create an Azure AD app and a client secret.
 
 > Note: Make sure to NOT add any Power BI Service permissions to the app. Doing so will lead to authentication errors when calling the APIs. See [this notice](https://docs.microsoft.com/en-us/power-bi/enterprise/read-only-apis-service-principal-authentication#:~:text=Make%20sure%20there%20are%20no%20Power%20BI%20admin%2Dconsent%2Drequired%20permissions%20set%20on%20this%20application.%20For%20more%20information%2C%20see%20Managing%20consent%20to%20applications%20and%20evaluating%20consent%20requests.) for more details.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.70"
+version = "0.10.71"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/power_bi/expected.json
+++ b/tests/power_bi/expected.json
@@ -75,12 +75,50 @@
   },
   {
     "dashboardInfo": {
-      "charts": [],
+      "charts": [
+        {
+          "title": "First Chart",
+          "url": ""
+        },
+        {
+          "title": "Third Chart",
+          "url": ""
+        }
+      ],
       "powerBiDashboardType": "DASHBOARD",
       "title": "Dashboard A",
       "url": "https://powerbi.com/dashboard/dashboard-1"
     },
     "logicalId": { "dashboardId": "dashboard-1", "platform": "POWER_BI" },
-    "upstream": { "sourceVirtualViews": [] }
-  }
+    "upstream": {
+      "sourceVirtualViews": [
+        "VIRTUAL_VIEW~2322FD3B8CE1D90D543947822929BBF3",
+        "VIRTUAL_VIEW~F072F23068858B3959BEE11F79071794"
+      ]
+    }
+  },
+  {
+    "dashboardInfo": {
+      "charts": [
+        {
+          "title": "Second Chart",
+          "url": ""
+        },
+        {
+          "title": "Third Chart",
+          "url": ""
+        }
+      ],
+      "powerBiDashboardType": "DASHBOARD",
+      "title": "Dashboard B",
+      "url": "https://powerbi.com/dashboard/dashboard-2"
+    },
+    "logicalId": { "dashboardId": "dashboard-2", "platform": "POWER_BI" },
+    "upstream": {
+      "sourceVirtualViews": [
+        "VIRTUAL_VIEW~2322FD3B8CE1D90D543947822929BBF3",
+        "VIRTUAL_VIEW~F072F23068858B3959BEE11F79071794"
+      ]
+    }
+  }  
 ]

--- a/tests/power_bi/test_extractor.py
+++ b/tests/power_bi/test_extractor.py
@@ -64,7 +64,7 @@ async def test_extractor(test_root_dir):
         webUrl=f"https://powerbi.com/dashboard/{dashboard1_id}",
     )
     dashboard2 = PowerBIDashboard(
-        id=dashboard1_id,
+        id=dashboard2_id,
         displayName="Dashboard B",
         webUrl=f"https://powerbi.com/dashboard/{dashboard2_id}",
     )
@@ -182,27 +182,27 @@ async def test_extractor(test_root_dir):
             ],
             dashboards=[
                 WorkspaceInfoDashboard(displayName="Dashboard A", id="dashboard-1"),
-                WorkspaceInfoDashboard(displayName="Dashboard A", id="dashboard-1"),
+                WorkspaceInfoDashboard(displayName="Dashboard B", id="dashboard-2"),
             ],
         )
     )
 
-    def fake_get_dataset(workspace_id, dataset_id) -> PowerBIDataset:
-        return datasets.get(dataset_id)
+    def fake_get_datasets(workspace_id) -> List[PowerBIDataset]:
+        return datasets.values()
 
-    def fake_get_report(workspace_id, report_id) -> PowerBIReport:
-        return reports.get(report_id)
+    def fake_get_reports(workspace_id) -> List[PowerBIReport]:
+        return reports.values()
 
-    def fake_get_dashboard(workspace_id, dashboard_id) -> PowerBIReport:
-        return dashboards.get(dashboard_id)
+    def fake_get_dashboards(workspace_id) -> List[PowerBIReport]:
+        return dashboards.values()
 
-    def fake_get_tiles(workspace_id, dashboard_id) -> List[PowerBITile]:
+    def fake_get_tiles(dashboard_id) -> List[PowerBITile]:
         return tiles.get(dashboard_id)
 
-    mock_instance.get_dataset.side_effect = fake_get_dataset
-    mock_instance.get_report.side_effect = fake_get_report
-    mock_instance.get_dashboard.side_effect = fake_get_dashboard
-    mock_instance.get_tile.side_effect = fake_get_tiles
+    mock_instance.get_datasets.side_effect = fake_get_datasets
+    mock_instance.get_reports.side_effect = fake_get_reports
+    mock_instance.get_dashboards.side_effect = fake_get_dashboards
+    mock_instance.get_tiles.side_effect = fake_get_tiles
 
     with patch("metaphor.power_bi.extractor.PowerBIClient") as mock_client:
         mock_client.return_value = mock_instance


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

[Read-only Power BI admin APIs](https://docs.microsoft.com/en-us/power-bi/enterprise/read-only-apis-service-principal-authentication#method) is a subset of [Power BI REST APIs](https://docs.microsoft.com/en-us/rest/api/power-bi/) that are [specifically designed](https://powerbi.microsoft.com/en-us/blog/announcing-new-admin-apis-and-service-principal-authentication-to-make-for-better-tenant-metadata-scanning/) for metadata extraction. 

By using the admin APIs exclusively, we no longer need to
1. Grant the service principal access to Power BI API
2. Add the service principal to each workspace

It also allows us to extract metadata from personal workspaces (aka "My workspace").

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Replace all existing non-admin API calls with their admin counterpart
- Update README with simplified instructions
- Update tests & fix bugs in original tests

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Manually tested against a production environment.
