### PR TITLE
Add optional role config for Snowflake connectors

### DIFF
--- a/metaphor/snowflake/README.md
+++ b/metaphor/snowflake/README.md
@@ -59,6 +59,7 @@ If using user password authentication:
 account: <snowflake_account>
 user: <snowflake_username>
 password: <snowflake_password>
+role: <snowflake_role> # Optional. Will use default role if not specified.
 default_database: <default_database_for_connections>
 output:
   file:
@@ -73,6 +74,7 @@ user: <snowflake_username>
 private_key:
   key_file: <private_key_file>
   passphrase: <private_key_encoding_passphrase>
+role: <snowflake_role> # Optional. Will use default role if not specified.
 default_database: <default_database_for_connections>
 output:
   file:

--- a/metaphor/snowflake/auth.py
+++ b/metaphor/snowflake/auth.py
@@ -40,6 +40,9 @@ class SnowflakeAuthConfig(BaseConfig):
     # if using key pair authentication
     private_key: Optional[SnowflakeKeyPairAuthConfig] = None
 
+    # role to use when opening a connection
+    role: Optional[str] = None
+
     # database context when opening a connection
     default_database: Optional[str] = None
 
@@ -54,23 +57,8 @@ class SnowflakeAuthConfig(BaseConfig):
 
 
 def connect(config: SnowflakeAuthConfig) -> snowflake.connector.SnowflakeConnection:
-    # either "password" or "private_key" should be set, otherwise pydantic validator will throw error
-
-    # default authenticator
-    if config.password is not None:
-        return snowflake.connector.connect(
-            account=config.account,
-            user=config.user,
-            password=config.password,
-            database=config.default_database,
-            application=METAPHOR_DATA_SNOWFLAKE_CONNECTOR,
-            session_parameters={
-                "QUERY_TAG": config.query_tag,
-                "quoted_identifiers_ignore_case": False,
-            },
-        )
-
     # key pair authentication
+    pkb = None
     if config.private_key is not None:
         passphrase = (
             config.private_key.passphrase.encode()
@@ -89,17 +77,16 @@ def connect(config: SnowflakeAuthConfig) -> snowflake.connector.SnowflakeConnect
             encryption_algorithm=serialization.NoEncryption(),
         )
 
-        return snowflake.connector.connect(
-            account=config.account,
-            user=config.user,
-            private_key=pkb,
-            database=config.default_database,
-            application=METAPHOR_DATA_SNOWFLAKE_CONNECTOR,
-            session_parameters={
-                "QUERY_TAG": config.query_tag,
-            },
-        )
-
-    raise ValueError(
-        "Invalid Snowflake configuration, please set either password or private key"
+    return snowflake.connector.connect(
+        account=config.account,
+        user=config.user,
+        password=config.password,
+        private_key=pkb,
+        role=config.role,
+        database=config.default_database,
+        application=METAPHOR_DATA_SNOWFLAKE_CONNECTOR,
+        session_parameters={
+            "QUERY_TAG": config.query_tag,
+            "quoted_identifiers_ignore_case": False,
+        },
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.115"
+version = "0.10.117"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/snowflake/config.yml
+++ b/tests/snowflake/config.yml
@@ -2,6 +2,7 @@
 account: account
 user: user
 password: password
+role: role
 default_database: database
 filter:
   includes:

--- a/tests/snowflake/config_with_key.yml
+++ b/tests/snowflake/config_with_key.yml
@@ -4,5 +4,6 @@ user: user
 private_key:
   key_file: key_file
   passphrase: passphrase
+role: role
 default_database: database
 output: {}

--- a/tests/snowflake/test_config.py
+++ b/tests/snowflake/test_config.py
@@ -14,6 +14,7 @@ def test_yaml_config(test_root_dir):
         account="account",
         user="user",
         password="password",
+        role="role",
         default_database="database",
         filter=DatasetFilter(
             includes={
@@ -48,6 +49,7 @@ def test_yaml_config_with_private_key(test_root_dir):
         private_key=SnowflakeKeyPairAuthConfig(
             key_file="key_file", passphrase="passphrase"
         ),
+        role="role",
         default_database="database",
         query_tag="MetaphorData",
     )


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

To allow users to connect using a different role, in case the default one doesn't work.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled. Also simplify the `connect` method.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Locally tested with & without the `role` config set.