### PR TITLE
Add must_set_exactly_one util method for config validation

### DIFF
--- a/metaphor/bigquery/config.py
+++ b/metaphor/bigquery/config.py
@@ -6,6 +6,7 @@ from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
 from metaphor.common.filter import DatasetFilter
+from metaphor.common.utils import must_set_exactly_one
 
 
 @dataclass
@@ -53,6 +54,5 @@ class BigQueryRunConfig(BaseConfig):
 
     @root_validator
     def have_key_path_or_credentials(cls, values):
-        if values["key_path"] is None and values["credentials"] is None:
-            raise ValueError("must set either key_path or credentials")
+        must_set_exactly_one(values, ["key_path", "credentials"])
         return values

--- a/metaphor/common/git.py
+++ b/metaphor/common/git.py
@@ -7,6 +7,8 @@ from git import Repo
 from pydantic import root_validator
 from pydantic.dataclasses import dataclass
 
+from metaphor.common.utils import must_set_exactly_one
+
 
 @dataclass
 class GitRepoConfig:
@@ -26,10 +28,9 @@ class GitRepoConfig:
     # relative path to the project, default to the root of the repo
     project_path: str = ""
 
-    @root_validator()
+    @root_validator
     def have_token_or_password(cls, values):
-        if values["access_token"] is None and values["password"] is None:
-            raise ValueError("must set either access_token or password")
+        must_set_exactly_one(values, ["access_token", "password"])
         return values
 
 

--- a/metaphor/common/utils.py
+++ b/metaphor/common/utils.py
@@ -1,4 +1,5 @@
 from datetime import datetime, time, timedelta, timezone
+from typing import Dict, List
 
 
 def start_of_day(daysAgo=0) -> datetime:
@@ -17,3 +18,9 @@ def chunks(list, n):
     """Yield successive n-sized chunks from the list."""
     for i in range(0, len(list), n):
         yield list[i : i + n]
+
+
+def must_set_exactly_one(values: Dict, keys: List[str]):
+    not_none = [k for k in keys if values.get(k) is not None]
+    if len(not_none) != 1:
+        raise ValueError(f"must set exactly one of {keys}, found {not_none}")

--- a/metaphor/looker/config.py
+++ b/metaphor/looker/config.py
@@ -6,6 +6,7 @@ from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
 from metaphor.common.git import GitRepoConfig
+from metaphor.common.utils import must_set_exactly_one
 
 
 @dataclass
@@ -46,8 +47,7 @@ class LookerRunConfig(BaseConfig):
     verify_ssl: bool = True
     timeout: int = 120
 
-    @root_validator()
+    @root_validator
     def have_local_or_git_dir_for_lookml(cls, values):
-        if values["lookml_dir"] is None and values["lookml_git_repo"] is None:
-            raise ValueError("must set either lookml_dir or lookml_git_repo")
+        must_set_exactly_one(values, ["lookml_dir", "lookml_git_repo"])
         return values

--- a/metaphor/snowflake/auth.py
+++ b/metaphor/snowflake/auth.py
@@ -7,6 +7,7 @@ from pydantic.dataclasses import dataclass
 from smart_open import open
 
 from metaphor.common.base_config import BaseConfig
+from metaphor.common.utils import must_set_exactly_one
 
 try:
     import snowflake.connector
@@ -51,8 +52,7 @@ class SnowflakeAuthConfig(BaseConfig):
 
     @root_validator
     def have_password_or_private_key(cls, values):
-        if values["password"] is None and values["private_key"] is None:
-            raise ValueError("must set either password or private_key")
+        must_set_exactly_one(values, ["password", "private_key"])
         return values
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.118"
+version = "0.10.119"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -1,9 +1,10 @@
 from datetime import datetime
 
+import pytest
 import pytz
 from freezegun import freeze_time
 
-from metaphor.common.utils import start_of_day
+from metaphor.common.utils import must_set_exactly_one, start_of_day
 
 
 @freeze_time("2020-01-10")
@@ -13,3 +14,16 @@ def test_start_of_day():
     assert start_of_day(3) == datetime(2020, 1, 7, 0, 0, 0, 0, pytz.UTC)
 
     assert start_of_day(30) == datetime(2019, 12, 11, 0, 0, 0, 0, pytz.UTC)
+
+
+def test_must_set_exactly_one():
+
+    must_set_exactly_one({"foo": 1}, ["foo"])
+    must_set_exactly_one({"foo": 1, "bar": None}, ["foo", "bar"])
+    must_set_exactly_one({"bar": 1, "baz": None}, ["foo", "bar", "baz"])
+
+    with pytest.raises(ValueError):
+        must_set_exactly_one({}, ["foo"])
+
+    with pytest.raises(ValueError):
+        must_set_exactly_one({"foo": 1, "bar": 1}, ["foo", "bar"])


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Factor out common validation logic and make sure that it checks exactly one, not at least one.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Unit tests.
