### PR TITLE
Tableau crawler preview error [sc-9553]

### DIFF
--- a/metaphor/tableau/extractor.py
+++ b/metaphor/tableau/extractor.py
@@ -52,6 +52,7 @@ class TableauExtractor(BaseExtractor):
         self._base_url: Optional[str] = None
         self._views: Dict[str, ViewItem] = {}
         self._dashboards: Dict[str, Dashboard] = {}
+        self._disable_preview_image = False
         self._snowflake_account: Optional[str] = None
         self._bigquery_project_name_to_id_map: Dict[str, str] = dict()
 
@@ -64,6 +65,7 @@ class TableauExtractor(BaseExtractor):
 
         logger.info("Fetching metadata from Tableau")
 
+        self._disable_preview_image = config.disable_preview_image
         self._snowflake_account = config.snowflake_account
         self._bigquery_project_name_to_id_map = config.bigquery_project_name_to_id_map
 
@@ -94,7 +96,7 @@ class TableauExtractor(BaseExtractor):
             )
             for item in views:
                 logger.debug(json.dumps(item.__dict__, default=str))
-                if not config.disable_preview_image:
+                if not self._disable_preview_image:
                     server.views.populate_preview_image(item)
                 self._views[item.id] = item
 
@@ -237,7 +239,7 @@ class TableauExtractor(BaseExtractor):
         try:
             preview_data_url = (
                 TableauExtractor._build_preview_data_url(view.preview_image)
-                if view.preview_image
+                if not self._disable_preview_image and view.preview_image
                 else None
             )
         except Exception as error:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.111"
+version = "0.10.112"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
### 🤔 Why?

If set `disable_preview_image: true`, we didn't populate the preview image, but when building chart preview URL, it still fetches the `view.preview_image` field, which will throw this error if not populated. This doesn't affect the crawler output, just produces many unnecessary error messages.

### 🤓 What?

- Check if preview disabled when building chart preview URL

### 🧪 Tested?

Locally tested the crawler with preview disable, no errors. 
