### PR TITLE
Snowflake usage ambiguous column name USER [sc-11092]

### DIFF
--- a/metaphor/snowflake/usage/extractor.py
+++ b/metaphor/snowflake/usage/extractor.py
@@ -73,7 +73,7 @@ class SnowflakeUsageExtractor(BaseExtractor):
         )
 
         excluded_usernames_clause = (
-            f"and USER_NAME NOT IN ({','.join(['%s'] * len(config.excluded_usernames))})"
+            f"and q.USER_NAME NOT IN ({','.join(['%s'] * len(config.excluded_usernames))})"
             if len(config.excluded_usernames) > 0
             else ""
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.8"
+version = "0.11.9"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
### 🤔 Why?

ambiguous column name 'USER_NAME' when using user filter

### 🤓 What?

- add table qualifier for the 'USER_NAME' column

### 🧪 Tested?

tested against production instance
