### PR TITLE
Remove custom timeout logic

### DIFF
--- a/metaphor/common/extractor.py
+++ b/metaphor/common/extractor.py
@@ -1,9 +1,7 @@
 import asyncio
-import os
 import traceback
 from abc import ABC, abstractmethod
 from datetime import datetime
-from multiprocessing import Process
 from typing import Collection, List, Optional, Type
 
 from metaphor.common.logger import get_logger
@@ -16,8 +14,6 @@ from .event_util import ENTITY_TYPES, EventUtil
 from .file_sink import FileSink
 
 logger = get_logger(__name__)
-
-DEFAULT_TIMEOUT = 3600  # 1 hour
 
 
 class BaseExtractor(ABC):
@@ -40,17 +36,7 @@ class BaseExtractor(ABC):
     def description(self) -> str:
         """Extract metadata and build messages, should be overridden"""
 
-    def run(self, config: BaseConfig):
-        timeout = float(os.environ.get("TIMEOUT", DEFAULT_TIMEOUT))
-
-        process = Process(target=self._run, args=(config,))
-        process.start()
-        process.join(timeout)
-        process.terminate()
-        if process.exitcode is None:
-            raise TimeoutError(f"Process killed after {timeout} seconds")
-
-    def _run(self, config: BaseConfig) -> List[MetadataChangeEvent]:
+    def run(self, config: BaseConfig) -> List[MetadataChangeEvent]:
         """Callable function to extract metadata and send/post messages"""
         start_time = datetime.now()
         logger.info(f"Starting extractor {self.__class__.__name__} at {start_time}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.4"
+version = "0.11.5"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/common/test_extractor.py
+++ b/tests/common/test_extractor.py
@@ -45,7 +45,7 @@ class DummyExtractor(BaseExtractor):
 def test_dummy_extractor():
     entities = [Dashboard(), Dataset(), VirtualView()]
     config = DummyRunConfig(dummy_attr=0, output=OutputConfig())
-    events = DummyExtractor(entities)._run(config)
+    events = DummyExtractor(entities).run(config)
 
     assert events == [
         MetadataChangeEvent(


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Remove the custom timeout logic added in https://github.com/MetaphorData/connectors/pull/302 as it's better to implement this at a higher level (e.g. a launch script) using [signal](https://docs.python.org/3/library/signal.html) instead of in the connectors themselves.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Manually verified that the connector still runs as expected.