### PR TITLE
Invalid Snowflake table name [sc-8756]

### DIFF
--- a/metaphor/snowflake/usage/extractor.py
+++ b/metaphor/snowflake/usage/extractor.py
@@ -146,6 +146,10 @@ class SnowflakeUsageExtractor(BaseExtractor):
 
                 table_name = obj.objectName.lower()
                 parts = table_name.split(".")
+                if len(parts) != 3:
+                    logger.debug(f"Invalid table name {table_name}, skip")
+                    continue
+
                 db, schema, table = parts[0], parts[1], parts[2]
                 if not self.filter.include_table(db, schema, table):
                     logger.debug(f"Ignore {table_name} due to filter config")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.88"
+version = "0.10.90"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
### 🤔 Why?

Seen some invalid snowflake dataset name in DB, and it's from the usage crawler. E.g. demo_db.public."dev_db.dbt_yi.test1"

### 🤓 What?

- filter out invalid dataset name in log parsing

### 🧪 Tested?

local run snowflake usage crawler, no invalid dataset names 
