### PR TITLE
BQ crawler timing out [sc-10766]

### DIFF
--- a/metaphor/bigquery/README.md
+++ b/metaphor/bigquery/README.md
@@ -11,7 +11,7 @@ We recommend creating a dedicated GCP service account with limited permissions f
     - Enter a service account name, e.g., `metaphor-bigquery`.
     - Enter a description, e.g. `Metadata collection for Metaphor app`
     - Click `CREATE AND CONTINUE`.
-    - Select `BigQuery Metadata Viewer` as the role and click `CONTINUE`.
+    - Select `BigQuery Metadata Viewer` and `BigQuery Job User` as the roles and click `CONTINUE`.
     - Click `DONE` to complete the process as there's no need to grant user access to the service account.
 
 Once the service account is created, you need to create a service account key for authentication:

--- a/metaphor/bigquery/README.md
+++ b/metaphor/bigquery/README.md
@@ -79,7 +79,7 @@ See [Filter Configurations](../common/docs/filter.md) for more information on th
 The max number of concurrent requests to the google cloud API can be configured as follows,
 
 ```yaml
-max_concurrency: <max_number_of_queries> # Default to 10
+max_concurrency: <max_number_of_queries> # Default to 5
 ```
 
 ### Notes

--- a/metaphor/bigquery/config.py
+++ b/metaphor/bigquery/config.py
@@ -44,8 +44,8 @@ class BigQueryRunConfig(BaseConfig):
     # Project ID to use. Use the service account's default project if not set
     project_id: Optional[str] = None
 
-    # Max number of concurrent requests to bigquery or logging API, default is 10
-    max_concurrency: int = 10
+    # Max number of concurrent requests to bigquery or logging API, default is 5
+    max_concurrency: int = 5
 
     # Include or exclude specific databases/schemas/tables
     filter: Optional[DatasetFilter] = dataclass_field(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.2"
+version = "0.11.3"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
### 🤔 Why?

The program is stuck at fetching table information from API. This is likely caused by resource contention with 2 levels of `executor.map` within the same thread pool, we used `executor.map`  to concurrently get datasets, and within that `executor.map` we use another map to get each table concurrently.
Refactoring the top-level to be a for-loop solved the problem.

### 🤓 What?

- refactoring the threadpool `executor.map` to only used in to fetch tables within a dataset
- update readme to add `BigQuery Job User` permission which is needed for creating query job for table DDL.
- reduce the default concurrency from 10 to 5, as I run into warming `Connection pool is full, discarding connection: bigquery.googleapis.com. Connection pool size: 10`. Tested multiple times and this doesn't have a noticeable impact on the performance.

### 🧪 Tested?

tested against our BQ instance.
