### PR TITLE
Fix Bigquery audit log parsing to handle QUERY jobs without a destination table

### DIFF
--- a/metaphor/bigquery/logEvent.py
+++ b/metaphor/bigquery/logEvent.py
@@ -63,6 +63,11 @@ class JobChangeEvent:
             ).remove_extras()
         elif job_type == "QUERY":
             query_job = job["jobConfig"]["queryConfig"]
+
+            # Not all query jobs will have a destination table, e.g. calling a stored procedure
+            if "destinationTable" not in query_job:
+                return None
+
             query = query_job["query"]
             destination_table = BigQueryResource.from_str(
                 query_job["destinationTable"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.101"
+version = "0.10.102"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION


<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Turns out not every [Query job](https://cloud.google.com/bigquery/docs/reference/auditlogs/rest/Shared.Types/BigQueryAuditMetadata#BigQueryAuditMetadata.JobConfig.Query) is guaranteed to have a `destinationTable` specified, e.g. a SCRIPT statement (i.e calling a stored procedure).

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Ignore log entries that don't have a `desitnationTable` set.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Locally ran the connector to verify.
