### PR TITLE
Support BigQuery & handle quotes in sql_table_name

### DIFF
--- a/metaphor/looker/config.py
+++ b/metaphor/looker/config.py
@@ -14,7 +14,7 @@ class LookerConnectionConfig:
 
     # "Account" portion of the resulting Dataset Logical ID.
     # Use Snowflake account for Snowflake connection.
-    account: str
+    account: Optional[str] = None
 
     # Default schema for the connection
     default_schema: Optional[str] = None

--- a/metaphor/looker/lookml_parser.py
+++ b/metaphor/looker/lookml_parser.py
@@ -87,7 +87,7 @@ def _to_dataset_id(source_name: str, connection: LookerConnectionConfig) -> Enti
         raise ValueError(f"Invalid source name {source_name}")
 
     # Normalize dataset name by lower casing & dropping the quotation marks
-    full_name = full_name.replace('"', "").lower()
+    full_name = full_name.replace('"', "").replace("`", "").lower()
 
     return to_dataset_entity_id(full_name, connection.platform, connection.account)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.70"
+version = "0.10.71"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/looker/config.yml
+++ b/tests/looker/config.yml
@@ -9,6 +9,10 @@ connections:
     default_schema: schema1
     platform: SNOWFLAKE
     account: account1
+  conn2:
+    database: db2
+    default_schema: schema2
+    platform: BIGQUERY
 project_source_url: http://foo.bar
 verify_ssl: true
 timeout: 1

--- a/tests/looker/sql_table_name/model.model.lkml
+++ b/tests/looker/sql_table_name/model.model.lkml
@@ -1,0 +1,7 @@
+connection: "bigquery"
+
+include: "/view.view"
+
+explore: explore1 {
+  view_name: "view1"
+}

--- a/tests/looker/sql_table_name/view.view.lkml
+++ b/tests/looker/sql_table_name/view.view.lkml
@@ -1,0 +1,3 @@
+view: view1 {
+  sql_table_name: `SCHEMA1`.table1 ;;
+}

--- a/tests/looker/test_config.py
+++ b/tests/looker/test_config.py
@@ -18,7 +18,12 @@ def test_yaml_config(test_root_dir):
                 default_schema="schema1",
                 platform=DataPlatform.SNOWFLAKE,
                 account="account1",
-            )
+            ),
+            "conn2": LookerConnectionConfig(
+                database="db2",
+                default_schema="schema2",
+                platform=DataPlatform.BIGQUERY,
+            ),
         },
         project_source_url="http://foo.bar",
         verify_ssl=True,


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Currently the Looker connector doesn't work with BigQuery connection as the config file requires the `account` field to be specified. It also fails to remove back-ticks in [sql_table_name](https://docs.looker.com/reference/view-params/sql_table_name-for-view) and generates invalid dataset IDs.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Make `account` field optional in config file and strip back-ticks when normalizing dataset names.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Unit tests.
