### PR TITLE
Support LookML explore extension

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.73"
+version = "0.10.76"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/looker/explore_extension/model.model.lkml
+++ b/tests/looker/explore_extension/model.model.lkml
@@ -1,0 +1,46 @@
+connection: "bigquery"
+
+# simple extension
+explore: explore1 {
+  extends: [base_explore1]
+}
+
+# multiple extensions
+explore: explore2 {
+  extends: [base_explore1, base_explore2, view3]
+}
+
+# chained extensions
+explore: explore3 {
+  extends: [explore1]
+}
+
+# extends with overrides
+explore: explore4 {
+  extends: [explore1]
+  view_name: "view3"
+}
+
+# explore that requires extension
+explore: base_explore1 {
+  view_name: "view1"
+  extension: required
+}
+
+# explore with "from"
+explore: base_explore2 {
+  from: "view2"
+}
+
+# explore without "from" or "view_name" 
+explore: view3 {
+}
+
+view: view1 {
+}
+
+view: view2 {
+}
+
+view: view3 {
+}

--- a/tests/looker/test_lookml_parser.py
+++ b/tests/looker/test_lookml_parser.py
@@ -438,3 +438,143 @@ def test_sql_table_name(test_root_dir):
             ),
         ),
     ]
+
+
+def test_explore_extension(test_root_dir):
+    models_map, virtual_views = parse_project(
+        f"{test_root_dir}/looker/explore_extension", connection_map
+    )
+
+    virtual_view1 = EntityId(
+        EntityType.VIRTUAL_VIEW,
+        VirtualViewLogicalID(name="model.view1", type=VirtualViewType.LOOKER_VIEW),
+    )
+
+    virtual_view2 = EntityId(
+        EntityType.VIRTUAL_VIEW,
+        VirtualViewLogicalID(name="model.view2", type=VirtualViewType.LOOKER_VIEW),
+    )
+
+    virtual_view3 = EntityId(
+        EntityType.VIRTUAL_VIEW,
+        VirtualViewLogicalID(name="model.view3", type=VirtualViewType.LOOKER_VIEW),
+    )
+
+    dataset_view1 = EntityId(
+        EntityType.DATASET,
+        DatasetLogicalID(
+            name="db.schema.view1",
+            platform=DataPlatform.BIGQUERY,
+        ),
+    )
+
+    dataset_view2 = EntityId(
+        EntityType.DATASET,
+        DatasetLogicalID(
+            name="db.schema.view2",
+            platform=DataPlatform.BIGQUERY,
+        ),
+    )
+
+    dataset_view3 = EntityId(
+        EntityType.DATASET,
+        DatasetLogicalID(
+            name="db.schema.view3",
+            platform=DataPlatform.BIGQUERY,
+        ),
+    )
+
+    assert models_map == {
+        "model": Model(
+            explores={
+                "explore1": Explore(name="explore1"),
+                "explore2": Explore(name="explore2"),
+                "explore3": Explore(name="explore3"),
+                "explore4": Explore(name="explore4"),
+                "base_explore1": Explore(name="base_explore1"),
+                "base_explore2": Explore(name="base_explore2"),
+                "view3": Explore(name="view3"),
+            }
+        )
+    }
+
+    assert virtual_views == [
+        VirtualView(
+            logical_id=VirtualViewLogicalID(
+                name="model.view1", type=VirtualViewType.LOOKER_VIEW
+            ),
+            looker_view=LookerView(
+                source_datasets=[str(dataset_view1)],
+            ),
+        ),
+        VirtualView(
+            logical_id=VirtualViewLogicalID(
+                name="model.view2", type=VirtualViewType.LOOKER_VIEW
+            ),
+            looker_view=LookerView(
+                source_datasets=[str(dataset_view2)],
+            ),
+        ),
+        VirtualView(
+            logical_id=VirtualViewLogicalID(
+                name="model.view3", type=VirtualViewType.LOOKER_VIEW
+            ),
+            looker_view=LookerView(
+                source_datasets=[str(dataset_view3)],
+            ),
+        ),
+        VirtualView(
+            logical_id=VirtualViewLogicalID(
+                name="model.explore1", type=VirtualViewType.LOOKER_EXPLORE
+            ),
+            looker_explore=LookerExplore(
+                model_name="model",
+                base_view=str(virtual_view1),
+            ),
+        ),
+        VirtualView(
+            logical_id=VirtualViewLogicalID(
+                name="model.explore2", type=VirtualViewType.LOOKER_EXPLORE
+            ),
+            looker_explore=LookerExplore(
+                model_name="model",
+                base_view=str(virtual_view2),
+            ),
+        ),
+        VirtualView(
+            logical_id=VirtualViewLogicalID(
+                name="model.explore3", type=VirtualViewType.LOOKER_EXPLORE
+            ),
+            looker_explore=LookerExplore(
+                model_name="model",
+                base_view=str(virtual_view1),
+            ),
+        ),
+        VirtualView(
+            logical_id=VirtualViewLogicalID(
+                name="model.explore4", type=VirtualViewType.LOOKER_EXPLORE
+            ),
+            looker_explore=LookerExplore(
+                model_name="model",
+                base_view=str(virtual_view3),
+            ),
+        ),
+        VirtualView(
+            logical_id=VirtualViewLogicalID(
+                name="model.base_explore2", type=VirtualViewType.LOOKER_EXPLORE
+            ),
+            looker_explore=LookerExplore(
+                model_name="model",
+                base_view=str(virtual_view2),
+            ),
+        ),
+        VirtualView(
+            logical_id=VirtualViewLogicalID(
+                name="model.view3", type=VirtualViewType.LOOKER_EXPLORE
+            ),
+            looker_explore=LookerExplore(
+                model_name="model",
+                base_view=str(virtual_view3),
+            ),
+        ),
+    ]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

The current implementation lacks support for [explore extension](https://docs.looker.com/reference/explore-params/extends), which leads to missing lineage.

This PR is similar to https://github.com/MetaphorData/connectors/pull/237 but for explores.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Support all possible forms of explore extensions
- Simple, one-level, one-view extension
- Multiple view extension
- Chained extension

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Unit tests
