### PR TITLE
PowerBI crawler didn't parse column data type [sc-10527]

### DIFF
--- a/metaphor/power_bi/extractor.py
+++ b/metaphor/power_bi/extractor.py
@@ -102,7 +102,7 @@ class PowerBITile(BaseModel):
 
 class PowerBITableColumn(BaseModel):
     name: str
-    datatype: str = "unknown"
+    dataType: str = "unknown"
 
 
 class PowerBITableMeasure(BaseModel):
@@ -378,7 +378,7 @@ class PowerBIExtractor(BaseExtractor):
                 tables.append(
                     PowerBIDatasetTable(
                         columns=[
-                            PbiColumn(field=c.name, type=c.datatype)
+                            PbiColumn(field=c.name, type=c.dataType)
                             for c in table.columns
                         ],
                         measures=[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.10.125"
+version = "0.10.126"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/power_bi/test_extractor.py
+++ b/tests/power_bi/test_extractor.py
@@ -135,8 +135,8 @@ async def test_extractor(test_root_dir):
                             PowerBITable(
                                 name="table1",
                                 columns=[
-                                    PowerBITableColumn(name="col1", datatype="string"),
-                                    PowerBITableColumn(name="col2", datatype="int"),
+                                    PowerBITableColumn(name="col1", dataType="string"),
+                                    PowerBITableColumn(name="col2", dataType="int"),
                                 ],
                                 measures=[
                                     PowerBITableMeasure(
@@ -163,8 +163,8 @@ async def test_extractor(test_root_dir):
                             PowerBITable(
                                 name="table2",
                                 columns=[
-                                    PowerBITableColumn(name="col1", datatype="string"),
-                                    PowerBITableColumn(name="col2", datatype="int"),
+                                    PowerBITableColumn(name="col1", dataType="string"),
+                                    PowerBITableColumn(name="col2", dataType="int"),
                                 ],
                                 measures=[],
                                 source=[
@@ -176,8 +176,8 @@ async def test_extractor(test_root_dir):
                             PowerBITable(
                                 name="table2",
                                 columns=[
-                                    PowerBITableColumn(name="col1", datatype="string"),
-                                    PowerBITableColumn(name="col2", datatype="int"),
+                                    PowerBITableColumn(name="col1", dataType="string"),
+                                    PowerBITableColumn(name="col2", dataType="int"),
                                 ],
                                 measures=[],
                                 source=[


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

A typo in the modeling, so the column data type always use the default value.

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

- Fix the typo and update the test case.

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

Verified the output of crawler.

<!--
  Describe how the change was tested end-to-end.
-->
