### PR TITLE
Speed up BigQuery profiler by turning off expensive column statistics by default

### DIFF
--- a/metaphor/bigquery/profile/README.md
+++ b/metaphor/bigquery/profile/README.md
@@ -12,6 +12,10 @@ The config file inherits all the required and optional fields from the general B
 
 ### Optional Configurations
 
+#### Column Statistics
+
+See [Column Statistics](../../common/docs/column_statistics.md) for details.
+
 #### Sampling
 
 See [Sampling Config](../../common/docs/sampling.md) for details.

--- a/metaphor/bigquery/profile/config.py
+++ b/metaphor/bigquery/profile/config.py
@@ -3,10 +3,16 @@ from dataclasses import field
 from pydantic.dataclasses import dataclass
 
 from metaphor.bigquery.config import BigQueryRunConfig
+from metaphor.common.column_statistics import ColumnStatistics
 from metaphor.common.sampling import SamplingConfig
 
 
 @dataclass
 class BigQueryProfileRunConfig(BigQueryRunConfig):
+
+    # Compute specific types of statistics for each column
+    column_statistics: ColumnStatistics = field(
+        default_factory=lambda: ColumnStatistics()
+    )
 
     sampling: SamplingConfig = field(default_factory=lambda: SamplingConfig())

--- a/metaphor/bigquery/profile/extractor.py
+++ b/metaphor/bigquery/profile/extractor.py
@@ -10,9 +10,9 @@ except ImportError:
     print("Please install metaphor[bigquery] extra\n")
     raise
 
-
 from metaphor.bigquery.extractor import BigQueryExtractor, build_client
 from metaphor.bigquery.profile.config import BigQueryProfileRunConfig, SamplingConfig
+from metaphor.common.column_statistics import ColumnStatistics
 from metaphor.common.event_util import ENTITY_TYPES
 from metaphor.common.extractor import BaseExtractor
 from metaphor.common.filter import DatasetFilter
@@ -46,6 +46,7 @@ class BigQueryProfileExtractor(BaseExtractor):
 
     def __init__(self):
         self._sampling = None
+        self._column_statistics = None
 
     async def extract(
         self, config: BigQueryProfileRunConfig
@@ -55,6 +56,7 @@ class BigQueryProfileExtractor(BaseExtractor):
         logger.info("Fetching usage info from BigQuery")
 
         self._sampling = config.sampling
+        self._column_statistics = config.column_statistics
 
         client = build_client(config)
         tables = self._fetch_tables(client, config)
@@ -133,7 +135,9 @@ class BigQueryProfileExtractor(BaseExtractor):
             else:
                 try:
                     results = [res for res in next(job.result())]
-                    BigQueryProfileExtractor._parse_result(results, schema, dataset)
+                    BigQueryProfileExtractor._parse_result(
+                        results, schema, dataset, self._column_statistics
+                    )
                 except AssertionError as error:
                     logger.error(f"Assertion failed during process results, {error}")
                 except StopIteration as error:
@@ -155,7 +159,9 @@ class BigQueryProfileExtractor(BaseExtractor):
         schema = BigQueryExtractor.parse_schema(bq_table)
 
         logger.debug(f"building query for {table}")
-        sql = self._build_profiling_query(schema, table, row_count, self._sampling)
+        sql = self._build_profiling_query(
+            schema, table, row_count, self._column_statistics, self._sampling
+        )
         job = client.query(sql)
 
         jobs.add(job.job_id)
@@ -168,6 +174,7 @@ class BigQueryProfileExtractor(BaseExtractor):
         schema: DatasetSchema,
         table_ref: TableReference,
         row_count: Union[int, None],
+        column_statistics: ColumnStatistics,
         sampling: SamplingConfig,
     ) -> str:
         query = ["SELECT COUNT(1)"]
@@ -175,22 +182,25 @@ class BigQueryProfileExtractor(BaseExtractor):
         for field in schema.fields:
             column = field.field_path
             data_type = field.native_type
-            nullable = field.nullable
 
-            if not BigQueryProfileExtractor._is_complex(data_type):
+            if (
+                column_statistics.unique_count
+                and not BigQueryProfileExtractor._is_complex(data_type)
+            ):
                 query.append(f", COUNT(DISTINCT `{column}`)")
 
-            if nullable:
+            if column_statistics.null_count:
                 query.append(f", COUNTIF(`{column}` is NULL)")
 
             if BigQueryProfileExtractor._is_numeric(data_type):
-                query.extend(
-                    [
-                        f", MIN(`{column}`)",
-                        f", MAX(`{column}`)",
-                        f", AVG(`{column}`)",
-                    ]
-                )
+                if column_statistics.min_value:
+                    query.append(f", MIN(`{column}`)")
+                if column_statistics.max_value:
+                    query.append(f", MAX(`{column}`)")
+                if column_statistics.avg_value:
+                    query.append(f", AVG(`{column}`)")
+                if column_statistics.std_dev:
+                    query.append(f", STDDEV(`{column}`)")
 
         query.append(f" FROM `{table_ref}`")
 
@@ -202,24 +212,102 @@ class BigQueryProfileExtractor(BaseExtractor):
         return "".join(query)
 
     @staticmethod
-    def _parse_result(results: List, schema: DatasetSchema, dataset: Dataset):
+    def _parse_result(
+        results: List,
+        schema: DatasetSchema,
+        dataset: Dataset,
+        column_statistics: ColumnStatistics,
+    ):
+        assert (
+            dataset.field_statistics is not None
+            and dataset.field_statistics.field_statistics is not None
+        )
+        fields = dataset.field_statistics.field_statistics
+
+        assert len(results) > 0, f"Empty result for ${dataset.logical_id}"
+        row_count = int(results[0])
+
+        index = 1
+        for field in schema.fields:
+            column = field.field_path
+            data_type = field.native_type
+
+            unique_count = None
+            if (
+                column_statistics.unique_count
+                and not BigQueryProfileExtractor._is_complex(data_type)
+            ):
+                unique_count = float(results[index])
+                index += 1
+
+            nulls, non_nulls = None, None
+            if column_statistics.null_count:
+                nulls = float(results[index])
+                non_nulls = row_count - nulls
+                index += 1
+
+            min_value, max_value, avg, std_dev = None, None, None, None
+            if BigQueryProfileExtractor._is_numeric(data_type):
+                if column_statistics.min_value:
+                    min_value = (
+                        None if results[index] is None else float(results[index])
+                    )
+                    index += 1
+
+                if column_statistics.max_value:
+                    max_value = (
+                        None if results[index] is None else float(results[index])
+                    )
+                    index += 1
+
+                if column_statistics.avg_value:
+                    avg = None if results[index] is None else float(results[index])
+                    index += 1
+
+                if column_statistics.std_dev:
+                    std_dev = None if results[index] is None else float(results[index])
+                    index += 1
+
+            fields.append(
+                FieldStatistics(
+                    field_path=column,
+                    distinct_value_count=unique_count,
+                    null_value_count=nulls,
+                    nonnull_value_count=non_nulls,
+                    min_value=min_value,
+                    max_value=max_value,
+                    average=avg,
+                    std_dev=std_dev,
+                )
+            )
+
+        # Verify that we've consumed all the elements from results
+        assert index == len(
+            results
+        ), f"Unconsumed elements from results for {dataset.logical_id}"
+
+        """
+        assert (
+            dataset.field_statistics is not None
+            and dataset.field_statistics.field_statistics is not None
+        )
+        fields = dataset.field_statistics.field_statistics
+
+        assert len(results) > 0, f"Empty result for ${dataset.logical_id}"
+
         row_count = int(results[0])
         index = 1
         for field in schema.fields:
             column = field.field_path
             data_type = field.native_type
-            nullable = field.nullable
 
             unique_values = None
             if not BigQueryProfileExtractor._is_complex(data_type):
                 unique_values = float(results[index])
                 index += 1
 
-            if nullable:
-                nulls = float(results[index]) if results[index] else 0.0
-                index += 1
-            else:
-                nulls = 0.0
+            nulls = float(results[index]) if results[index] else 0.0
+            index += 1
 
             if BigQueryProfileExtractor._is_numeric(data_type):
                 min_value = float(results[index]) if results[index] else None
@@ -227,6 +315,8 @@ class BigQueryProfileExtractor(BaseExtractor):
                 max_value = float(results[index]) if results[index] else None
                 index += 1
                 avg = float(results[index]) if results[index] else None
+                index += 1
+                stddev = float(results[index]) if results[index] else None
                 index += 1
             else:
                 min_value, max_value, avg = None, None, None
@@ -244,6 +334,7 @@ class BigQueryProfileExtractor(BaseExtractor):
             )
 
         assert index == len(results), "index should match number of results"
+        """
 
     # See https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#numeric_types
     @staticmethod

--- a/metaphor/bigquery/profile/extractor.py
+++ b/metaphor/bigquery/profile/extractor.py
@@ -286,56 +286,6 @@ class BigQueryProfileExtractor(BaseExtractor):
             results
         ), f"Unconsumed elements from results for {dataset.logical_id}"
 
-        """
-        assert (
-            dataset.field_statistics is not None
-            and dataset.field_statistics.field_statistics is not None
-        )
-        fields = dataset.field_statistics.field_statistics
-
-        assert len(results) > 0, f"Empty result for ${dataset.logical_id}"
-
-        row_count = int(results[0])
-        index = 1
-        for field in schema.fields:
-            column = field.field_path
-            data_type = field.native_type
-
-            unique_values = None
-            if not BigQueryProfileExtractor._is_complex(data_type):
-                unique_values = float(results[index])
-                index += 1
-
-            nulls = float(results[index]) if results[index] else 0.0
-            index += 1
-
-            if BigQueryProfileExtractor._is_numeric(data_type):
-                min_value = float(results[index]) if results[index] else None
-                index += 1
-                max_value = float(results[index]) if results[index] else None
-                index += 1
-                avg = float(results[index]) if results[index] else None
-                index += 1
-                stddev = float(results[index]) if results[index] else None
-                index += 1
-            else:
-                min_value, max_value, avg = None, None, None
-
-            dataset.field_statistics.field_statistics.append(
-                FieldStatistics(
-                    field_path=column,
-                    distinct_value_count=unique_values,
-                    null_value_count=nulls,
-                    nonnull_value_count=(row_count - nulls),
-                    min_value=min_value,
-                    max_value=max_value,
-                    average=avg,
-                )
-            )
-
-        assert index == len(results), "index should match number of results"
-        """
-
     # See https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#numeric_types
     @staticmethod
     def _is_numeric(data_type: str) -> bool:

--- a/metaphor/common/column_statistics.py
+++ b/metaphor/common/column_statistics.py
@@ -1,0 +1,22 @@
+from pydantic.dataclasses import dataclass
+
+
+@dataclass
+class ColumnStatistics:
+    # Compute null and non-null counts
+    null_count: bool = True
+
+    # Compute unique value counts
+    unique_count: bool = False
+
+    # Compute min value
+    min_value: bool = True
+
+    # Compute max value
+    max_value: bool = True
+
+    # Compute average value
+    avg_value: bool = False
+
+    # Compute standard deviation
+    std_dev: bool = False

--- a/metaphor/common/docs/column_statistics.md
+++ b/metaphor/common/docs/column_statistics.md
@@ -1,0 +1,24 @@
+# Column Statistics
+
+Profiling large tables can take a lot of time and resources. Fortunately, most data warehouses and databases pre-compute some column statistics (e.g. null count, min, and max) and can readily return them without resorting to a full table scan. These are enabled by default in the `column_statistics` config. To compute the other more expensive statistics, you'll need to manually enable them in the config.
+
+```yaml
+column_statistics:
+    # Compute null and non-null counts (default True)
+    null_count: true
+
+    # Compute unique value counts (default False)
+    unique_count: false
+
+    # Compute min value (default True)
+    min_value: true
+
+    # Compute max value (default True)
+    max_value: true
+
+    # Compute average value (default False)
+    avg_value: false
+
+    # Compute standard deviation (default False)
+    std_dev: false
+```

--- a/metaphor/snowflake/profile/README.md
+++ b/metaphor/snowflake/profile/README.md
@@ -34,6 +34,10 @@ By default, the connector only profile Snowflake "base table", i.e. exclude view
 exclude_views: false
 ```
 
+#### Column Statistics
+
+See [Column Statistics](../../common/docs/column_statistics.md) for details.
+
 #### Sampling
 
 See [Sampling Config](../../common/docs/sampling.md) for details.

--- a/metaphor/snowflake/profile/config.py
+++ b/metaphor/snowflake/profile/config.py
@@ -2,29 +2,9 @@ from dataclasses import field
 
 from pydantic.dataclasses import dataclass
 
+from metaphor.common.column_statistics import ColumnStatistics
 from metaphor.common.sampling import SamplingConfig
 from metaphor.snowflake.config import SnowflakeRunConfig
-
-
-@dataclass
-class ColumnStatistics:
-    # Compute null and non-null counts
-    null_count: bool = True
-
-    # Compute unique value counts
-    unique_count: bool = False
-
-    # Compute min value
-    min_value: bool = True
-
-    # Compute max value
-    max_value: bool = True
-
-    # Compute average value
-    avg_value: bool = False
-
-    # Compute standard deviation
-    std_dev: bool = False
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.7"
+version = "0.11.8"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/bigquery/profile/test_extractor.py
+++ b/tests/bigquery/profile/test_extractor.py
@@ -1,6 +1,7 @@
 from google.cloud.bigquery import DatasetReference, TableReference
 
 from metaphor.bigquery.profile.extractor import BigQueryProfileExtractor
+from metaphor.common.column_statistics import ColumnStatistics
 from metaphor.common.sampling import SamplingConfig
 from metaphor.models.metadata_change_event import (
     DataPlatform,
@@ -14,7 +15,7 @@ from metaphor.models.metadata_change_event import (
 )
 
 
-def test_build_profiling_query():
+def test_build_profiling_query_default():
     schema = DatasetSchema(
         fields=[
             SchemaField(field_path="id", native_type="STRING", nullable=False),
@@ -25,16 +26,57 @@ def test_build_profiling_query():
 
     table = TableReference(DatasetReference("project", "dataset_id"), "table_id")
 
+    column_statistics = ColumnStatistics()
+    sampling_config = SamplingConfig(percentage=50, threshold=100000)
+
     expected = (
-        "SELECT COUNT(1), COUNT(DISTINCT `id`), COUNT(DISTINCT `price`), "
-        "COUNTIF(`price` is NULL), MIN(`price`), MAX(`price`), AVG(`price`), "
+        "SELECT COUNT(1), "
+        "COUNTIF(`id` is NULL), "
+        "COUNTIF(`price` is NULL), MIN(`price`), MAX(`price`), "
         "COUNTIF(`json` is NULL) "
         "FROM `project.dataset_id.table_id`"
     )
 
     assert (
         BigQueryProfileExtractor._build_profiling_query(
-            schema, table, 1000, SamplingConfig(percentage=50, threshold=100000)
+            schema, table, 1000, column_statistics, sampling_config
+        )
+        == expected
+    )
+
+
+def test_build_profiling_query_full():
+    schema = DatasetSchema(
+        fields=[
+            SchemaField(field_path="id", native_type="STRING", nullable=False),
+            SchemaField(field_path="price", native_type="INT", nullable=True),
+            SchemaField(field_path="json", native_type="RECORD", nullable=True),
+        ]
+    )
+
+    table = TableReference(DatasetReference("project", "dataset_id"), "table_id")
+
+    column_statistics = ColumnStatistics(
+        null_count=True,
+        unique_count=True,
+        min_value=True,
+        max_value=True,
+        avg_value=True,
+        std_dev=True,
+    )
+    sampling_config = SamplingConfig(percentage=50, threshold=100000)
+
+    expected = (
+        "SELECT COUNT(1), "
+        "COUNT(DISTINCT `id`), COUNTIF(`id` is NULL), "
+        "COUNT(DISTINCT `price`), COUNTIF(`price` is NULL), MIN(`price`), MAX(`price`), AVG(`price`), STDDEV(`price`), "
+        "COUNTIF(`json` is NULL) "
+        "FROM `project.dataset_id.table_id`"
+    )
+
+    assert (
+        BigQueryProfileExtractor._build_profiling_query(
+            schema, table, 1000, column_statistics, sampling_config
         )
         == expected
     )
@@ -50,21 +92,26 @@ def test_build_profiling_query_with_sampling():
 
     table = TableReference(DatasetReference("project", "dataset_id"), "table_id")
 
+    column_statistics = ColumnStatistics()
+    sampling_config = SamplingConfig(percentage=50, threshold=100000)
+
     expected = (
-        "SELECT COUNT(1), COUNT(DISTINCT `id`), COUNT(DISTINCT `price`), "
-        "COUNTIF(`price` is NULL), MIN(`price`), MAX(`price`), AVG(`price`) "
-        "FROM `project.dataset_id.table_id` TABLESAMPLE SYSTEM (50 PERCENT)"
+        "SELECT COUNT(1), "
+        "COUNTIF(`id` is NULL), "
+        "COUNTIF(`price` is NULL), MIN(`price`), MAX(`price`) "
+        "FROM `project.dataset_id.table_id` "
+        "TABLESAMPLE SYSTEM (50 PERCENT)"
     )
 
     assert (
         BigQueryProfileExtractor._build_profiling_query(
-            schema, table, 1000000, SamplingConfig(percentage=50, threshold=100000)
+            schema, table, 1000000, column_statistics, sampling_config
         )
         == expected
     )
 
 
-def test_parse_profiling_result():
+def test_parse_profiling_result_default():
     schema = DatasetSchema(
         fields=[
             SchemaField(field_path="id", native_type="STRING", nullable=False),
@@ -72,34 +119,44 @@ def test_parse_profiling_result():
             SchemaField(field_path="json", native_type="RECORD", nullable=True),
         ]
     )
-    results = (5, 5, 4, 0, 3, 8, 5, 2)
+    results = (
+        # row count
+        5,
+        # id
+        2,
+        # price
+        0,
+        1,
+        2,
+        # json
+        5,
+    )
     dataset = BigQueryProfileExtractor._init_dataset(full_name="foo")
 
-    BigQueryProfileExtractor._parse_result(results, schema, dataset)
+    column_statistics = ColumnStatistics()
+
+    BigQueryProfileExtractor._parse_result(results, schema, dataset, column_statistics)
 
     assert dataset == Dataset(
         entity_type=EntityType.DATASET,
         field_statistics=DatasetFieldStatistics(
             field_statistics=[
                 FieldStatistics(
-                    distinct_value_count=5.0,
                     field_path="id",
-                    nonnull_value_count=5.0,
-                    null_value_count=0.0,
+                    nonnull_value_count=3.0,
+                    null_value_count=2.0,
                 ),
                 FieldStatistics(
-                    average=5.0,
-                    distinct_value_count=4.0,
                     field_path="price",
-                    max_value=8.0,
-                    min_value=3.0,
+                    max_value=2.0,
+                    min_value=1.0,
                     nonnull_value_count=5.0,
                     null_value_count=0.0,
                 ),
                 FieldStatistics(
                     field_path="json",
-                    nonnull_value_count=3.0,
-                    null_value_count=2.0,
+                    nonnull_value_count=0.0,
+                    null_value_count=5.0,
                 ),
             ]
         ),


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

BigQuery profiler can take a long time to run for large tables. Disable computing of expensive column statistics like we did for Snowflake profiler https://github.com/MetaphorData/connectors/pull/227.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Move `ColumnStatistics` class to `metaphor.common` package and add README file
- Add `column_statistics` config and construct BigQuery profiling query based on the settings 

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Tested again production. A previous run that timed out after an hour now completed in 15 minutes.
