### PR TITLE
duplicate snowflake tags [sc-9457]

### DIFF
--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -80,7 +80,8 @@ class SnowflakeExtractor(BaseExtractor):
                 self._fetch_primary_keys(cursor, database)
                 self._fetch_unique_keys(cursor, database)
                 self._fetch_table_info(conn, tables)
-                self._fetch_tags(cursor)
+
+            self._fetch_tags(cursor)
 
         logger.debug(self._datasets)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.100"
+version = "0.10.101"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
### 🤔 Why?

Query to snowflake account_usage views contains results for all DBs, so we should only do it once, not for each DB.

### 🤓 What?

- Move snowflake tags query outside each DB iteration, and only run once.

### 🧪 Tested?

Run it successfully at local, checked the output MCE
