### PR TITLE
Postgres usage: init_dataset() missing 2 required positional arguments [sc-8874]

### DIFF
--- a/metaphor/common/usage_util.py
+++ b/metaphor/common/usage_util.py
@@ -23,8 +23,8 @@ class UsageUtil:
         account: Optional[str],
         full_name: str,
         platform: DataPlatform,
-        useHistory: bool,
-        utc_now: datetime,
+        useHistory: bool = False,
+        utc_now: Optional[datetime] = None,
     ) -> Dataset:
         dataset = Dataset()
         dataset.entity_type = EntityType.DATASET

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.95"
+version = "0.10.96"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

The `UsageUtil.init_dataset` interface changed since #207, make new added arguments optional in this PR. Therefore, `use_history` will be disabled by default.

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

- Make argument optional

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

Generate MCE on local with error.

<!--
  Describe how the change was tested end-to-end.
-->
