### PR TITLE
Add pydantic validtor to snowflake auth config

### DIFF
--- a/metaphor/snowflake/auth.py
+++ b/metaphor/snowflake/auth.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
-from pydantic import validator
+from pydantic import root_validator
 from pydantic.dataclasses import dataclass
 from smart_open import open
 
@@ -46,11 +46,11 @@ class SnowflakeAuthConfig(BaseConfig):
     # the query tags for each snowflake query the connector issues
     query_tag: Optional[str] = METAPHOR_DATA
 
-    @validator("private_key")
-    def have_password_or_private_key(cls, v, values):
-        if v is None and values["password"] is None:
+    @root_validator
+    def have_password_or_private_key(cls, values):
+        if values["password"] is None and values["private_key"] is None:
             raise ValueError("must set either password or private_key")
-        return v
+        return values
 
 
 def connect(config: SnowflakeAuthConfig) -> snowflake.connector.SnowflakeConnection:

--- a/metaphor/snowflake/auth.py
+++ b/metaphor/snowflake/auth.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
+from pydantic import validator
 from pydantic.dataclasses import dataclass
 from smart_open import open
 
@@ -45,8 +46,16 @@ class SnowflakeAuthConfig(BaseConfig):
     # the query tags for each snowflake query the connector issues
     query_tag: Optional[str] = METAPHOR_DATA
 
+    @validator("private_key")
+    def have_password_or_private_key(cls, v, values):
+        if v is None and values["password"] is None:
+            raise ValueError("must set either password or private_key")
+        return v
+
 
 def connect(config: SnowflakeAuthConfig) -> snowflake.connector.SnowflakeConnection:
+    # either "password" or "private_key" should be set, otherwise pydantic validator will throw error
+
     # default authenticator
     if config.password is not None:
         return snowflake.connector.connect(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.107"
+version = "0.10.109"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/snowflake/config_missing_credentials.yml
+++ b/tests/snowflake/config_missing_credentials.yml
@@ -1,0 +1,5 @@
+---
+account: account
+user: user
+default_database: database
+output: {}

--- a/tests/snowflake/config_with_key.yml
+++ b/tests/snowflake/config_with_key.yml
@@ -1,0 +1,8 @@
+---
+account: account
+user: user
+private_key:
+  key_file: key_file
+  passphrase: passphrase
+default_database: database
+output: {}

--- a/tests/snowflake/test_config.py
+++ b/tests/snowflake/test_config.py
@@ -1,5 +1,9 @@
+import pytest
+from pydantic import ValidationError
+
 from metaphor.common.base_config import OutputConfig
 from metaphor.common.filter import DatasetFilter
+from metaphor.snowflake.auth import SnowflakeKeyPairAuthConfig
 from metaphor.snowflake.config import SnowflakeRunConfig
 
 
@@ -29,3 +33,28 @@ def test_yaml_config(test_root_dir):
         ),
         output=OutputConfig(),
     )
+
+
+def test_yaml_config_with_private_key(test_root_dir):
+    config = SnowflakeRunConfig.from_yaml_file(
+        f"{test_root_dir}/snowflake/config_with_key.yml"
+    )
+
+    assert config == SnowflakeRunConfig(
+        output=OutputConfig(api=None, file=None),
+        account="account",
+        user="user",
+        password=None,
+        private_key=SnowflakeKeyPairAuthConfig(
+            key_file="key_file", passphrase="passphrase"
+        ),
+        default_database="database",
+        query_tag="MetaphorData",
+    )
+
+
+def test_yaml_config_with_missing_credential(test_root_dir):
+    with pytest.raises(ValidationError):
+        SnowflakeRunConfig.from_yaml_file(
+            f"{test_root_dir}/snowflake/config_missing_credentials.yml"
+        )


### PR DESCRIPTION
### 🤔 Why?

To ensure either password or private key is set in the config

### 🤓 What?

- add pydantic validator to ensure either password or private key is set in the config

### 🧪 Tested?

unit tests of the configs
