### PR TITLE
Build Docker image directly from source instead of from PyPI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,9 +19,35 @@ defaults:
     shell: bash
 
 jobs:
+  version:
+    name: Get version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - run: npm install toml
+
+      - id: get-version
+        name: Get version
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const fs = require('fs');
+            const toml = require('toml');
+            const pyproject = toml.parse(fs.readFileSync('pyproject.toml')); 
+            core.setOutput('version', pyproject.tool.poetry.version);
+
   pypi:
     name: Publish to PyPI
     runs-on: ubuntu-latest
+    needs: version
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -44,37 +70,12 @@ jobs:
           2>&1 | tee ${{ runner.temp }}/logs
           || grep -qiE 'File already exists' ${{ runner.temp }}/logs
 
-      # Tag release
-      - uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - run: npm install toml
-
-      - id: get-version
-        name: Get version
-        uses: actions/github-script@v5
-        with:
-          script: |
-            const fs = require('fs');
-
-            const logs = fs.readFileSync('${{ runner.temp }}/logs').toString('utf8');
-            if (logs.search(/File already exists/ig) >= 0) {
-              core.notice('No new version was published to PyPI.');
-              process.exit(0);
-            }
-
-            const toml = require('toml');
-            const pyproject = toml.parse(fs.readFileSync('pyproject.toml')); 
-            core.setOutput('version', pyproject.tool.poetry.version);
-
       - name: Create tag
-        if: ${{ steps.get-version.outputs.version }}
         uses: actions/github-script@v5
         with:
           github-token: ${{ github.token }}
           script: |
-            const version = '${{ steps.get-version.outputs.version }}';
+            const version = '${{ needs.version.outputs.version }}';
             core.notice(`Tagging ${{ github.sha }} as ${version}`);
 
             try {
@@ -95,8 +96,7 @@ jobs:
   docker:
     name: Publish to Docker
     runs-on: ubuntu-latest
-    needs:
-      - pypi
+    needs: version
     steps:
       - name: Login to Docker Hub
         uses: docker/login-action@v1
@@ -108,4 +108,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ${{ env.DOCKER_IMAGE }}:latest
+          tags: |
+            ${{ env.DOCKER_IMAGE }}:latest
+            ${{ env.DOCKER_IMAGE }}:${{ needs.version.outputs.version }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,7 +4,7 @@ name: CD
 env:
   PYTHON_VERSION: 3.7
   POETRY_VERSION: 1.1.12
-  NODE_VERSION: 14
+  NODE_VERSION: 16
   DOCKER_IMAGE: metaphordata/connectors
 
 # Run this build workflow after a new PR is merged

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.8-slim
 
-RUN pip install metaphor-connectors[all]
+ADD . /src 
+
+RUN pip install '/src[all]'
 
 CMD ["sh", "-c", "python -m ${PY_MODULE} ${CONFIG_FILE}"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Metaphor Connectors
 
-[![CI/CD](https://github.com/MetaphorData/connectors/actions/workflows/cicd.yml/badge.svg)](https://github.com/MetaphorData/connectors/actions/workflows/cicd.yml)
+[![CI](https://github.com/MetaphorData/connectors/actions/workflows/ci.yml/badge.svg)](https://github.com/MetaphorData/connectors/actions/workflows/cicd.yml)
 [![CodeQL](https://github.com/MetaphorData/connectors/workflows/CodeQL/badge.svg)](https://github.com/MetaphorData/connectors/actions/workflows/codeql-analysis.yml)
 [![PyPI Version](https://img.shields.io/pypi/v/metaphor-connectors)](https://pypi.org/project/metaphor-connectors/)
 ![Python version 3.7+](https://img.shields.io/badge/python-3.7%2B-blue)


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

There is a delay (sometime hours) before the newly published package on PyPI becomes available. As a result, the current Docker image build process ends up installing the previous version.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Refactor Dockerfile and the CD pipeline to install directly from the latest source and tag it with the correct version number.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

CD: https://github.com/MetaphorData/connectors/actions/runs/2599490786
Published: https://hub.docker.com/r/metaphordata/connectors/tags