### PR TITLE
Extract computed column from ThoughtSpot [SC-9521]

### DIFF
--- a/metaphor/thought_spot/models.py
+++ b/metaphor/thought_spot/models.py
@@ -71,6 +71,7 @@ class ColumnMetadata(Metadata):
     type: str
     sources: List[ColumnSource]
     dataType: Optional[str]
+    optionalType: Optional[str]
 
 
 class SourceType(Enum):
@@ -153,3 +154,39 @@ class LiveBoardMetadate(Metadata):
     header: LiveBoardHeader
     type: str
     reportContent: ReportContent
+
+
+class TMLResult(BaseModel):
+    info: Header
+    edoc: Optional[str]
+
+
+class TMLFormula(BaseModel):
+    id: Optional[str]
+    name: str
+    expr: str
+
+
+class TMLBase(BaseModel):
+    name: str
+    formulas: List[TMLFormula]
+
+
+class TMLColumn(BaseModel):
+    name: str
+    column_id: Optional[str]
+    formula_id: Optional[str]
+
+
+class TMLWorksheet(TMLBase):
+    worksheet_columns: List[TMLColumn]
+
+
+class TMLView(TMLBase):
+    view_columns: List[TMLColumn]
+
+
+class TMLObject(BaseModel):
+    guid: str
+    worksheet: Optional[TMLWorksheet]
+    view: Optional[TMLView]

--- a/metaphor/thought_spot/utils.py
+++ b/metaphor/thought_spot/utils.py
@@ -240,6 +240,7 @@ class ThoughtSpot:
                 res.extend(response["storables"])
         return res
 
+    @staticmethod
     def _fetch_tml(
         metadata_controller: MetadataController,
         ids: List[str],

--- a/metaphor/thought_spot/utils.py
+++ b/metaphor/thought_spot/utils.py
@@ -21,11 +21,17 @@ from pydantic import parse_obj_as
 from restapisdk.configuration import Environment
 from restapisdk.controllers.metadata_controller import MetadataController
 from restapisdk.controllers.session_controller import SessionController
+from restapisdk.models.export_object_tml_format_type_enum import (
+    ExportObjectTMLFormatTypeEnum,
+)
 from restapisdk.models.get_object_detail_type_enum import GetObjectDetailTypeEnum
 from restapisdk.models.search_object_header_type_enum import SearchObjectHeaderTypeEnum
 from restapisdk.models.session_login_response import SessionLoginResponse
 from restapisdk.models.tspublic_rest_v_2_metadata_header_search_request import (
     TspublicRestV2MetadataHeaderSearchRequest,
+)
+from restapisdk.models.tspublic_rest_v_2_metadata_tml_export_request import (
+    TspublicRestV2MetadataTmlExportRequest,
 )
 from restapisdk.models.tspublic_rest_v_2_session_gettoken_request import (
     TspublicRestV2SessionGettokenRequest,
@@ -45,6 +51,7 @@ from metaphor.thought_spot.models import (
     Metadata,
     SourceMetadata,
     SourceType,
+    TMLResult,
 )
 
 logger = get_logger(__name__)
@@ -194,6 +201,14 @@ class ThoughtSpot:
         # Because mypy can't handle dynamic type variables properly, we skip type-checking here.
         return parse_obj_as(List[target_type], obj)  # type: ignore
 
+    @classmethod
+    def fetch_tml(cls, client: RestapisdkClient, ids: List[str]) -> List[TMLResult]:
+        logger.info(f"Fetching tml for ids: {ids}")
+
+        obj = ThoughtSpot._fetch_tml(client.metadata, ids)
+
+        return parse_obj_as(List[TMLResult], obj)
+
     @staticmethod
     def _fetch_headers(
         metadata_controller: MetadataController,
@@ -223,4 +238,19 @@ class ThoughtSpot:
             response = json.loads(response_json)
             if "storables" in response:
                 res.extend(response["storables"])
+        return res
+
+    def _fetch_tml(
+        metadata_controller: MetadataController,
+        ids: List[str],
+    ) -> List[Any]:
+        res: List[Any] = []
+        for chunk_ids in chunks(ids, 10):
+            body = TspublicRestV2MetadataTmlExportRequest(
+                id=chunk_ids, format_type=ExportObjectTMLFormatTypeEnum.JSON
+            )
+            response_json = metadata_controller.export_object_tml(body)
+            response = json.loads(response_json)
+            if "object" in response:
+                res.extend(response["object"])
         return res

--- a/poetry.lock
+++ b/poetry.lock
@@ -1654,7 +1654,7 @@ python-versions = "*"
 
 [[package]]
 name = "metaphor-models"
-version = "0.7.13"
+version = "0.8.1"
 description = ""
 category = "main"
 optional = false
@@ -2768,7 +2768,7 @@ throughtspot = ["thoughtspot-rest-api-sdk"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<3.11"  # See https://github.com/googleapis/python-bigquery/issues/856
-content-hash = "6a3bfb588f468a2a2fac4a02b7d24940500c1866ec88b6196077c8a8939c7326"
+content-hash = "e773f2344835e5ece003838b4f89329f2914ed9372836caeb1179f5b5ef4ae0b"
 
 [metadata.files]
 alembic = [
@@ -3614,8 +3614,8 @@ mccabe = [
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 metaphor-models = [
-    {file = "metaphor-models-0.7.13.tar.gz", hash = "sha256:f8ccc3366a682dca41a117d485c35bcceb901bd27c90bdf32c7f316ab783cd02"},
-    {file = "metaphor_models-0.7.13-py3-none-any.whl", hash = "sha256:d49efab3791cfb6c77c9c8599ae0889e74af65a51ee1c3fd464185a2a03cb75a"},
+    {file = "metaphor-models-0.8.1.tar.gz", hash = "sha256:d6527ee273311ad1ccbe1333e80cfff7ea1c583bc452d2e3ced5e3f099786d33"},
+    {file = "metaphor_models-0.8.1-py3-none-any.whl", hash = "sha256:a61eec767dbc9f70e58c723df17557421c0898c7dee7b91b4fe205662f7989c7"},
 ]
 msal = [
     {file = "msal-1.17.0-py2.py3-none-any.whl", hash = "sha256:5a52d78e70d2c451e267c1e8c2342e4c06f495c75c859aeafd9260d3974f09fe"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ google-cloud-bigquery = { version = "^2.21.0", optional = true }
 google-cloud-logging = { version = "^2.7.0", optional = true }
 lkml = { version = "^1.2.0", optional = true }
 looker-sdk = { version = "^22.4.0", optional = true }
-metaphor-models = "^0.7.13"
+metaphor-models = "^0.8.1"
 msal = { version = "^1.17.0", optional = true }
 pydantic = "^1.9.0"
 python = ">=3.7,<3.11"  # See https://github.com/googleapis/python-bigquery/issues/856

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.103"
+version = "0.10.104"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

Extract information about computed: `optional_type` representing a column is computed or not,`formula` stores the expression in TML code. The `formula` maybe is not very accurate since the TML could be auto generated or user defined. 

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

- Extract computed column metadata

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

- Run crawler in local and MCEs is correct.

<!--
  Describe how the change was tested end-to-end.
-->
