### PR TITLE
Improve PAX parsing to handle names without quotes

### DIFF
--- a/metaphor/power_bi/power_query_parser.py
+++ b/metaphor/power_bi/power_query_parser.py
@@ -23,11 +23,15 @@ class PowerQueryParser:
         assert match, "Can't parse platform from power query expression."
         platform_str = match.group(1)
 
-        field_pattern = re.compile(r'{\[Name="([\w\-]+)"(.*)\]}')
+        field_pattern_param = re.compile(r'{\[Name="([\w\-]+)".*\]}')
+        field_pattern_var = re.compile(r"^\s+(\w+)_\w+ = .+")
 
         def get_field(text: str) -> str:
-            match = field_pattern.search(text)
-            assert match, "Can't parse field from power query expression"
+            match = field_pattern_param.search(text)
+            if match is None:
+                match = field_pattern_var.search(text)
+
+            assert match, f"Can't parse field from power query expression: {text}"
             return match.group(1)
 
         account = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.18"
+version = "0.11.19"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/power_bi/test_parse_power_query.py
+++ b/tests/power_bi/test_parse_power_query.py
@@ -20,6 +20,15 @@ def test_parse_dataset_snowflake():
         )
     ]
 
+    exp = 'let\n    Source = Snowflake.Databases("some-account.snowflakecomputing.com","COMPUTE_WH"),\n    DB_NAME_Database = Source{[Name=Database,Kind="Database"]}[Data],\n    PUBLIC_Schema = DB_Database{[Name="PUBLIC",Kind="Schema"]}[Data],\n    TEST_Table = PUBLIC_Schema{[Name="TEST",Kind="Table"]}[Data]\nin\n    TEST_Table'
+    assert PowerQueryParser.parse_source_datasets(exp) == [
+        to_dataset_entity_id(
+            "db_name.public.test",
+            platform=DataPlatform.SNOWFLAKE,
+            account="some-account",
+        )
+    ]
+
 
 def test_parse_dataset_bigquery():
     exp = 'let\n    Source = GoogleBigQuery.Database(),\n    #"test-project" = Source{[Name="test-project"]}[Data],\n    test_Schema = #"test-project"{[Name="test",Kind="Schema"]}[Data],\n    example_Table = test_Schema{[Name="example",Kind="Table"]}[Data]\nin\n    example_Table'


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

It's possible to specify database, schema, and table name without using the double quotation marks in PAX, e.g. 

```
let
    Source = Snowflake.Databases("<account>", DATA_WAREHOUSE, [CreateNavigationProperties=null, ConnectionTimeout=null, CommandTimeout=null]),\
    DB_PRD_REPORTING_Database = Source{[Name=DATABASE,Kind="Database"]}[Data],
    EDW_Schema = DB_PRD_REPORTING_Database{[Name="EDW",Kind="Schema"]}[Data],
    SITE_VW_View = EDW_Schema{[Name="SITE_VW",Kind="View"]}[Data],
    ...
```

In this case, the only way to extract the name of the database (`DB_PRD_REPORTING`) is from the variable name (`DB_PRD_REPORTING_Database`). 

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Manually verified against the production deployment.
