### PR TITLE
URL field on DashboardInfo is deprecated write to sourceInfo.mainUrl instead [sc-7604]

### DIFF
--- a/metaphor/power_bi/extractor.py
+++ b/metaphor/power_bi/extractor.py
@@ -34,6 +34,7 @@ from metaphor.models.metadata_change_event import (
 from metaphor.models.metadata_change_event import PowerBIDatasetTable
 from metaphor.models.metadata_change_event import PowerBIMeasure as PbiMeasure
 from metaphor.models.metadata_change_event import (
+    SourceInfo,
     VirtualView,
     VirtualViewLogicalID,
     VirtualViewType,
@@ -404,7 +405,9 @@ class PowerBIExtractor(BaseExtractor):
                     description=wi_report.description,
                     power_bi_dashboard_type=PowerBIDashboardType.REPORT,
                     title=wi_report.name,
-                    url=report.webUrl,
+                ),
+                source_info=SourceInfo(
+                    main_url=report.webUrl,
                 ),
                 upstream=DashboardUpstream(source_virtual_views=[upstream_id]),
             )
@@ -449,7 +452,9 @@ class PowerBIExtractor(BaseExtractor):
                     title=wi_dashboard.displayName,
                     charts=self.transform_tiles_to_charts(tiles),
                     power_bi_dashboard_type=PowerBIDashboardType.DASHBOARD,
-                    url=pbi_dashboard.webUrl,
+                ),
+                source_info=SourceInfo(
+                    main_url=pbi_dashboard.webUrl,
                 ),
                 upstream=DashboardUpstream(source_virtual_views=unique_list(upstream)),
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.71"
+version = "0.10.72"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/power_bi/expected.json
+++ b/tests/power_bi/expected.json
@@ -53,8 +53,10 @@
     "dashboardInfo": {
       "description": "This is a report about foo",
       "powerBiDashboardType": "REPORT",
-      "title": "Foo Report",
-      "url": "https://powerbi.com/report/report-1"
+      "title": "Foo Report"
+    },
+    "sourceInfo": {
+      "mainUrl": "https://powerbi.com/report/report-1"
     },
     "logicalId": { "dashboardId": "report-1", "platform": "POWER_BI" },
     "upstream": {
@@ -65,8 +67,10 @@
     "dashboardInfo": {
       "description": "This is a report about bar",
       "powerBiDashboardType": "REPORT",
-      "title": "Bar Report",
-      "url": "https://powerbi.com/report/report-2"
+      "title": "Bar Report"
+    },
+    "sourceInfo": {
+      "mainUrl": "https://powerbi.com/report/report-2"
     },
     "logicalId": { "dashboardId": "report-2", "platform": "POWER_BI" },
     "upstream": {
@@ -86,8 +90,10 @@
         }
       ],
       "powerBiDashboardType": "DASHBOARD",
-      "title": "Dashboard A",
-      "url": "https://powerbi.com/dashboard/dashboard-1"
+      "title": "Dashboard A"
+    },
+    "sourceInfo": {
+      "mainUrl": "https://powerbi.com/dashboard/dashboard-1"
     },
     "logicalId": { "dashboardId": "dashboard-1", "platform": "POWER_BI" },
     "upstream": {
@@ -110,8 +116,10 @@
         }
       ],
       "powerBiDashboardType": "DASHBOARD",
-      "title": "Dashboard B",
-      "url": "https://powerbi.com/dashboard/dashboard-2"
+      "title": "Dashboard B"
+    },
+    "sourceInfo": {
+      "mainUrl": "https://powerbi.com/dashboard/dashboard-2"
     },
     "logicalId": { "dashboardId": "dashboard-2", "platform": "POWER_BI" },
     "upstream": {


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

As title

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

- Write URL to `sourceInfo`.
<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

Manually test PowerBI crawler.
<!--
  Describe how the change was tested end-to-end.
-->
