### PR TITLE
Add major & minor version tags to published Docker image

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,7 +23,9 @@ jobs:
     name: Get version
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.get-version.outputs.version }}
+      full: ${{ steps.get-version.outputs.full }}
+      major: ${{ steps.get-version.outputs.major }}
+      minor: ${{ steps.get-version.outputs.minor }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -42,7 +44,10 @@ jobs:
             const fs = require('fs');
             const toml = require('toml');
             const pyproject = toml.parse(fs.readFileSync('pyproject.toml')); 
-            core.setOutput('version', pyproject.tool.poetry.version);
+            const version = pyproject.tool.poetry.version;
+            core.setOutput('full', version);
+            core.setOutput('major', version.split('.').slice(0, 1).join('.'));
+            core.setOutput('minor', version.split('.').slice(0, 2).join('.'));
 
   pypi:
     name: Publish to PyPI
@@ -75,7 +80,7 @@ jobs:
         with:
           github-token: ${{ github.token }}
           script: |
-            const version = '${{ needs.version.outputs.version }}';
+            const version = '${{ needs.version.outputs.full }}';
             core.notice(`Tagging ${{ github.sha }} as ${version}`);
 
             try {
@@ -110,4 +115,6 @@ jobs:
           push: true
           tags: |
             ${{ env.DOCKER_IMAGE }}:latest
-            ${{ env.DOCKER_IMAGE }}:${{ needs.version.outputs.version }}
+            ${{ env.DOCKER_IMAGE }}:${{ needs.version.outputs.full }}
+            ${{ env.DOCKER_IMAGE }}:${{ needs.version.outputs.major }}
+            ${{ env.DOCKER_IMAGE }}:${{ needs.version.outputs.minor }}


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

So the image can be imported in a sem-ver fashion, e.g. `metaphordata/connectors:0.10`.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Manually invoked the CD workflow and verified the tags on Docker Hub: https://hub.docker.com/r/metaphordata/connectors/tags
