### PR TITLE
Add optional job_project_id config to BigQuery crawlers

### DIFF
--- a/metaphor/bigquery/README.md
+++ b/metaphor/bigquery/README.md
@@ -74,6 +74,14 @@ credentials:
 
 See [Filter Configurations](../common/docs/filter.md) for more information on the optional `filter` config.
 
+#### BigQuery Job Project ID
+
+By default, all BigQuery API calls are made using the project ID specified in `project_id` config. However, sometimes you may wish to run BigQuery jobs using a different project ID, e.g. when querying the DDLs for tables & views. You can do so by specifying the `job_project_id` config as follows,
+
+```yaml
+job_project_id: <project_id>
+```
+
 #### Concurrency
 
 The max number of concurrent requests to the google cloud API can be configured as follows,

--- a/metaphor/bigquery/config.py
+++ b/metaphor/bigquery/config.py
@@ -44,6 +44,9 @@ class BigQueryRunConfig(BaseConfig):
     # Project ID to use. Use the service account's default project if not set
     project_id: Optional[str] = None
 
+    # Use a different project ID to run BigQuery jobs if set
+    job_project_id: Optional[str] = None
+
     # Max number of concurrent requests to bigquery or logging API, default is 5
     max_concurrency: int = 5
 

--- a/metaphor/bigquery/extractor.py
+++ b/metaphor/bigquery/extractor.py
@@ -88,7 +88,8 @@ class BigQueryExtractor(BaseExtractor):
 
             logger.info(f"Getting table DDL for {dataset_ref}")
             table_ddl = client.query(
-                f"select table_name, ddl from `{dataset_ref.project}.{dataset_ref.dataset_id}.INFORMATION_SCHEMA.TABLES`"
+                f"select table_name, ddl from `{dataset_ref.project}.{dataset_ref.dataset_id}.INFORMATION_SCHEMA.TABLES`",
+                project=config.job_project_id,
             ).result()
 
             for table_name, ddl in table_ddl:

--- a/metaphor/bigquery/profile/extractor.py
+++ b/metaphor/bigquery/profile/extractor.py
@@ -56,7 +56,7 @@ class BigQueryProfileExtractor(BaseExtractor):
 
         logger.info("Fetching usage info from BigQuery")
 
-        self._job_project_id = config.project_id
+        self._job_project_id = config.job_project_id
         self._sampling = config.sampling
         self._column_statistics = config.column_statistics
 

--- a/metaphor/bigquery/profile/extractor.py
+++ b/metaphor/bigquery/profile/extractor.py
@@ -45,6 +45,7 @@ class BigQueryProfileExtractor(BaseExtractor):
         return BigQueryProfileRunConfig
 
     def __init__(self):
+        self._job_project_id = None
         self._sampling = None
         self._column_statistics = None
 
@@ -55,6 +56,7 @@ class BigQueryProfileExtractor(BaseExtractor):
 
         logger.info("Fetching usage info from BigQuery")
 
+        self._job_project_id = config.project_id
         self._sampling = config.sampling
         self._column_statistics = config.column_statistics
 
@@ -162,7 +164,7 @@ class BigQueryProfileExtractor(BaseExtractor):
         sql = self._build_profiling_query(
             schema, table, row_count, self._column_statistics, self._sampling
         )
-        job = client.query(sql)
+        job = client.query(sql, project=self._job_project_id)
 
         jobs.add(job.job_id)
         job.add_done_callback(partial(job_callback, schema=schema, dataset=dataset))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.12"
+version = "0.11.13"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/bigquery/config.yml
+++ b/tests/bigquery/config.yml
@@ -1,4 +1,5 @@
 ---
 key_path: key_path
 project_id: project_id
+job_project_id: job_project_id
 output: {}

--- a/tests/bigquery/test_config.py
+++ b/tests/bigquery/test_config.py
@@ -12,6 +12,7 @@ def test_yaml_config_with_key_path(test_root_dir):
     assert config == BigQueryRunConfig(
         key_path="key_path",
         project_id="project_id",
+        job_project_id="job_project_id",
         output=OutputConfig(),
     )
 


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

To allow running BigQuery jobs using a project ID different from the default.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Manually tested against a production deployment. 
