### PR TITLE
Tableau failed to parse workbook upstream [sc-9732]

### DIFF
--- a/metaphor/tableau/extractor.py
+++ b/metaphor/tableau/extractor.py
@@ -186,6 +186,7 @@ class TableauExtractor(BaseExtractor):
         table_fullname = table["fullName"]
         table_schema = table["schema"]
 
+        # table name, schema and database potentially have null value
         if None in (table_name, table_schema, table["database"]):
             return None
 

--- a/metaphor/tableau/extractor.py
+++ b/metaphor/tableau/extractor.py
@@ -185,11 +185,11 @@ class TableauExtractor(BaseExtractor):
         table_name = table["name"]
         table_fullname = table["fullName"]
         table_schema = table["schema"]
-        database_name = table["database"]["name"]
 
-        if None in (table_name, table_schema, database_name):
+        if None in (table_name, table_schema, table["database"]):
             return None
 
+        database_name = table["database"]["name"]
         connection_type = table["database"]["connectionType"]
         if connection_type not in connection_type_map:
             # connection type not supported

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.113"
+version = "0.10.114"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
### 🤔 Why?

The `database` field under `DatabaseTable` can be null in the Metadata graphql API response. And seems unstable for `extract` data, as sometimes this field is missing, not always.

### 🤓 What?

- Add check for null database, we are not parsing those `extract` data anyway.

### 🧪 Tested?

tested locally without issue. I was able to reproduce this issue today with the previous code. 

