### PR TITLE
Fix LookML native derived tables parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.76"
+version = "0.10.77"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/looker/derived_table/model.model.lkml
+++ b/tests/looker/derived_table/model.model.lkml
@@ -3,19 +3,13 @@ connection: "snowflake"
 include: "/view.view"
 
 explore: explore1 {
-  label: "label"
-  description: "description"
   view_name: "view1"
 }
 
 explore: explore2 {
-  label: "label"
-  description: "description"
   view_name: "view2"
 }
 
 explore: explore3 {
-  label: "label3"
-  description: "description3"
   view_name: "view3"
 }

--- a/tests/looker/derived_table/view.view.lkml
+++ b/tests/looker/derived_table/view.view.lkml
@@ -3,19 +3,6 @@ view: view1 {
     sql:
       SELECT * FROM table1 ;;
   }
-
-  dimension: country {
-    type: string
-    description: "The country"
-    sql: ${TABLE}.country ;;
-  }
-
-  measure: average_measurement {
-    group_label: "Measurement"
-    type: average
-    description: "My measurement"
-    sql: ${TABLE}.measurement ;;
-  }
 }
 
 view: view2 {
@@ -23,33 +10,12 @@ view: view2 {
     sql:
       SELECT * FROM ${view1.SQL_TABLE_NAME} ;;
   }
-
-  dimension: country {
-    type: string
-    description: "The country"
-    sql: ${TABLE}.country ;;
-  }
-
-  measure: average_measurement {
-    group_label: "Measurement"
-    type: average
-    description: "My measurement"
-    sql: ${TABLE}.measurement ;;
-  }
 }
 
 view: view3 {
   derived_table: {
-    explore_source: view1 {
-      column: country {
-        field: view1.country
-      }
+    explore_source: explore1 {
+      
     }
-  }
-
-  dimension: country {
-    type: string
-    description: "The country"
-    sql: ${TABLE}.country ;;
   }
 }

--- a/tests/looker/test_lookml_parser.py
+++ b/tests/looker/test_lookml_parser.py
@@ -298,97 +298,67 @@ def test_derived_table(test_root_dir):
     expected = {
         "model": Model(
             explores={
-                "explore1": Explore(
-                    name="explore1",
-                ),
-                "explore2": Explore(
-                    name="explore2",
-                ),
-                "explore3": Explore(
-                    name="explore3",
-                ),
+                "explore1": Explore(name="explore1"),
+                "explore2": Explore(name="explore2"),
+                "explore3": Explore(name="explore3"),
             }
         )
     }
     assert models_map == expected
 
-    assert compare_list_ignore_order(
-        virtual_views,
-        [
-            VirtualView(
-                logical_id=VirtualViewLogicalID(
-                    name="model.view1", type=VirtualViewType.LOOKER_VIEW
-                ),
-                looker_view=LookerView(
-                    dimensions=[
-                        LookerViewDimension(data_type="string", field="country")
-                    ],
-                    measures=[
-                        LookerViewMeasure(field="average_measurement", type="average")
-                    ],
-                    source_datasets=[str(dataset_id)],
-                ),
+    assert virtual_views == [
+        VirtualView(
+            logical_id=VirtualViewLogicalID(
+                name="model.view1", type=VirtualViewType.LOOKER_VIEW
             ),
-            VirtualView(
-                logical_id=VirtualViewLogicalID(
-                    name="model.view2", type=VirtualViewType.LOOKER_VIEW
-                ),
-                looker_view=LookerView(
-                    dimensions=[
-                        LookerViewDimension(data_type="string", field="country")
-                    ],
-                    measures=[
-                        LookerViewMeasure(field="average_measurement", type="average")
-                    ],
-                    source_datasets=[str(dataset_id)],
-                ),
+            looker_view=LookerView(
+                source_datasets=[str(dataset_id)],
             ),
-            VirtualView(
-                logical_id=VirtualViewLogicalID(
-                    name="model.view3", type=VirtualViewType.LOOKER_VIEW
-                ),
-                looker_view=LookerView(
-                    dimensions=[
-                        LookerViewDimension(data_type="string", field="country")
-                    ],
-                    source_datasets=["DATASET~22F73B93BC1BBDE2A552F0B23A83626B"],
-                ),
+        ),
+        VirtualView(
+            logical_id=VirtualViewLogicalID(
+                name="model.view2", type=VirtualViewType.LOOKER_VIEW
             ),
-            VirtualView(
-                logical_id=VirtualViewLogicalID(
-                    name="model.explore1", type=VirtualViewType.LOOKER_EXPLORE
-                ),
-                looker_explore=LookerExplore(
-                    model_name="model",
-                    base_view=str(virtual_view_id1),
-                    description="description",
-                    label="label",
-                ),
+            looker_view=LookerView(
+                source_datasets=[str(dataset_id)],
             ),
-            VirtualView(
-                logical_id=VirtualViewLogicalID(
-                    name="model.explore2", type=VirtualViewType.LOOKER_EXPLORE
-                ),
-                looker_explore=LookerExplore(
-                    model_name="model",
-                    base_view=str(virtual_view_id2),
-                    description="description",
-                    label="label",
-                ),
+        ),
+        VirtualView(
+            logical_id=VirtualViewLogicalID(
+                name="model.view3", type=VirtualViewType.LOOKER_VIEW
             ),
-            VirtualView(
-                logical_id=VirtualViewLogicalID(
-                    name="model.explore3", type=VirtualViewType.LOOKER_EXPLORE
-                ),
-                looker_explore=LookerExplore(
-                    model_name="model",
-                    base_view=str(virtual_view_id3),
-                    description="description3",
-                    label="label3",
-                ),
+            looker_view=LookerView(
+                source_datasets=[str(dataset_id)],
             ),
-        ],
-    )
+        ),
+        VirtualView(
+            logical_id=VirtualViewLogicalID(
+                name="model.explore1", type=VirtualViewType.LOOKER_EXPLORE
+            ),
+            looker_explore=LookerExplore(
+                model_name="model",
+                base_view=str(virtual_view_id1),
+            ),
+        ),
+        VirtualView(
+            logical_id=VirtualViewLogicalID(
+                name="model.explore2", type=VirtualViewType.LOOKER_EXPLORE
+            ),
+            looker_explore=LookerExplore(
+                model_name="model",
+                base_view=str(virtual_view_id2),
+            ),
+        ),
+        VirtualView(
+            logical_id=VirtualViewLogicalID(
+                name="model.explore3", type=VirtualViewType.LOOKER_EXPLORE
+            ),
+            looker_explore=LookerExplore(
+                model_name="model",
+                base_view=str(virtual_view_id3),
+            ),
+        ),
+    ]
 
 
 def test_sql_table_name(test_root_dir):


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

The current implementation incorrectly assumes `explore_source` points to a view, whereas in reality, it should be an explore instead: https://docs.looker.com/data-modeling/learning-lookml/creating-ndts

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Wrap `raw_views` and `raw_explores` in a `raw_model` and passes that into both the view & explore building methods
- Leverage `_get_base_view_name` to determine the base view of `explore_source`

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Unit tests
