### PR TITLE
Remove deprecated dashboard.url

### DIFF
--- a/metaphor/looker/extractor.py
+++ b/metaphor/looker/extractor.py
@@ -101,12 +101,11 @@ class LookerExtractor(BaseExtractor):
             dashboard_info = DashboardInfo(
                 title=dashboard.title,
                 description=dashboard.description,
-                url=f"{config.base_url}/{dashboard.preferred_viewer}/{dashboard.id}",
                 charts=[],
             )
 
             source_info = SourceInfo(
-                main_url=dashboard_info.url,
+                main_url=f"{config.base_url}/{dashboard.preferred_viewer}/{dashboard.id}",
             )
 
             # All numeric fields must be converted to "float" to meet quicktype's expectation

--- a/metaphor/metabase/extractor.py
+++ b/metaphor/metabase/extractor.py
@@ -206,11 +206,10 @@ class MetabaseExtractor(BaseExtractor):
             title=dashboard_details["name"],
             description=dashboard_details["description"],
             charts=charts,
-            url=f"{self._server_url}/dashboard/{dashboard_id}",
         )
 
         source_info = SourceInfo(
-            main_url=dashboard_info.url,
+            main_url=f"{self._server_url}/dashboard/{dashboard_id}",
         )
 
         dashboard_upstream = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.85"
+version = "0.10.86"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

We must not write a URL to this field because `DashboardInfo.url` is deprecated.

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

- Use `SourceInfo.main_url` instead

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

Run `Looker` and `Metabase` crawler successfully

<!--
  Describe how the change was tested end-to-end.
-->
