### PR TITLE
Add required $top parameter when querying PowerBI apps

### DIFF
--- a/metaphor/power_bi/extractor.py
+++ b/metaphor/power_bi/extractor.py
@@ -193,7 +193,7 @@ class PowerBIClient:
 
     def get_apps(self) -> List[PowerBIApp]:
         # https://docs.microsoft.com/en-us/rest/api/power-bi/admin/apps-get-apps-as-admin
-        url = f"{self.API_ENDPOINT}/admin/apps"
+        url = f"{self.API_ENDPOINT}/admin/apps?$top=5000"
         return self._call_get(
             url, List[PowerBIApp], transform_response=lambda r: r.json()["value"]
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.124"
+version = "0.10.125"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Power BI crawler is crashing with the following error:

```
GET https://api.powerbi.com/v1.0/myorg/admin/apps failed, {"error":{"code":"InvalidRequest","message":"This API expects $top query option to be provided."}}

```

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Add the required `$top` parameter missed in https://github.com/MetaphorData/connectors/pull/301.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->
