### PR TITLE
Add timeout to extractor execution

### DIFF
--- a/metaphor/common/extractor.py
+++ b/metaphor/common/extractor.py
@@ -1,7 +1,9 @@
 import asyncio
+import os
 import traceback
 from abc import ABC, abstractmethod
 from datetime import datetime
+from multiprocessing import Process
 from typing import Collection, List, Optional, Type
 
 from metaphor.models.crawler_run_metadata import CrawlerRunMetadata, Platform, Status
@@ -15,6 +17,8 @@ from .event_util import ENTITY_TYPES, EventUtil
 from .file_sink import FileSink
 
 logger = get_logger(__name__)
+
+DEFAULT_TIMEOUT = 3600  # 1 hour
 
 
 class BaseExtractor(ABC):
@@ -37,7 +41,17 @@ class BaseExtractor(ABC):
     def description(self) -> str:
         """Extract metadata and build messages, should be overridden"""
 
-    def run(self, config: BaseConfig) -> List[MetadataChangeEvent]:
+    def run(self, config: BaseConfig):
+        timeout = float(os.environ.get("TIMEOUT", DEFAULT_TIMEOUT))
+
+        process = Process(target=self._run, args=(config,))
+        process.start()
+        process.join(timeout)
+        process.terminate()
+        if process.exitcode is None:
+            raise TimeoutError(f"Process killed after {timeout} seconds")
+
+    def _run(self, config: BaseConfig) -> List[MetadataChangeEvent]:
         """Callable function to extract metadata and send/post messages"""
         start_time = datetime.now()
         logger.info(f"Starting extractor {self.__class__.__name__} at {start_time}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.123"
+version = "0.10.122"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.121"
+version = "0.10.123"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/common/test_extractor.py
+++ b/tests/common/test_extractor.py
@@ -45,7 +45,7 @@ class DummyExtractor(BaseExtractor):
 def test_dummy_extractor():
     entities = [Dashboard(), Dataset(), VirtualView()]
     config = DummyRunConfig(dummy_attr=0, output=OutputConfig())
-    events = DummyExtractor(entities).run(config)
+    events = DummyExtractor(entities)._run(config)
 
     assert events == [
         MetadataChangeEvent(


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

To prevent a stuck or mis-configured connector from running forever.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

The original plan was to add a common `timeout` config option with a default value. However, it turns out that doing so [is difficult before Python 3.10](https://stackoverflow.com/questions/51575931/class-inheritance-in-python-3-7-dataclasses). Since this is more of a fail-safe mechanism than a configuration option, overriding it using an environment variable seems like a perfectly acceptable solution.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

```
% TIMEOUT=2 python -m metaphor.bigquery ~/Desktop/local/bigquery.yml
...
Traceback (most recent call last):
  File "/Users/marslan/.pyenv/versions/3.9.6/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Users/marslan/.pyenv/versions/3.9.6/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/Users/marslan/Metaphor/connectors/metaphor/bigquery/__main__.py", line 6, in <module>
    cli_main("BigQuery metadata extractor", BigQueryExtractor)
  File "/Users/marslan/Metaphor/connectors/metaphor/common/cli.py", line 19, in cli_main
    extractor.run(config=config_cls.from_yaml_file(args.config))
  File "/Users/marslan/Metaphor/connectors/metaphor/common/extractor.py", line 52, in run
    raise TimeoutError(f"Process killed after {timeout} seconds")
TimeoutError: Process killed after 2.0 seconds
```
