### PR TITLE
Use GitPython to crawl Looker repo [sc-5045]

### DIFF
--- a/metaphor/bigquery/config.py
+++ b/metaphor/bigquery/config.py
@@ -27,9 +27,9 @@ class BigQueryCredentials:
     # Client ID contained in the key file
     client_id: str
 
-    type: Optional[str] = "service_account"
-    auth_uri: Optional[str] = "https://accounts.google.com/o/oauth2/auth"
-    token_uri: Optional[str] = "https://oauth2.googleapis.com/token"
+    type: str = "service_account"
+    auth_uri: str = "https://accounts.google.com/o/oauth2/auth"
+    token_uri: str = "https://oauth2.googleapis.com/token"
 
 
 @dataclass
@@ -44,7 +44,7 @@ class BigQueryRunConfig(BaseConfig):
     project_id: Optional[str] = None
 
     # Max number of concurrent requests to bigquery or logging API, default is 10
-    max_concurrency: Optional[int] = 10
+    max_concurrency: int = 10
 
     # Include or exclude specific databases/schemas/tables
     filter: Optional[DatasetFilter] = dataclass_field(

--- a/metaphor/common/docs/git_repo.md
+++ b/metaphor/common/docs/git_repo.md
@@ -1,0 +1,22 @@
+# Git Repo Connection Config
+
+When the connector needs to fetch source code from a git repository, we can set up the connection config by using personal access token or the username and password. Currently, the git connector supports repos on Github and GitLab. 
+
+## Personal Access Token
+
+Using personal access token with read scope is the recommended way to connect to git repository. To create a new token, please refer to the instructions for [Github](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) or [GitLab](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#create-a-personal-access-token). The configuration will be:
+
+```yaml
+git_url: <git_repo_url> # ending with .git
+access_token: <personal_access_token>
+```
+
+## Username Password
+
+Alternatively one can choose to use password to authenticate with the git service. The configuration will be:
+
+```yaml
+git_url: <git_repo_url> # ending with .git
+username: <username>
+password: <password>
+```

--- a/metaphor/common/docs/git_repo.md
+++ b/metaphor/common/docs/git_repo.md
@@ -12,7 +12,13 @@ username: <username>
 access_token: <personal_access_token>
 ```
 
-**NOTE**: For GitLab or GitLab enterprise, please use `oauth2` as the username.
+**NOTE**: For GitLab or GitLab enterprise, please use `oauth2` as the username:
+
+```yaml
+git_url: <git_repo_url> # ending with .git
+username: oauth2
+access_token: <personal_access_token>
+```
 
 ## Username Password
 

--- a/metaphor/common/docs/git_repo.md
+++ b/metaphor/common/docs/git_repo.md
@@ -1,6 +1,6 @@
 # Git Repo Connection Config
 
-When the connector needs to fetch source code from a git repository, we can set up the connection config by using personal access token or the username and password. Currently, the git connector supports repos on Github and GitLab. 
+When the connector needs to fetch source code from a git repository, we can set up the connection config by using personal access token or the username and password. 
 
 ## Personal Access Token
 
@@ -8,8 +8,11 @@ Using personal access token with read scope is the recommended way to connect to
 
 ```yaml
 git_url: <git_repo_url> # ending with .git
+username: <username>
 access_token: <personal_access_token>
 ```
+
+**NOTE**: For GitLab or GitLab enterprise, please use `oauth2` as the username.
 
 ## Username Password
 
@@ -20,3 +23,5 @@ git_url: <git_repo_url> # ending with .git
 username: <username>
 password: <password>
 ```
+
+**NOTE**: BitBucket Cloud [stopped supporting account passwords for Git authentication](https://atlassian.community/t5/x/x/ba-p/1948231). Please generate and use [App passwords](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/) instead.

--- a/metaphor/common/docs/git_repo.md
+++ b/metaphor/common/docs/git_repo.md
@@ -12,13 +12,7 @@ username: <username>
 access_token: <personal_access_token>
 ```
 
-**NOTE**: For GitLab or GitLab enterprise, please use `oauth2` as the username:
-
-```yaml
-git_url: <git_repo_url> # ending with .git
-username: oauth2
-access_token: <personal_access_token>
-```
+> NOTE: For GitLab or GitLab enterprise, please use `oauth2` as the username:
 
 ## Username Password
 
@@ -30,4 +24,4 @@ username: <username>
 password: <password>
 ```
 
-**NOTE**: BitBucket Cloud [stopped supporting account passwords for Git authentication](https://atlassian.community/t5/x/x/ba-p/1948231). Please generate and use [App passwords](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/) instead.
+> NOTE: BitBucket Cloud [stopped supporting account passwords for Git authentication](https://atlassian.community/t5/x/x/ba-p/1948231). Please generate and use [App passwords](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/) instead.

--- a/metaphor/common/git.py
+++ b/metaphor/common/git.py
@@ -1,0 +1,51 @@
+import os
+import tempfile
+from typing import Optional
+from urllib.parse import urlparse
+
+from git import Repo
+from pydantic import root_validator
+from pydantic.dataclasses import dataclass
+
+
+@dataclass
+class GitRepoConfig:
+
+    # Git repository URL, ending with ".git"
+    git_url: str
+
+    # git repo access token
+    access_token: Optional[str] = None
+
+    # git repo username
+    username: Optional[str] = None
+
+    # git repo password
+    password: Optional[str] = None
+
+    # path to the project, default to the root of the repo
+    project_path: str = "."
+
+    @root_validator()
+    def have_token_or_username_password(cls, values):
+        if values["access_token"] is None and (
+            values["username"] is None or values["password"] is None
+        ):
+            raise ValueError("must set either access_token or username+password")
+        return values
+
+
+def clone_repo(config: GitRepoConfig, local_dir: Optional[str] = None) -> str:
+    """
+    Clone a git repo to local storage and return the path to the project
+    If local directory not provided, use generated temp directory
+    """
+    if local_dir is None:
+        local_dir = tempfile.mkdtemp()
+
+    parsed_url = urlparse(config.git_url)
+    auth = config.access_token or f"{config.username}:{config.password}"
+    git_url = f"{parsed_url.scheme}://{auth}@{parsed_url.netloc}{parsed_url.path}"
+
+    Repo.clone_from(git_url, local_dir)
+    return os.path.join(local_dir, config.project_path)

--- a/metaphor/common/git.py
+++ b/metaphor/common/git.py
@@ -23,7 +23,7 @@ class GitRepoConfig:
     # git repo password
     password: Optional[str] = None
 
-    # path to the project, default to the root of the repo
+    # relative path to the project, default to the root of the repo
     project_path: str = ""
 
     @root_validator()

--- a/metaphor/common/git.py
+++ b/metaphor/common/git.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 from typing import Optional
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 from git import Repo
 from pydantic import root_validator
@@ -14,11 +14,11 @@ class GitRepoConfig:
     # Git repository URL, ending with ".git"
     git_url: str
 
+    # git repo username
+    username: str
+
     # git repo access token
     access_token: Optional[str] = None
-
-    # git repo username
-    username: Optional[str] = None
 
     # git repo password
     password: Optional[str] = None
@@ -27,15 +27,10 @@ class GitRepoConfig:
     project_path: str = ""
 
     @root_validator()
-    def have_token_or_username_password(cls, values):
-        if values["access_token"] is None and (
-            values["username"] is None or values["password"] is None
-        ):
-            raise ValueError("must set either access_token or username+password")
+    def have_token_or_password(cls, values):
+        if values["access_token"] is None and values["password"] is None:
+            raise ValueError("must set either access_token or password")
         return values
-
-
-_supported_git_services = ["github.com", "gitlab.com"]
 
 
 def clone_repo(config: GitRepoConfig, local_dir: Optional[str] = None) -> str:
@@ -46,19 +41,18 @@ def clone_repo(config: GitRepoConfig, local_dir: Optional[str] = None) -> str:
     if local_dir is None:
         local_dir = tempfile.mkdtemp()
 
-    parsed_url = urlparse(config.git_url)
-    assert parsed_url.netloc in _supported_git_services, "Unsupported git service"
-
-    if parsed_url.netloc == "github.com":
-        auth = config.access_token or f"{config.username}:{config.password}"
-    else:  # gitlab
-        auth = (
-            f"oauth2:{config.access_token}"
-            if config.access_token
-            else f"{config.username}:{config.password}"
-        )
-
-    git_url = f"{parsed_url.scheme}://{auth}@{parsed_url.netloc}{parsed_url.path}"
+    git_url = _generate_git_url(config)
 
     Repo.clone_from(git_url, local_dir)
     return os.path.join(local_dir, config.project_path)
+
+
+def _generate_git_url(config: GitRepoConfig) -> str:
+    """Generate a git URL containing authentication"""
+    parsed_url = urlparse(config.git_url)
+
+    auth = f"{quote(config.username)}:{config.access_token or config.password}"
+    host = (parsed_url.hostname or parsed_url.netloc) + (
+        f":{parsed_url.port}" if parsed_url.port else ""
+    )
+    return f"{parsed_url.scheme}://{auth}@{host}{parsed_url.path}"

--- a/metaphor/looker/README.md
+++ b/metaphor/looker/README.md
@@ -55,7 +55,6 @@ Create a YAML config file based on the following template.
 base_url: <looker_base_url>
 client_id: <client_id>
 client_secret: <client_secret>
-lookml_dir: <path_to_lookml_project>
 connections:
   <name>:
     database: <database_name>
@@ -71,12 +70,28 @@ Note that `connections` is a mapping of database connection names to connection 
 
 See [Common Configurations](../common/README.md) for more information on `output`.
 
+The connector also needs to parse the LookML project to extract additional metadata. There are two ways to provide the project source code. If the source code is in local environment, we can set the path to the project root as following:
+
+```yaml
+lookml_dir: <path_to_lookml_project>
+```
+
+Alternatively, if the source code is hosted on Git, we can set the git repository config as following:
+
+```yaml
+lookml_git_repo:
+  git_url: <git_repo_url>
+  access_token: <git_repo_personal_access_token>
+```
+
+For more information about git repo configuration, please refer to [Git Repo Connection Config](../common/docs/git_repo.md).
+
 ### Optional Configurations
 
 To add a "View LookML" link to Looker explore & views on Metaphor you need to specify a base URL for the Looker project. This can be either a URL to the GitHub repository (`https://github.com/<account>/<repo>`) or Looker IDE (`https://<account>.cloud.looker.com/projects/<project>/files/`).
 
 ```yaml
-projectSourceUrl: <looker_project_url>
+project_source_url: <looker_project_source_url>
 ```
 
 You can also disable SSL verify and change the request timeout if needed, e.g.

--- a/metaphor/looker/extractor.py
+++ b/metaphor/looker/extractor.py
@@ -3,6 +3,8 @@ from typing import Collection, Dict, Iterable, List, Optional, Sequence, Set, Tu
 
 from metaphor.models.crawler_run_metadata import Platform
 
+from metaphor.common.git import clone_repo
+
 try:
     import looker_sdk
     from looker_sdk.sdk.api40.methods import Looker40SDK
@@ -87,8 +89,11 @@ class LookerExtractor(BaseExtractor):
             k.lower(): v for (k, v) in config.connections.items()
         }
 
+        lookml_dir = config.lookml_dir or clone_repo(config.lookml_git_repo)
+        logger.info(f"Parsing LookML project at {lookml_dir}")
+
         model_map, virtual_views = parse_project(
-            config.lookml_dir, connections, config.project_source_url
+            lookml_dir, connections, config.project_source_url
         )
 
         dashboards = self._fetch_dashboards(config, sdk, model_map)

--- a/poetry.lock
+++ b/poetry.lock
@@ -989,7 +989,7 @@ python-versions = "*"
 name = "gitdb"
 version = "4.0.9"
 description = "Git Object Database"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -1000,7 +1000,7 @@ smmap = ">=3.0.1,<6"
 name = "gitpython"
 version = "3.1.27"
 description = "GitPython is a python library used to interact with Git repositories"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -2413,7 +2413,7 @@ webhdfs = ["requests"]
 name = "smmap"
 version = "5.0.0"
 description = "A pure Python implementation of a sliding window memory map manager"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -2791,11 +2791,11 @@ docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
 [extras]
-all = ["asyncpg", "google-api-python-client", "google-auth-oauthlib", "google-cloud-bigquery", "google-cloud-logging", "lkml", "looker-sdk", "msal", "slack-sdk", "snowflake-connector-python", "sql-metadata", "tableauserverclient", "thoughtspot-rest-api-sdk"]
+all = ["asyncpg", "GitPython", "google-api-python-client", "google-auth-oauthlib", "google-cloud-bigquery", "google-cloud-logging", "lkml", "looker-sdk", "msal", "slack-sdk", "snowflake-connector-python", "sql-metadata", "tableauserverclient", "thoughtspot-rest-api-sdk"]
 bigquery = ["google-cloud-bigquery", "google-cloud-logging", "sql-metadata"]
 dbt = []
 google_directory = ["google-api-python-client", "google-auth-oauthlib"]
-looker = ["lkml", "looker-sdk", "sql-metadata"]
+looker = ["GitPython", "lkml", "looker-sdk", "sql-metadata"]
 metabase = ["sql-metadata"]
 postgresql = ["asyncpg"]
 power_bi = ["msal"]
@@ -2808,7 +2808,7 @@ throughtspot = ["thoughtspot-rest-api-sdk"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<3.11"  # See https://github.com/googleapis/python-bigquery/issues/856
-content-hash = "2740525783a28158f3af85ec0441f0ed0a5aa578f64adbda7e3640a8422ec70c"
+content-hash = "d1b1abf603c11d1acbc476c806e34dabcba49a32787700c2c43f135ff92d17b1"
 
 [metadata.files]
 alembic = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.110"
+version = "0.10.111"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]
@@ -15,6 +15,7 @@ boto3 = "^1.24.20"
 botocore = "^1.27.20"
 canonicaljson = "^1.4.0"
 fastjsonschema = "^2.15.1"
+GitPython = "^3.1.0"
 google-api-python-client = { version = "^2.36.0", optional = true }
 google-auth-oauthlib = { version = "^0.5.0", optional = true }
 google-cloud-bigquery = { version = "^3.2.0", optional = true }
@@ -38,6 +39,7 @@ thoughtspot-rest-api-sdk = { version = "~=1.11.0", optional = true }
 [tool.poetry.extras]
 all = [
   "asyncpg",
+  "GitPython",
   "google-api-python-client",
   "google-auth-oauthlib",
   "google-cloud-bigquery",
@@ -55,7 +57,7 @@ all = [
 bigquery = ["google-cloud-bigquery", "google-cloud-logging", "sql-metadata"]
 dbt = []
 google_directory = ["google-api-python-client", "google-auth-oauthlib"]
-looker = ["lkml", "looker-sdk", "sql-metadata"]
+looker = ["GitPython", "lkml", "looker-sdk", "sql-metadata"]
 metabase = ["sql-metadata"]
 postgresql = ["asyncpg"]
 power_bi = ["msal"]

--- a/tests/common/test_git.py
+++ b/tests/common/test_git.py
@@ -1,0 +1,56 @@
+import pytest
+from pydantic import ValidationError
+
+from metaphor.common.git import GitRepoConfig, _generate_git_url
+
+
+def test_sampling_config():
+    assert (
+        _generate_git_url(
+            GitRepoConfig(
+                git_url="https://github.com/foo/looker.git",
+                username="foo",
+                access_token="bar",
+            )
+        )
+        == "https://foo:bar@github.com/foo/looker.git"
+    )
+
+    assert (
+        _generate_git_url(
+            GitRepoConfig(
+                git_url="https://gitlab.com/abc.git",
+                username="oauth2",
+                access_token="bar",
+            )
+        )
+        == "https://oauth2:bar@gitlab.com/abc.git"
+    )
+
+    assert (
+        _generate_git_url(
+            GitRepoConfig(
+                git_url="https://gitlab.com/abc.git",
+                username="foo",
+                password="bar",
+            )
+        )
+        == "https://foo:bar@gitlab.com/abc.git"
+    )
+
+    assert (
+        _generate_git_url(
+            GitRepoConfig(
+                git_url="https://abc@bitbucket.org:80/a/test.git",
+                username="foo",
+                password="bar",
+            )
+        )
+        == "https://foo:bar@bitbucket.org:80/a/test.git"
+    )
+
+    with pytest.raises(ValidationError):
+        GitRepoConfig(
+            git_url="https://github.com/foo/looker.git",
+            username="foo",
+        )

--- a/tests/looker/config2.yml
+++ b/tests/looker/config2.yml
@@ -4,6 +4,7 @@ client_id: client_id
 client_secret: client_secret
 lookml_git_repo:
   git_url: https://github.com/foo/looker.git
+  username: foo
   access_token: bar
 connections:
   conn1:

--- a/tests/looker/config2.yml
+++ b/tests/looker/config2.yml
@@ -1,0 +1,14 @@
+---
+base_url: base_url
+client_id: client_id
+client_secret: client_secret
+lookml_git_repo:
+  git_url: https://github.com/foo/looker.git
+  access_token: bar
+connections:
+  conn1:
+    database: db1
+    default_schema: schema1
+    platform: SNOWFLAKE
+    account: account1
+output: {}

--- a/tests/looker/config_missing_lookml.yml
+++ b/tests/looker/config_missing_lookml.yml
@@ -1,0 +1,11 @@
+---
+base_url: base_url
+client_id: client_id
+client_secret: client_secret
+connections:
+  conn1:
+    database: db1
+    default_schema: schema1
+    platform: SNOWFLAKE
+    account: account1
+output: {}

--- a/tests/looker/test_config.py
+++ b/tests/looker/test_config.py
@@ -51,7 +51,9 @@ def test_yaml_config_with_git(test_root_dir):
             )
         },
         lookml_git_repo=GitRepoConfig(
-            git_url="https://github.com/foo/looker.git", access_token="bar"
+            git_url="https://github.com/foo/looker.git",
+            username="foo",
+            access_token="bar",
         ),
         output=OutputConfig(),
     )

--- a/tests/looker/test_config.py
+++ b/tests/looker/test_config.py
@@ -1,6 +1,9 @@
+import pytest
 from metaphor.models.metadata_change_event import DataPlatform
+from pydantic import ValidationError
 
 from metaphor.common.base_config import OutputConfig
+from metaphor.common.git import GitRepoConfig
 from metaphor.looker.config import LookerConnectionConfig, LookerRunConfig
 
 
@@ -30,3 +33,32 @@ def test_yaml_config(test_root_dir):
         timeout=1,
         output=OutputConfig(),
     )
+
+
+def test_yaml_config_with_git(test_root_dir):
+    config = LookerRunConfig.from_yaml_file(f"{test_root_dir}/looker/config2.yml")
+
+    assert config == LookerRunConfig(
+        base_url="base_url",
+        client_id="client_id",
+        client_secret="client_secret",
+        connections={
+            "conn1": LookerConnectionConfig(
+                database="db1",
+                account="account1",
+                default_schema="schema1",
+                platform="SNOWFLAKE",
+            )
+        },
+        lookml_git_repo=GitRepoConfig(
+            git_url="https://github.com/foo/looker.git", access_token="bar"
+        ),
+        output=OutputConfig(),
+    )
+
+
+def test_yaml_config_missing_lookml(test_root_dir):
+    with pytest.raises(ValidationError):
+        LookerRunConfig.from_yaml_file(
+            f"{test_root_dir}/looker/config_missing_lookml.yml"
+        )


### PR DESCRIPTION
### 🤔 Why?

Provides the capability to fetch LookML project from git repo

### 🤓 What?

- use GitPython to clone LookML repo
- Update config

### 🧪 Tested?

locally run crawler with access token
