### PR TITLE
Missing snowflake view lineage [sc-11489]

### DIFF
--- a/metaphor/bigquery/lineage/README.md
+++ b/metaphor/bigquery/lineage/README.md
@@ -22,7 +22,7 @@ See [Access Control](https://cloud.google.com/logging/docs/access-control#consol
 The config file inherits all the required and optional fields from the general BigQuery connector [Config File](../README.md#config-file). In addition, you can specify the following configurations:
 
 ```yaml
-# # (Optional) Whether to enable parsing view definition to build view lineage, default True
+# (Optional) Whether to enable parsing view definition to build view lineage, default True
 enable_view_lineage: <boolean>
 
 # (Optional) Whether to enable parsing audit log to find table lineage information, default True

--- a/metaphor/snowflake/lineage/README.md
+++ b/metaphor/snowflake/lineage/README.md
@@ -11,7 +11,7 @@ Create a dedicated user & role based on the [Setup](../README.md#Setup) guide fo
 The config file inherits all the required and optional fields from the general Snowflake connector [Config File](../README.md#config-file). In addition, you can specify the following configurations:
 
 ```yaml
-# (Optional)Whether to enable finding view lineage from object dependencies, default True
+# (Optional) Whether to enable finding view lineage from object dependencies, default True.
 enable_view_lineage: bool = True
 
 # (Optional) Whether to enable finding table lineage information from access history and query history, default True

--- a/metaphor/snowflake/lineage/README.md
+++ b/metaphor/snowflake/lineage/README.md
@@ -11,6 +11,12 @@ Create a dedicated user & role based on the [Setup](../README.md#Setup) guide fo
 The config file inherits all the required and optional fields from the general Snowflake connector [Config File](../README.md#config-file). In addition, you can specify the following configurations:
 
 ```yaml
+# (Optional)Whether to enable finding view lineage from object dependencies, default True
+enable_view_lineage: bool = True
+
+# (Optional) Whether to enable finding table lineage information from access history and query history, default True
+enable_lineage_from_history: bool = True
+
 # (Optional) Number of days to include in the usage analysis. Default to 7.
 lookback_days: <days>
 

--- a/metaphor/snowflake/lineage/README.md
+++ b/metaphor/snowflake/lineage/README.md
@@ -14,7 +14,7 @@ The config file inherits all the required and optional fields from the general S
 # (Optional) Whether to enable finding view lineage from object dependencies, default True.
 enable_view_lineage: bool = True
 
-# (Optional) Whether to enable finding table lineage information from access history and query history, default True
+# (Optional) Whether to enable finding table lineage information from access history and query history, default True.
 enable_lineage_from_history: bool = True
 
 # (Optional) Number of days to include in the usage analysis. Default to 7.

--- a/metaphor/snowflake/lineage/config.py
+++ b/metaphor/snowflake/lineage/config.py
@@ -7,6 +7,12 @@ DEFAULT_BATCH_SIZE = 100000
 
 @dataclass
 class SnowflakeLineageRunConfig(SnowflakeRunConfig):
+    # Whether to enable finding view lineage from object dependencies, default True
+    enable_view_lineage: bool = True
+
+    # Whether to enable finding table lineage information from access history and query history, default True
+    enable_lineage_from_history: bool = True
+
     # Number of days back in the query log to process
     lookback_days: int = 7
 

--- a/metaphor/snowflake/lineage/extractor.py
+++ b/metaphor/snowflake/lineage/extractor.py
@@ -84,30 +84,12 @@ class SnowflakeLineageExtractor(BaseExtractor):
         with conn:
             cursor = conn.cursor()
 
-            # Join QUERY_HISTORY & ACCESS_HISTORY to include only queries that succeeded.
-            cursor.execute(
-                """
-                SELECT COUNT(*)
-                FROM
-                    SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY q,
-                    SNOWFLAKE.ACCOUNT_USAGE.ACCESS_HISTORY a
-                WHERE q.QUERY_ID = a.QUERY_ID
-                    AND q.EXECUTION_STATUS = 'SUCCESS'
-                    AND ARRAY_SIZE(a.BASE_OBJECTS_ACCESSED) > 0
-                    AND ARRAY_SIZE(a.OBJECTS_MODIFIED) > 0
-                    AND a.QUERY_START_TIME > %s
-                ORDER BY a.QUERY_START_TIME ASC
-                """,
-                (start_date,),
-            )
-            count = cursor.fetchone()[0]
-            batches = math.ceil(count / self.batch_size)
-            logger.info(f"Total {count} queries, dividing into {batches} batches")
-
-            queries = {
-                x: QueryWithParam(
-                    f"""
-                    SELECT a.BASE_OBJECTS_ACCESSED, a.OBJECTS_MODIFIED, q.QUERY_TEXT
+            if config.enable_lineage_from_history:
+                logger.info("Fetching access and query history")
+                # Join QUERY_HISTORY & ACCESS_HISTORY to include only queries that succeeded.
+                cursor.execute(
+                    """
+                    SELECT COUNT(*)
                     FROM
                         SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY q,
                         SNOWFLAKE.ACCOUNT_USAGE.ACCESS_HISTORY a
@@ -117,33 +99,54 @@ class SnowflakeLineageExtractor(BaseExtractor):
                         AND ARRAY_SIZE(a.OBJECTS_MODIFIED) > 0
                         AND a.QUERY_START_TIME > %s
                     ORDER BY a.QUERY_START_TIME ASC
-                    LIMIT {self.batch_size} OFFSET %s
                     """,
-                    (
-                        start_date,
-                        x * self.batch_size,
-                    ),
+                    (start_date,),
                 )
-                for x in range(batches)
-            }
-            async_execute(
-                conn,
-                queries,
-                "fetch_access_logs",
-                self.max_concurrency,
-                self._parse_access_logs,
-            )
+                count = cursor.fetchone()[0]
+                batches = math.ceil(count / self.batch_size)
+                logger.info(f"Total {count} queries, dividing into {batches} batches")
 
-            logger.info("Fetching direct object dependencies")
-            cursor.execute(
-                """
-                SELECT REFERENCED_DATABASE, REFERENCED_SCHEMA, REFERENCED_OBJECT_NAME, REFERENCED_OBJECT_DOMAIN,
-                    REFERENCING_DATABASE, REFERENCING_SCHEMA, REFERENCING_OBJECT_NAME, REFERENCING_OBJECT_DOMAIN
-                FROM SNOWFLAKE.ACCOUNT_USAGE.OBJECT_DEPENDENCIES;
-                """
-            )
-            dependencies = cursor.fetchall()
-            self._parse_object_dependencies(dependencies)
+                queries = {
+                    x: QueryWithParam(
+                        f"""
+                        SELECT a.BASE_OBJECTS_ACCESSED, a.OBJECTS_MODIFIED, q.QUERY_TEXT
+                        FROM
+                            SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY q,
+                            SNOWFLAKE.ACCOUNT_USAGE.ACCESS_HISTORY a
+                        WHERE q.QUERY_ID = a.QUERY_ID
+                            AND q.EXECUTION_STATUS = 'SUCCESS'
+                            AND ARRAY_SIZE(a.BASE_OBJECTS_ACCESSED) > 0
+                            AND ARRAY_SIZE(a.OBJECTS_MODIFIED) > 0
+                            AND a.QUERY_START_TIME > %s
+                        ORDER BY a.QUERY_START_TIME ASC
+                        LIMIT {self.batch_size} OFFSET %s
+                        """,
+                        (
+                            start_date,
+                            x * self.batch_size,
+                        ),
+                    )
+                    for x in range(batches)
+                }
+                async_execute(
+                    conn,
+                    queries,
+                    "fetch_access_logs",
+                    self.max_concurrency,
+                    self._parse_access_logs,
+                )
+
+            if config.enable_view_lineage:
+                logger.info("Fetching direct object dependencies")
+                cursor.execute(
+                    """
+                    SELECT REFERENCED_DATABASE, REFERENCED_SCHEMA, REFERENCED_OBJECT_NAME, REFERENCED_OBJECT_DOMAIN,
+                        REFERENCING_DATABASE, REFERENCING_SCHEMA, REFERENCING_OBJECT_NAME, REFERENCING_OBJECT_DOMAIN
+                    FROM SNOWFLAKE.ACCOUNT_USAGE.OBJECT_DEPENDENCIES;
+                    """
+                )
+                dependencies = cursor.fetchall()
+                self._parse_object_dependencies(dependencies)
 
         return self._datasets.values()
 

--- a/metaphor/snowflake/lineage/extractor.py
+++ b/metaphor/snowflake/lineage/extractor.py
@@ -233,7 +233,7 @@ class SnowflakeLineageExtractor(BaseExtractor):
                 not source_object_domain
                 or source_object_domain.upper() not in SUPPORTED_OBJECT_DOMAIN_TYPES
                 or not target_object_domain
-                or target_object_domain not in SUPPORTED_OBJECT_DOMAIN_TYPES
+                or target_object_domain.upper() not in SUPPORTED_OBJECT_DOMAIN_TYPES
             ):
                 continue
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.16"
+version = "0.11.17"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/snowflake/lineage/data/parse_object_dependencies_result.json
+++ b/tests/snowflake/lineage/data/parse_object_dependencies_result.json
@@ -1,0 +1,14 @@
+{
+  "acme.metaphor.bar": {
+    "logicalId": {
+      "account": "snowflake_account",
+      "name": "acme.metaphor.bar",
+      "platform": "SNOWFLAKE"
+    },
+    "upstream": {
+      "sourceDatasets": [
+        "DATASET~EAEA28F30430853E9C299356A7C4CB46"
+      ]
+    }
+  }
+}

--- a/tests/snowflake/lineage/data/parse_object_dependencies_result.json
+++ b/tests/snowflake/lineage/data/parse_object_dependencies_result.json
@@ -10,5 +10,17 @@
         "DATASET~EAEA28F30430853E9C299356A7C4CB46"
       ]
     }
+  },
+  "acme.metaphor.xyz": {
+    "logicalId": {
+      "account": "snowflake_account",
+      "name": "acme.metaphor.xyz",
+      "platform": "SNOWFLAKE"
+    },
+    "upstream": {
+      "sourceDatasets": [
+        "DATASET~219FE88EBECD32D96D20E516E08E4DA0"
+      ]
+    }
   }
 }

--- a/tests/snowflake/lineage/test_config.py
+++ b/tests/snowflake/lineage/test_config.py
@@ -5,13 +5,15 @@ from metaphor.snowflake.lineage.config import SnowflakeLineageRunConfig
 
 def test_yaml_config(test_root_dir):
     config = SnowflakeLineageRunConfig.from_yaml_file(
-        f"{test_root_dir}/snowflake/usage/config.yml"
+        f"{test_root_dir}/snowflake/lineage/config.yml"
     )
 
     assert config == SnowflakeLineageRunConfig(
         account="account",
         user="user",
         password="password",
+        enable_view_lineage=True,
+        enable_lineage_from_history=True,
         filter=DatasetFilter(),
         lookback_days=7,
         output=OutputConfig(),

--- a/tests/snowflake/lineage/test_parser.py
+++ b/tests/snowflake/lineage/test_parser.py
@@ -68,7 +68,9 @@ def test_parse_object_dependencies(test_root_dir):
     extractor.filter = DatasetFilter()
 
     dependencies = [
-        ("ACME", "METAPHOR", "FOO", "TABLE", "ACME", "METAPHOR", "BAR", "VIEW")
+        ("ACME", "METAPHOR", "FOO", "TABLE", "ACME", "METAPHOR", "BAR", "VIEW"),
+        ("ACME", "METAPHOR", "ABC", "TABLE", "ACME", "METAPHOR", "XYZ", "VIEW"),
+        ("ACME", "METAPHOR", "F", "TABLE", "ACME", "METAPHOR", "B", "STAGE"),
     ]
 
     extractor._parse_object_dependencies(dependencies)

--- a/tests/snowflake/lineage/test_parser.py
+++ b/tests/snowflake/lineage/test_parser.py
@@ -60,3 +60,23 @@ def test_parse_access_log(test_root_dir):
     assert results == load_json(
         test_root_dir + "/snowflake/lineage/data/parse_query_log_result.json"
     )
+
+
+def test_parse_object_dependencies(test_root_dir):
+    extractor = SnowflakeLineageExtractor()
+    extractor.account = "snowflake_account"
+    extractor.filter = DatasetFilter()
+
+    dependencies = [
+        ("ACME", "METAPHOR", "FOO", "TABLE", "ACME", "METAPHOR", "BAR", "VIEW")
+    ]
+
+    extractor._parse_object_dependencies(dependencies)
+
+    results = {}
+    for key, value in extractor._datasets.items():
+        results[key] = EventUtil.clean_nones(value.to_dict())
+
+    assert results == load_json(
+        test_root_dir + "/snowflake/lineage/data/parse_object_dependencies_result.json"
+    )


### PR DESCRIPTION
### 🤔 Why?

the `access_history` doesn’t contain any table to view lineage, since creating a view by query does not actually write any data.

### 🤓 What?

- use the `object_dependencies` view to get table to view direct relationship. https://docs.snowflake.com/en/user-guide/object-dependencies.html#label-object-dependencies-view-query

### 🧪 Tested?

tested against our snowflake instance and verified the output JSON
