### PR TITLE
Limit PowerBI crawler to scan for public workspaces only

### DIFF
--- a/metaphor/common/utils.py
+++ b/metaphor/common/utils.py
@@ -11,3 +11,9 @@ def start_of_day(daysAgo=0) -> datetime:
 def unique_list(non_unique_list: list) -> list:
     """Returns an order-preserving list with no duplicate elements"""
     return list(dict.fromkeys(non_unique_list))
+
+
+def chunks(list, n):
+    """Yield successive n-sized chunks from the list."""
+    for i in range(0, len(list), n):
+        yield list[i : i + n]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.84"
+version = "0.10.85"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/power_bi/test_extractor.py
+++ b/tests/power_bi/test_extractor.py
@@ -97,94 +97,96 @@ async def test_extractor(test_root_dir):
     tiles = {dashboard1_id: [tile1, tile3], dashboard2_id: [tile2, tile3]}
 
     mock_instance.get_workspace_info = MagicMock(
-        return_value=WorkspaceInfo(
-            id="123",
-            name="foo",
-            type="normal",
-            state="",
-            reports=[
-                WorkspaceInfoReport(
-                    id=report1.id,
-                    name=report1.name,
-                    datasetId=report1.datasetId,
-                    description="This is a report about foo",
-                ),
-                WorkspaceInfoReport(
-                    id=report2.id,
-                    name=report2.name,
-                    datasetId=report2.datasetId,
-                    description="This is a report about bar",
-                ),
-            ],
-            datasets=[
-                WorkspaceInfoDataset(
-                    configuredBy="alice@foo.com",
-                    id=dataset1.id,
-                    name=dataset1.name,
-                    description="This is a dataset",
-                    tables=[
-                        PowerBITable(
-                            name="table1",
-                            columns=[
-                                PowerBITableColumn(name="col1", datatype="string"),
-                                PowerBITableColumn(name="col2", datatype="int"),
-                            ],
-                            measures=[
-                                PowerBITableMeasure(
-                                    name="exp1", expression="avg(col1)"
-                                ),
-                                PowerBITableMeasure(
-                                    name="exp2", expression="max(col1)"
-                                ),
-                            ],
-                            source=[
-                                {
-                                    "expression": 'let\n    Source = AmazonRedshift.Database("url:5439","db"),\n    public = Source{[Name="public"]}[Data],\n    table1 = public{[Name="table"]}[Data]\nin\n    table1'
-                                }
-                            ],
-                        )
-                    ],
-                ),
-                WorkspaceInfoDataset(
-                    configuredBy="bob@foo.com",
-                    id=dataset2.id,
-                    name=dataset2.name,
-                    description="This is another dataset",
-                    tables=[
-                        PowerBITable(
-                            name="table2",
-                            columns=[
-                                PowerBITableColumn(name="col1", datatype="string"),
-                                PowerBITableColumn(name="col2", datatype="int"),
-                            ],
-                            measures=[],
-                            source=[
-                                {
-                                    "expression": 'let\n    Source = Snowflake.Databases("some-account.snowflakecomputing.com","COMPUTE_WH"),\n    DB_Database = Source{[Name="DB",Kind="Database"]}[Data],\n    PUBLIC_Schema = DB_Database{[Name="PUBLIC",Kind="Schema"]}[Data],\n    TEST_Table = PUBLIC_Schema{[Name="TEST",Kind="Table"]}[Data]\nin\n    TEST_Table'
-                                }
-                            ],
-                        ),
-                        PowerBITable(
-                            name="table2",
-                            columns=[
-                                PowerBITableColumn(name="col1", datatype="string"),
-                                PowerBITableColumn(name="col2", datatype="int"),
-                            ],
-                            measures=[],
-                            source=[
-                                {
-                                    "expression": 'let\n    Source = GoogleBigQuery.Database(),\n    #"test-project" = Source{[Name="test-project"]}[Data],\n    test_Schema = #"test-project"{[Name="test",Kind="Schema"]}[Data],\n    example_Table = test_Schema{[Name="example",Kind="Table"]}[Data]\nin\n    example_Table'
-                                }
-                            ],
-                        ),
-                    ],
-                ),
-            ],
-            dashboards=[
-                WorkspaceInfoDashboard(displayName="Dashboard A", id="dashboard-1"),
-                WorkspaceInfoDashboard(displayName="Dashboard B", id="dashboard-2"),
-            ],
-        )
+        return_value=[
+            WorkspaceInfo(
+                id="123",
+                name="foo",
+                type="normal",
+                state="",
+                reports=[
+                    WorkspaceInfoReport(
+                        id=report1.id,
+                        name=report1.name,
+                        datasetId=report1.datasetId,
+                        description="This is a report about foo",
+                    ),
+                    WorkspaceInfoReport(
+                        id=report2.id,
+                        name=report2.name,
+                        datasetId=report2.datasetId,
+                        description="This is a report about bar",
+                    ),
+                ],
+                datasets=[
+                    WorkspaceInfoDataset(
+                        configuredBy="alice@foo.com",
+                        id=dataset1.id,
+                        name=dataset1.name,
+                        description="This is a dataset",
+                        tables=[
+                            PowerBITable(
+                                name="table1",
+                                columns=[
+                                    PowerBITableColumn(name="col1", datatype="string"),
+                                    PowerBITableColumn(name="col2", datatype="int"),
+                                ],
+                                measures=[
+                                    PowerBITableMeasure(
+                                        name="exp1", expression="avg(col1)"
+                                    ),
+                                    PowerBITableMeasure(
+                                        name="exp2", expression="max(col1)"
+                                    ),
+                                ],
+                                source=[
+                                    {
+                                        "expression": 'let\n    Source = AmazonRedshift.Database("url:5439","db"),\n    public = Source{[Name="public"]}[Data],\n    table1 = public{[Name="table"]}[Data]\nin\n    table1'
+                                    }
+                                ],
+                            )
+                        ],
+                    ),
+                    WorkspaceInfoDataset(
+                        configuredBy="bob@foo.com",
+                        id=dataset2.id,
+                        name=dataset2.name,
+                        description="This is another dataset",
+                        tables=[
+                            PowerBITable(
+                                name="table2",
+                                columns=[
+                                    PowerBITableColumn(name="col1", datatype="string"),
+                                    PowerBITableColumn(name="col2", datatype="int"),
+                                ],
+                                measures=[],
+                                source=[
+                                    {
+                                        "expression": 'let\n    Source = Snowflake.Databases("some-account.snowflakecomputing.com","COMPUTE_WH"),\n    DB_Database = Source{[Name="DB",Kind="Database"]}[Data],\n    PUBLIC_Schema = DB_Database{[Name="PUBLIC",Kind="Schema"]}[Data],\n    TEST_Table = PUBLIC_Schema{[Name="TEST",Kind="Table"]}[Data]\nin\n    TEST_Table'
+                                    }
+                                ],
+                            ),
+                            PowerBITable(
+                                name="table2",
+                                columns=[
+                                    PowerBITableColumn(name="col1", datatype="string"),
+                                    PowerBITableColumn(name="col2", datatype="int"),
+                                ],
+                                measures=[],
+                                source=[
+                                    {
+                                        "expression": 'let\n    Source = GoogleBigQuery.Database(),\n    #"test-project" = Source{[Name="test-project"]}[Data],\n    test_Schema = #"test-project"{[Name="test",Kind="Schema"]}[Data],\n    example_Table = test_Schema{[Name="example",Kind="Table"]}[Data]\nin\n    example_Table'
+                                    }
+                                ],
+                            ),
+                        ],
+                    ),
+                ],
+                dashboards=[
+                    WorkspaceInfoDashboard(displayName="Dashboard A", id="dashboard-1"),
+                    WorkspaceInfoDashboard(displayName="Dashboard B", id="dashboard-2"),
+                ],
+            )
+        ]
     )
 
     def fake_get_datasets(workspace_id) -> List[PowerBIDataset]:


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

The current PowerBI crawler had a couple of scalability issues when running against large Power BI installations.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Set sensible default values for the optional fields that are not documented properly.
- Call [PostWorkspaceInfo](https://docs.microsoft.com/en-us/rest/api/power-bi/admin/workspace-info-post-workspace-info) with up to 100 workspace IDs to improve performance and lower the chance of hitting the API rate limit.

TODO: https://app.shortcut.com/metaphor-data/story/8190/powerbi-admin-api-rate-limiting

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Manually tested against a production installation.