### PR TITLE
Support using glob patterns in filters

### DIFF
--- a/metaphor/bigquery/README.md
+++ b/metaphor/bigquery/README.md
@@ -51,7 +51,7 @@ output:
     directory: <output_directory>
 ```
 
-See [Common Configurations](../common/README.md) for more information on `output`.
+See [Output Config](../common/docs/output.md) for more information on `output`.
 
 To connect to BigQuery, either the keyfile path or credentials from the JSON keyfile must be set in the config as following:
 

--- a/metaphor/common/docs/filter.md
+++ b/metaphor/common/docs/filter.md
@@ -1,20 +1,20 @@
-# Filter
+# Filter Config
 
 By default, the connector will extract metadata from all tables/views in all schemas and databases. You can optionally limit it by specifying the `filter` option. For example, the following config will only include tables/views from database `db1` and `db2`:
 
 ```yaml
 filter:
   includes:
-    db1:    
+    db1:
     db2:
 ```
 
-You can also exclude only specific databases, schemas, or tables/views. For example, the following will include all tables/views except `db1.*`, `db2.schema1.*`, and `db3.schema1.table1`:
+You can also exclude specific databases, schemas, or tables/views. For example, the following will include all tables/views except `db1.*`, `db2.schema1.*`, and `db3.schema1.table1`:
 
 ```yaml
 filter:
   excludes:
-    db1:  
+    db1:
     db2:
       schema1:
     db3:
@@ -33,13 +33,16 @@ filter:
       schema1:  
         - table1
         - table2
-
 ```
 
-## Supported Connectors
+## Wildcards
 
-- [metaphor.postgresql](metaphor/postgresql/README.md)
-- [metaphor.redshift](metaphor/redshift/README.md)
-- [metaphor.snowflake](metaphor/snowflake/README.md)
-- [metaphor.snowflake.profile](metaphor/snowflake/profile/README.md)
-- [metaphor.snowflake.usage](metaphor/snowflake/usage/README.md)
+Use wildcard characters (`*` and `?`) to match specific patterns. For example, the following config will exclude all schemas with a prefix `staging_` and a suffix `_temp`:
+
+```yaml
+filter:
+  excludes:
+    *:
+      staging_*:
+      *_temp:
+```

--- a/metaphor/common/docs/output.md
+++ b/metaphor/common/docs/output.md
@@ -1,10 +1,8 @@
-# Common Configurations
-
-## Output
+# Output Config
 
 You can configure the connector to output to files or API.
 
-### Output to Files
+## Output to Files
 
 File-based output is the preferred way as it enables decoupling between the connector and ingestion pipeline. Add the following fragment to your config file:
 
@@ -24,7 +22,7 @@ output:
 
 To write the output to a S3 bucket, you must also set the AWS region & credentials using the [AWS CLI environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html), specifically, `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`.
 
-### Output to API
+## Output to API
 
 You can choose to output the results to an API using the following config:
 

--- a/metaphor/common/filter.py
+++ b/metaphor/common/filter.py
@@ -1,10 +1,11 @@
-from typing import Dict, Optional, Set, Union
+from fnmatch import fnmatch
+from typing import Dict, Optional, Set
 
 from pydantic.dataclasses import dataclass
 
 TableFilter = Set[str]
-SchemaFilter = Dict[str, Union[None, TableFilter]]
-DatabaseFilter = Dict[str, Union[None, SchemaFilter]]
+SchemaFilter = Dict[str, Optional[TableFilter]]
+DatabaseFilter = Dict[str, Optional[SchemaFilter]]
 
 
 @dataclass
@@ -49,41 +50,75 @@ class DatasetFilter:
 
         return DatasetFilter(includes=includes, excludes=excludes)
 
+    def _accepted_by_schema_pattern(
+        self,
+        schema_name: str,
+        table_name: str,
+        schema_pattern: str,
+        table_filter: Optional[TableFilter],
+    ):
+        if fnmatch(schema_name, schema_pattern):
+            # None means all tables are accepted
+            if table_filter is None:
+                return True
+
+            for table_pattern in table_filter:
+                if fnmatch(table_name, table_pattern):
+                    return True
+
+        return False
+
+    def _accepted_by_database_pattern(
+        self,
+        database_name: str,
+        schema_name: str,
+        table_name: str,
+        database_pattern: str,
+        schema_filter: Optional[SchemaFilter],
+    ):
+        if fnmatch(database_name, database_pattern):
+            # None means all schemas are accepted
+            if schema_filter is None:
+                return True
+
+            for (pattern, table_filter) in schema_filter.items():
+                if self._accepted_by_schema_pattern(
+                    schema_name, table_name, pattern, table_filter
+                ):
+                    return True
+
+        return False
+
+    def _accepted_by_filter(
+        self,
+        database_name: str,
+        schema_name: str,
+        table_name: str,
+        database_filter: DatabaseFilter,
+    ):
+        for pattern, schema_filter in database_filter.items():
+            if self._accepted_by_database_pattern(
+                database_name, schema_name, table_name, pattern, schema_filter
+            ):
+                return True
+
+        return False
+
     def include_table(self, database: str, schema: str, table: str) -> bool:
         database_lower = database.lower()
         schema_lower = schema.lower()
         table_lower = table.lower()
 
-        def covered_by_filter(database_filter: DatabaseFilter):
-            # not covered by database filter
-            if database_lower not in database_filter:
-                return False
-
-            schema_filter = database_filter[database_lower]
-
-            # empty schema filter
-            if schema_filter is None or len(schema_filter) == 0:
-                return True
-
-            # not covered by schema filter
-            if schema_lower not in schema_filter:
-                return False
-
-            table_filter = schema_filter[schema_lower]
-
-            # empty table filter
-            if table_filter is None or len(table_filter) == 0:
-                return True
-
-            # covered by table filter?
-            return table_lower in table_filter
-
         # Filtered out by includes
-        if self.includes is not None and not covered_by_filter(self.includes):
+        if self.includes is not None and not self._accepted_by_filter(
+            database_lower, schema_lower, table_lower, self.includes
+        ):
             return False
 
         # Filtered out by excludes
-        if self.excludes is not None and covered_by_filter(self.excludes):
+        if self.excludes is not None and self._accepted_by_filter(
+            database_lower, schema_lower, table_lower, self.excludes
+        ):
             return False
 
         return True

--- a/metaphor/dbt/README.md
+++ b/metaphor/dbt/README.md
@@ -22,7 +22,7 @@ output:
     directory: <output_directory>
 ```
 
-See [Common Configurations](../common/README.md) for more information on `output`.
+See [Output Config](../common/docs/output.md) for more information on `output`.
 
 ### Optional Configurations
 

--- a/metaphor/dbt/cloud/README.md
+++ b/metaphor/dbt/cloud/README.md
@@ -23,7 +23,7 @@ output:
 
 You can extract `account_id` & `job_id` from a particular dbt job's URL, which has the format `https://cloud.getdbt.com/#/accounts/<account_id>/projects/<project_id>/jobs/<job_id>/`.
 
-See [Common Configurations](../common/README.md) for more information on `output`.
+See [Output Config](../common/docs/output.md) for more information on `output`.
 
 ## Testing
 

--- a/metaphor/google_directory/README.md
+++ b/metaphor/google_directory/README.md
@@ -46,7 +46,7 @@ output:
     directory: <output_directory>
 ```
 
-See [Common Configurations](../common/README.md) for more information on `output`.
+See [Output Config](../common/docs/output.md) for more information on `output`.
 
 ## Testing
 

--- a/metaphor/looker/README.md
+++ b/metaphor/looker/README.md
@@ -68,7 +68,7 @@ output:
 
 Note that `connections` is a mapping of database connection names to connection settings. You can find these settings under `Admin` > `Connections`. For now, the only platform supported is `SNOWFLAKE` with `account` set to the matching [Snowflake Account Identifier](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html).
 
-See [Common Configurations](../common/README.md) for more information on `output`.
+See [Output Config](../common/docs/output.md) for more information on `output`.
 
 The connector also needs to parse the LookML project to extract additional metadata. There are two ways to provide the project source code. If the source code is in local environment, we can set the path to the project root as following:
 

--- a/metaphor/manual/governance/README.md
+++ b/metaphor/manual/governance/README.md
@@ -35,7 +35,7 @@ output:
 
 > Note: You only need to specify `account` if the platform is `SNOWFLAKE`.
 
-See [Common Configurations](../common/README.md) for more information on `output`.
+See [Output Config](../common/docs/output.md) for more information on `output`.
 
 ### Examples
 

--- a/metaphor/manual/lineage/README.md
+++ b/metaphor/manual/lineage/README.md
@@ -30,7 +30,7 @@ output:
 
 > Note: You only need to specify `account` if the platform is `SNOWFLAKE`.
 
-See [Common Configurations](../common/README.md) for more information on `output`.
+See [Output Config](../common/docs/output.md) for more information on `output`.
 
 ### Examples
 

--- a/metaphor/postgresql/README.md
+++ b/metaphor/postgresql/README.md
@@ -36,7 +36,7 @@ output:
     directory: <output_directory>
 ```
 
-See [Common Configurations](../common/README.md) for more information on `output`.
+See [Output Config](../common/docs/output.md) for more information on `output`.
 
 ### Optional Configurations
 

--- a/metaphor/redshift/README.md
+++ b/metaphor/redshift/README.md
@@ -36,7 +36,7 @@ output:
     directory: <output_directory>
 ```
 
-See [Common Configurations](../common/README.md) for more information on `output`.
+See [Output Config](../common/docs/output.md) for more information on `output`.
 
 ### Optional Configurations
 

--- a/metaphor/snowflake/README.md
+++ b/metaphor/snowflake/README.md
@@ -83,9 +83,11 @@ output:
 
 The `private_key.passphrase` is only needed if using encrypted version of the private key. Otherwise, it can be omitted from the config.
 
-See [Common Configurations](../common/README.md) for more information on `output`.
+See [Output Config](../common/docs/output.md) for more information on `output`.
 
 ### Optional Configurations
+
+See [Filter Configurations](../common/docs/filter.md) for more information on the optional `filter` config.
 
 #### Concurrency
 
@@ -102,8 +104,6 @@ Each query issued by snowflake connectors can be tagged with a query tag. It can
 ```yaml
 query_tag: <query_taqg> # Default to 'MetaphorData'
 ```
-
-See [Filter Configurations](../common/docs/filter.md) for more information on the optional `filter` config.
 
 ## Testing
 

--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -167,7 +167,6 @@ class SnowflakeExtractor(BaseExtractor):
         ) in cursor:
             full_name = dataset_fullname(database, table_schema, table_name)
             if full_name not in self._datasets:
-                logger.warning(f"Table {full_name} not found")
                 continue
 
             dataset = self._datasets[full_name]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.119"
+version = "0.10.120"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/common/test_filter.py
+++ b/tests/common/test_filter.py
@@ -24,6 +24,19 @@ def test_include_table_empty_filter():
     assert filter.include_table("db2", "boo", "bar")
 
 
+def test_include_table_glob_patterns():
+
+    filter = DatasetFilter(
+        includes={"db?": {"schema*": set(["*"])}},
+        excludes=None,
+    )
+
+    assert filter.include_table("db1", "schema1", "table1")
+    assert filter.include_table("db2", "schema2", "table2")
+    assert not filter.include_table("db1", "foo", "bar")
+    assert not filter.include_table("db_extra", "schema1", "table1")
+
+
 def test_include_table_includes_only():
 
     filter = DatasetFilter(


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Sometimes it's useful to include/exclude databases/schemas/tables using wildcard (glob) patterns. For example, use `staging_*` to filter out all tables with a `staging_` prefix.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Refactor `filter.include_table` to support glob patterns
- Move filter config doc to `common/docs` for consistency

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Unit test and manually tested against production.
