### PR TITLE
BigQuery KeyError snapshot sync configuration [sc-11102]

### DIFF
--- a/metaphor/bigquery/extractor.py
+++ b/metaphor/bigquery/extractor.py
@@ -93,7 +93,7 @@ class BigQueryExtractor(BaseExtractor):
 
             for table_name, ddl in table_ddl:
                 table = tables.get(str(table_name).lower())
-                if not table:
+                if table is None:
                     logger.error(f"table {table_name} not found for DDL")
                     continue
                 table.schema.sql_schema.table_schema = ddl

--- a/metaphor/bigquery/extractor.py
+++ b/metaphor/bigquery/extractor.py
@@ -92,7 +92,7 @@ class BigQueryExtractor(BaseExtractor):
             ).result()
 
             for table_name, ddl in table_ddl:
-                table = tables[str(table_name).lower()]
+                table = tables.get(str(table_name).lower())
                 if not table:
                     logger.error(f"table {table_name} not found for DDL")
                     continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.11"
+version = "0.11.12"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
### 🤔 Why?

used python `dict[]` by mistake, which throws keyerror if the key is not found. 

### 🤓 What?

- use `dict.get()` since we are checking for `None` value in the next line

### 🧪 Tested?

tested against production instance.
