### PR TITLE
Add option to filter self-loops in BigQuery lineage

### DIFF
--- a/metaphor/bigquery/lineage/README.md
+++ b/metaphor/bigquery/lineage/README.md
@@ -28,6 +28,9 @@ enable_view_lineage: <boolean>
 # (Optional) Whether to enable parsing audit log to find table lineage information, default True
 enable_lineage_from_log: <boolean>
 
+# (Optional) Whether to include self-referencing loops in lineage, default True
+include_self_lineage: <boolean>
+
 # (Optional) Number of days of logs to extract for lineage analysis. Default to 30.
 lookback_days: <days>
 

--- a/metaphor/bigquery/lineage/config.py
+++ b/metaphor/bigquery/lineage/config.py
@@ -13,4 +13,7 @@ class BigQueryLineageRunConfig(BigQueryRunConfig):
 
     lookback_days: int = 30
 
+    # Whether to include self loop in lineage
+    include_self_lineage: bool = True
+
     batch_size: int = 1000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.5"
+version = "0.11.6"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/bigquery/lineage/config.yml
+++ b/tests/bigquery/lineage/config.yml
@@ -4,4 +4,5 @@ project_id: project_id
 enable_view_lineage: true
 enable_lineage_from_log: false
 lookback_days: 10
+include_self_lineage: false
 output: {}

--- a/tests/bigquery/lineage/data/result.json
+++ b/tests/bigquery/lineage/data/result.json
@@ -21,7 +21,8 @@
       "sourceDatasets": [
         "DATASET~930E4BD28074A60959C98F61289311E0",
         "DATASET~E16CCC1A55EE3E61C1CE8B0C47F67998",
-        "DATASET~55CAA090B9E8317AFC195CBD843D6665"
+        "DATASET~55CAA090B9E8317AFC195CBD843D6665",
+        "DATASET~6BC1F571B76A5BBE6B1F6C0E7DCA533C"
       ],
       "transformation": "INSERT INTO `metaphor-data.test.yi_test3` \nSELECT * from `metaphor-data.test.yi_tests1` \nUNION ALL \nSELECT * from `metaphor-data.test.yi_tests2`"
     }

--- a/tests/bigquery/lineage/data/sample_log.json
+++ b/tests/bigquery/lineage/data/sample_log.json
@@ -120,7 +120,8 @@
                   "projects/metaphor-data/datasets/test/tables/yi_tests1",
                   "projects/metaphor-data/datasets/test/tables/yi_tests2",
                   "projects/metaphor-data/datasets/test/tables/yi_tests3",
-                  "projects/metaphor-data/datasets/test/tables/yi_tests2"
+                  "projects/metaphor-data/datasets/test/tables/yi_tests2",
+                  "projects/metaphor-data/datasets/test/tables/yi_tests"
                 ],
                 "outputRowCount": "1"
               },

--- a/tests/bigquery/lineage/test_config.py
+++ b/tests/bigquery/lineage/test_config.py
@@ -13,6 +13,7 @@ def test_yaml_config(test_root_dir):
         enable_view_lineage=True,
         enable_lineage_from_log=False,
         lookback_days=10,
+        include_self_lineage=False,
         batch_size=1000,
         output=OutputConfig(),
     )

--- a/tests/bigquery/lineage/test_extractor.py
+++ b/tests/bigquery/lineage/test_extractor.py
@@ -32,7 +32,10 @@ def mock_list_entries(mock_build_log_client, entries):
 @freeze_time("2022-01-27")
 async def test_log_extractor(test_root_dir):
     config = BigQueryLineageRunConfig(
-        output=OutputConfig(), key_path="fake_file", enable_view_lineage=False
+        output=OutputConfig(),
+        key_path="fake_file",
+        enable_view_lineage=False,
+        include_self_lineage=True,
     )
     extractor = BigQueryLineageExtractor()
 

--- a/tests/bigquery/lineage/test_parser.py
+++ b/tests/bigquery/lineage/test_parser.py
@@ -48,6 +48,9 @@ def test_parse_log(test_root_dir):
                 BigQueryResource(
                     project_id="metaphor-data", dataset_id="test", table_id="yi_tests3"
                 ),
+                BigQueryResource(
+                    project_id="metaphor-data", dataset_id="test", table_id="yi_tests"
+                ),
             ],
             destination_table=BigQueryResource(
                 project_id="metaphor-data", dataset_id="test", table_id="yi_tests"


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

We currently filter out BigQuery query log entries where the destination table appears in the source tables. This can lead to undesirable missing lineage.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Add a config option to control if self-reference should be filtered out, instead of dropping the query log entry altogether.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified against production.
