### PR TITLE
tests failing

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,13 @@
+# Docker Images
+
+Production Docker images are automatically built and published to [Metaphor's Docker Hub](https://hub.docker.com/r/metaphordata/connectors) as part of the CI/CD pipeline.
+
+To build and publish an image with the `test` tag for testing, run the following commands,
+
+```sh
+# Assuming not yet logged in
+docker login
+
+docker build --platform linux/amd64 -t metaphordata/connectors:test .
+docker push metaphordata/connectors:test
+```

--- a/metaphor/bigquery/config.py
+++ b/metaphor/bigquery/config.py
@@ -51,9 +51,7 @@ class BigQueryRunConfig(BaseConfig):
     max_concurrency: int = 5
 
     # Include or exclude specific databases/schemas/tables
-    filter: Optional[DatasetFilter] = dataclass_field(
-        default_factory=lambda: DatasetFilter()
-    )
+    filter: DatasetFilter = dataclass_field(default_factory=lambda: DatasetFilter())
 
     @root_validator
     def have_key_path_or_credentials(cls, values):

--- a/metaphor/common/cli.py
+++ b/metaphor/common/cli.py
@@ -1,9 +1,8 @@
 from typing import Type
 
-from metaphor.common.extractor import BaseExtractor
+from metaphor.common.base_extractor import BaseExtractor
 
 
 def cli_main(extractor_cls: Type[BaseExtractor], config_file: str):
-    extractor = extractor_cls()
-    config_cls = extractor.config_class()
-    extractor.run(config=config_cls.from_yaml_file(config_file))
+    extractor = extractor_cls.from_config_file(config_file)
+    extractor.run()

--- a/metaphor/dbt/extractor.py
+++ b/metaphor/dbt/extractor.py
@@ -1,8 +1,8 @@
 import json
-from typing import Collection, Dict, List, Optional, Union
+from typing import Collection, Dict, List, Union
 
+from metaphor.common.base_extractor import BaseExtractor
 from metaphor.common.event_util import ENTITY_TYPES
-from metaphor.common.extractor import BaseExtractor
 from metaphor.common.logger import get_logger
 from metaphor.dbt.config import DbtRunConfig
 from metaphor.models.crawler_run_metadata import Platform
@@ -14,7 +14,6 @@ from metaphor.models.metadata_change_event import (
 )
 
 from .catalog_parser_v1 import CatalogParserV1
-from .generated.dbt_catalog_v1 import DbtCatalog
 from .manifest_parser_v3 import ManifestParserV3
 from .manifest_parser_v5 import ManifestParserV5
 from .manifest_parser_v6 import ManifestParserV6
@@ -28,36 +27,33 @@ class DbtExtractor(BaseExtractor):
     Using manifest v3 and catalog v1 schema, but backward-compatible with older schema versions
     """
 
-    def platform(self) -> Optional[Platform]:
-        return Platform.DBT_MODEL
-
-    def description(self) -> str:
-        return "dbt metadata crawler"
-
     @staticmethod
-    def config_class():
-        return DbtRunConfig
+    def from_config_file(config_file: str) -> "DbtExtractor":
+        return DbtExtractor(DbtRunConfig.from_yaml_file(config_file))
 
-    def __init__(self):
-        self.data_platform: DataPlatform = DataPlatform.UNKNOWN
-        self._catalog: Optional[DbtCatalog] = None
+    def __init__(self, config: DbtRunConfig):
+        super().__init__(config, "dbt metadata crawler", Platform.DBT_MODEL)
+        self._manifest = config.manifest
+        self._catalog = config.catalog
+        self._config = config
+
+        self._data_platform = DataPlatform.UNKNOWN
         self._datasets: Dict[str, Dataset] = {}
         self._virtual_views: Dict[str, VirtualView] = {}
         self._metrics: Dict[str, Metric] = {}
 
-    async def extract(self, config: DbtRunConfig) -> Collection[ENTITY_TYPES]:
-        assert isinstance(config, DbtExtractor.config_class())
+    async def extract(self) -> Collection[ENTITY_TYPES]:
 
         logger.info("Fetching metadata from DBT repo")
 
-        with open(config.manifest) as file:
+        with open(self._manifest) as file:
             manifest_json = json.load(file)
 
         manifest_metadata = manifest_json.get("metadata", "")
 
         platform = manifest_metadata.get("adapter_type", "").upper()
         assert platform in DataPlatform.__members__, f"Invalid data platform {platform}"
-        self.data_platform = DataPlatform[platform]
+        self._data_platform = DataPlatform[platform]
 
         schema_version = (
             manifest_metadata.get("dbt_schema_version", "")
@@ -68,23 +64,23 @@ class DbtExtractor(BaseExtractor):
         manifest_parser: Union[ManifestParserV3, ManifestParserV5, ManifestParserV6]
         if schema_version in ("v1", "v2", "v3"):
             manifest_parser = ManifestParserV3(
-                config,
-                self.data_platform,
+                self._config,
+                self._data_platform,
                 self._datasets,
                 self._virtual_views,
             )
         elif schema_version in ("v4", "v5"):
             manifest_parser = ManifestParserV5(
-                config,
-                self.data_platform,
+                self._config,
+                self._data_platform,
                 self._datasets,
                 self._virtual_views,
                 self._metrics,
             )
         elif schema_version == "v6":
             manifest_parser = ManifestParserV6(
-                config,
-                self.data_platform,
+                self._config,
+                self._data_platform,
                 self._datasets,
                 self._virtual_views,
                 self._metrics,
@@ -95,16 +91,16 @@ class DbtExtractor(BaseExtractor):
         logger.info(f"parsing manifest.json {schema_version} ...")
         manifest_parser.parse(manifest_json)
 
-        if config.catalog:
+        if self._catalog:
             catalog_parser = CatalogParserV1(
-                config,
-                self.data_platform,
+                self._config,
+                self._data_platform,
                 self._datasets,
                 self._virtual_views,
             )
 
             logger.info("parsing catalog.json ...")
-            catalog_parser.parse(config.catalog)
+            catalog_parser.parse(self._catalog)
 
         entities: List[ENTITY_TYPES] = []
         entities.extend(self._datasets.values())

--- a/metaphor/manual/governance/config.py
+++ b/metaphor/manual/governance/config.py
@@ -3,7 +3,7 @@ from typing import List
 
 from pydantic.dataclasses import dataclass
 
-from metaphor.common.extractor import BaseConfig
+from metaphor.common.base_extractor import BaseConfig
 from metaphor.common.models import DeserializableDatasetLogicalID
 
 

--- a/metaphor/manual/governance/extractor.py
+++ b/metaphor/manual/governance/extractor.py
@@ -1,9 +1,9 @@
-from typing import List, Optional
+from typing import List
 
+from metaphor.common.base_extractor import BaseExtractor
 from metaphor.common.entity_id import to_person_entity_id
-from metaphor.common.extractor import BaseExtractor
 from metaphor.common.logger import get_logger
-from metaphor.models.crawler_run_metadata import Platform
+from metaphor.manual.governance.config import ManualGovernanceConfig
 from metaphor.models.metadata_change_event import (
     Dataset,
     MetadataChangeEvent,
@@ -12,32 +12,27 @@ from metaphor.models.metadata_change_event import (
     TagAssignment,
 )
 
-from .config import ManualGovernanceConfig
-
 logger = get_logger(__name__)
 
 
 class ManualGovernanceExtractor(BaseExtractor):
     """Manual governance extractor"""
 
-    def platform(self) -> Optional[Platform]:
-        return None
-
-    def description(self) -> str:
-        return "Manual governance connector"
-
     @staticmethod
-    def config_class():
-        return ManualGovernanceConfig
+    def from_config_file(config_file: str) -> "ManualGovernanceExtractor":
+        return ManualGovernanceExtractor(
+            ManualGovernanceConfig.from_yaml_file(config_file)
+        )
 
-    async def extract(
-        self, config: ManualGovernanceConfig
-    ) -> List[MetadataChangeEvent]:
-        assert isinstance(config, ManualGovernanceExtractor.config_class())
+    def __init__(self, config: ManualGovernanceConfig) -> None:
+        super().__init__(config, "Manual governance connector", None)
+        self._datasets = config.datasets
+
+    async def extract(self) -> List[MetadataChangeEvent]:
         logger.info("Fetching governance from config")
 
         datasets = []
-        for governance in config.datasets:
+        for governance in self._datasets:
             dataset = Dataset(logical_id=governance.id.to_logical_id())
             datasets.append(dataset)
 

--- a/metaphor/manual/lineage/config.py
+++ b/metaphor/manual/lineage/config.py
@@ -2,7 +2,7 @@ from typing import List
 
 from pydantic.dataclasses import dataclass
 
-from metaphor.common.extractor import BaseConfig
+from metaphor.common.base_extractor import BaseConfig
 from metaphor.common.models import DeserializableDatasetLogicalID
 
 

--- a/metaphor/postgresql/config.py
+++ b/metaphor/postgresql/config.py
@@ -1,5 +1,4 @@
 from dataclasses import field
-from typing import Optional
 
 from pydantic.dataclasses import dataclass
 
@@ -15,6 +14,6 @@ class PostgreSQLRunConfig(BaseConfig):
     password: str
 
     # Include or exclude specific databases/schemas/tables
-    filter: Optional[DatasetFilter] = field(default_factory=lambda: DatasetFilter())
+    filter: DatasetFilter = field(default_factory=lambda: DatasetFilter())
 
     port: int = 5432

--- a/metaphor/redshift/access_event.py
+++ b/metaphor/redshift/access_event.py
@@ -2,10 +2,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import AsyncIterator
 
-from asyncpg import Record
-
-from metaphor.postgresql.config import PostgreSQLRunConfig
-from metaphor.postgresql.extractor import PostgreSQLExtractor
+from asyncpg import Connection, Record
 
 REDSHIFT_USAGE_SQL_TEMPLATE = """
 SELECT DISTINCT ss.userid,
@@ -66,12 +63,10 @@ class AccessEvent:
 
     @staticmethod
     async def fetch_access_event(
-        config: PostgreSQLRunConfig,
-        database: str,
+        conn: Connection,
         start_date: datetime,
         end_date: datetime,
     ) -> AsyncIterator["AccessEvent"]:
-        conn = await PostgreSQLExtractor._connect_database(config, database)
 
         results = await conn.fetch(
             REDSHIFT_USAGE_SQL_TEMPLATE.format(

--- a/metaphor/redshift/profile/extractor.py
+++ b/metaphor/redshift/profile/extractor.py
@@ -1,10 +1,6 @@
-from typing import Collection, Optional
-
-from metaphor.common.event_util import ENTITY_TYPES
 from metaphor.common.logger import get_logger
 from metaphor.models.crawler_run_metadata import Platform
 from metaphor.models.metadata_change_event import DataPlatform
-from metaphor.postgresql.extractor import PostgreSQLExtractor
 from metaphor.postgresql.profile.extractor import PostgreSQLProfileExtractor
 from metaphor.redshift.profile.config import RedshiftProfileRunConfig
 
@@ -14,23 +10,16 @@ logger = get_logger(__name__)
 class RedshiftProfileExtractor(PostgreSQLProfileExtractor):
     """Redshift data profile extractor"""
 
-    def platform(self) -> Optional[Platform]:
-        return Platform.REDSHIFT
-
-    def description(self) -> str:
-        return "Redshift data profile crawler"
-
     @staticmethod
-    def config_class():
-        return RedshiftProfileRunConfig
+    def from_config_file(config_file: str) -> "RedshiftProfileExtractor":
+        return RedshiftProfileExtractor(
+            RedshiftProfileRunConfig.from_yaml_file(config_file)
+        )
 
-    def __init__(self):
-        super().__init__()
-        self._platform = DataPlatform.REDSHIFT
-
-    async def extract(
-        self, config: RedshiftProfileRunConfig
-    ) -> Collection[ENTITY_TYPES]:
-        assert isinstance(config, PostgreSQLExtractor.config_class())
-        logger.info(f"Fetching data profile from redshift host {config.host}")
-        return await self._extract(config)
+    def __init__(self, config: RedshiftProfileRunConfig):
+        super().__init__(
+            config,
+            "Redshift data profile crawler",
+            Platform.REDSHIFT,
+            DataPlatform.REDSHIFT,
+        )

--- a/metaphor/snowflake/config.py
+++ b/metaphor/snowflake/config.py
@@ -1,5 +1,4 @@
 from dataclasses import field
-from typing import Optional
 
 from pydantic.dataclasses import dataclass
 
@@ -12,7 +11,7 @@ from metaphor.snowflake.utils import DEFAULT_THREAD_POOL_SIZE
 class SnowflakeRunConfig(SnowflakeAuthConfig):
 
     # Include or exclude specific databases/schemas/tables
-    filter: Optional[DatasetFilter] = field(default_factory=lambda: DatasetFilter())
+    filter: DatasetFilter = field(default_factory=lambda: DatasetFilter())
 
     # Max number of concurrent queries to database
-    max_concurrency: Optional[int] = DEFAULT_THREAD_POOL_SIZE
+    max_concurrency: int = DEFAULT_THREAD_POOL_SIZE

--- a/metaphor/tableau/config.py
+++ b/metaphor/tableau/config.py
@@ -1,9 +1,11 @@
 import dataclasses
 from typing import Dict, Optional
 
+from pydantic import root_validator
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
+from metaphor.common.utils import must_set_exactly_one
 
 
 @dataclass
@@ -39,3 +41,8 @@ class TableauRunConfig(BaseConfig):
 
     # whether to disable Chart preview image
     disable_preview_image: bool = False
+
+    @root_validator
+    def have_access_token_or_user_password(cls, values):
+        must_set_exactly_one(values, ["access_token", "user_password"])
+        return values

--- a/metaphor/thought_spot/__init__.py
+++ b/metaphor/thought_spot/__init__.py
@@ -1,6 +1,6 @@
 from metaphor.common.cli import cli_main
-from metaphor.thought_spot.extractor import ThoughtspotExtractor
+from metaphor.thought_spot.extractor import ThoughtSpotExtractor
 
 
 def main(config_file: str):
-    cli_main(ThoughtspotExtractor, config_file)
+    cli_main(ThoughtSpotExtractor, config_file)

--- a/metaphor/thought_spot/config.py
+++ b/metaphor/thought_spot/config.py
@@ -7,7 +7,7 @@ from metaphor.common.base_config import BaseConfig
 
 
 @dataclass
-class ThoughtspotRunConfig(BaseConfig):
+class ThoughtSpotRunConfig(BaseConfig):
     user: str
 
     # ThoughtSpot instance url

--- a/metaphor/thought_spot/utils.py
+++ b/metaphor/thought_spot/utils.py
@@ -40,7 +40,7 @@ from metaphor.models.metadata_change_event import (
     DataPlatform,
     ThoughtSpotDataObjectType,
 )
-from metaphor.thought_spot.config import ThoughtspotRunConfig
+from metaphor.thought_spot.config import ThoughtSpotRunConfig
 from metaphor.thought_spot.models import (
     AnswerMetadata,
     ConnectionHeader,
@@ -143,7 +143,7 @@ class ThoughtSpot:
     }
 
     @staticmethod
-    def create_client(config: ThoughtspotRunConfig) -> RestapisdkClient:
+    def create_client(config: ThoughtSpotRunConfig) -> RestapisdkClient:
         def _client(token: str):
             return RestapisdkClient(
                 content_type="application/json",

--- a/tests/bigquery/query/test_extractor.py
+++ b/tests/bigquery/query/test_extractor.py
@@ -22,17 +22,18 @@ def mock_list_entries(mock_build_log_client, entries):
 @freeze_time("2022-01-27")
 async def test_extractor(test_root_dir):
     config = BigQueryQueryRunConfig(output=OutputConfig(), key_path="fake_file")
-    extractor = BigQueryQueryExtractor()
 
     entries = load_entries(test_root_dir + "/bigquery/query/data/sample_log.json")
 
     # @patch doesn't work for async func in py3.7: https://bugs.python.org/issue36996
     with patch(
         "metaphor.bigquery.query.extractor.build_logging_client"
-    ) as mock_build_client:
-        mock_build_client.return_value.project = "project1"
-        mock_list_entries(mock_build_client, entries)
+    ) as mock_build_logging_client:
+        extractor = BigQueryQueryExtractor(config)
 
-        events = [EventUtil.trim_event(e) for e in await extractor.extract(config)]
+        mock_build_logging_client.return_value.project = "project1"
+        mock_list_entries(mock_build_logging_client, entries)
+
+        events = [EventUtil.trim_event(e) for e in await extractor.extract()]
 
     assert events == load_json(test_root_dir + "/bigquery/query/data/result.json")

--- a/tests/bigquery/test_extractor.py
+++ b/tests/bigquery/test_extractor.py
@@ -83,10 +83,11 @@ async def test_extractor(test_root_dir):
     config = BigQueryRunConfig(
         output=OutputConfig(), key_path="fake_file", project_id="fake_project"
     )
-    extractor = BigQueryExtractor()
 
     # @patch doesn't work for async func in py3.7: https://bugs.python.org/issue36996
     with patch("metaphor.bigquery.extractor.build_client") as mock_build_client:
+        extractor = BigQueryExtractor(config)
+
         mock_build_client.return_value.project = "project1"
 
         mock_list_datasets(mock_build_client, [mock_dataset("dataset1")])
@@ -168,6 +169,6 @@ async def test_extractor(test_root_dir):
             },
         )
 
-        events = [EventUtil.trim_event(e) for e in await extractor.extract(config)]
+        events = [EventUtil.trim_event(e) for e in await extractor.extract()]
 
     assert events == load_json(f"{test_root_dir}/bigquery/expected.json")

--- a/tests/bigquery/usage/test_extractor.py
+++ b/tests/bigquery/usage/test_extractor.py
@@ -24,18 +24,19 @@ async def test_extractor(test_root_dir):
     config = BigQueryUsageRunConfig(
         use_history=False, output=OutputConfig(), key_path="fake_file"
     )
-    extractor = BigQueryUsageExtractor()
 
     entries = load_entries(test_root_dir + "/bigquery/usage/data/sample_log.json")
 
     # @patch doesn't work for async func in py3.7: https://bugs.python.org/issue36996
     with patch(
         "metaphor.bigquery.usage.extractor.build_logging_client"
-    ) as mock_build_client:
-        mock_build_client.return_value.project = "project1"
-        mock_list_entries(mock_build_client, entries)
+    ) as mock_build_logging_client:
+        extractor = BigQueryUsageExtractor(config)
 
-        events = [EventUtil.trim_event(e) for e in await extractor.extract(config)]
+        mock_build_logging_client.return_value.project = "project1"
+        mock_list_entries(mock_build_logging_client, entries)
+
+        events = [EventUtil.trim_event(e) for e in await extractor.extract()]
 
     assert events == load_json(test_root_dir + "/bigquery/usage/data/result.json")
 
@@ -44,18 +45,19 @@ async def test_extractor(test_root_dir):
 @freeze_time("2022-01-10")
 async def test_extractor_use_history(test_root_dir):
     config = BigQueryUsageRunConfig(output=OutputConfig(), key_path="fake_file")
-    extractor = BigQueryUsageExtractor()
 
     entries = load_entries(test_root_dir + "/bigquery/usage/data/sample_log.json")
 
     # @patch doesn't work for async func in py3.7: https://bugs.python.org/issue36996
     with patch(
         "metaphor.bigquery.usage.extractor.build_logging_client"
-    ) as mock_build_client:
-        mock_build_client.return_value.project = "project1"
-        mock_list_entries(mock_build_client, entries)
+    ) as mock_build_logging_client:
+        extractor = BigQueryUsageExtractor(config)
 
-        events = [EventUtil.trim_event(e) for e in await extractor.extract(config)]
+        mock_build_logging_client.return_value.project = "project1"
+        mock_list_entries(mock_build_logging_client, entries)
+
+        events = [EventUtil.trim_event(e) for e in await extractor.extract()]
 
     assert events == load_json(
         test_root_dir + "/bigquery/usage/data/history_result.json"

--- a/tests/bigquery/usage/test_parser.py
+++ b/tests/bigquery/usage/test_parser.py
@@ -1,8 +1,11 @@
-import re
+from datetime import datetime, timezone
+from unittest.mock import patch
 
 from freezegun import freeze_time
 
+from metaphor.bigquery.usage.config import BigQueryUsageRunConfig
 from metaphor.bigquery.usage.extractor import BigQueryUsageExtractor
+from metaphor.common.base_config import OutputConfig
 from metaphor.common.event_util import EventUtil
 from tests.bigquery.load_entries import load_entries
 from tests.test_utils import load_json
@@ -10,16 +13,22 @@ from tests.test_utils import load_json
 
 @freeze_time("2022-01-10")
 def test_parse_access_log(test_root_dir):
-    extractor = BigQueryUsageExtractor()
-    extractor._datasets_pattern = [re.compile(".*")]
-
-    for entry in load_entries(test_root_dir + "/bigquery/usage/data/sample_log.json"):
-        extractor._parse_table_data_read_entry(entry, False)
-
-    results = {}
-    for key, value in extractor._datasets.items():
-        results[key] = EventUtil.clean_nones(value.to_dict())
-
-    assert results == load_json(
-        test_root_dir + "/bigquery/usage/data/parse_query_log_result.json"
+    config = BigQueryUsageRunConfig(
+        use_history=False, output=OutputConfig(), key_path="fake_file"
     )
+
+    with patch("metaphor.bigquery.usage.extractor.build_logging_client"):
+        extractor = BigQueryUsageExtractor(config)
+
+        for entry in load_entries(
+            test_root_dir + "/bigquery/usage/data/sample_log.json"
+        ):
+            extractor._parse_table_data_read_entry(entry, datetime.now(tz=timezone.utc))
+
+        results = {}
+        for key, value in extractor._datasets.items():
+            results[key] = EventUtil.clean_nones(value.to_dict())
+
+        assert results == load_json(
+            test_root_dir + "/bigquery/usage/data/parse_query_log_result.json"
+        )

--- a/tests/dbt/cloud/test_extractor.py
+++ b/tests/dbt/cloud/test_extractor.py
@@ -18,7 +18,7 @@ async def test_extractor(test_root_dir):
 
     mock_dbt_extractor = MagicMock()
 
-    async def fake_extract(config):
+    async def fake_extract():
         return []
 
     mock_dbt_extractor.extract.side_effect = fake_extract
@@ -38,10 +38,10 @@ async def test_extractor(test_root_dir):
             job_id=2222,
             service_token="service_token",
         )
-        extractor = DbtCloudExtractor()
-        await extractor.extract(config)
+        extractor = DbtCloudExtractor(config)
+        await extractor.extract()
 
-        mock_dbt_extractor.extract.assert_called_once_with(
+        mock_dbt_extractor_class.assert_called_once_with(
             DbtRunConfig(
                 manifest="tempfile",
                 account="snowflake_account",
@@ -49,3 +49,4 @@ async def test_extractor(test_root_dir):
                 output=OutputConfig(),
             )
         )
+        mock_dbt_extractor.extract.assert_called_once()

--- a/tests/dbt/test_extractor.py
+++ b/tests/dbt/test_extractor.py
@@ -90,7 +90,7 @@ async def _test_project(
         meta_ownerships=[MetaOwnership(meta_key="owner", ownership_type="Maintainer")],
         meta_tags=[MetaTag(meta_key="pii", tag_type="PII")],
     )
-    extractor = DbtExtractor()
-    events = [EventUtil.trim_event(e) for e in await extractor.extract(config)]
+    extractor = DbtExtractor(config)
+    events = [EventUtil.trim_event(e) for e in await extractor.extract()]
 
     assert events == load_json(expected)

--- a/tests/manual/governance/test_extractor.py
+++ b/tests/manual/governance/test_extractor.py
@@ -13,8 +13,8 @@ async def test_extractor(test_root_dir):
     config = ManualGovernanceConfig.from_yaml_file(
         f"{test_root_dir}/manual/governance/config.yml"
     )
-    extractor = ManualGovernanceExtractor()
+    extractor = ManualGovernanceExtractor(config)
 
-    events = [EventUtil.trim_event(e) for e in await extractor.extract(config)]
+    events = [EventUtil.trim_event(e) for e in await extractor.extract()]
 
     assert events == load_json(f"{test_root_dir}/manual/governance/expected.json")

--- a/tests/manual/lineage/test_extractor.py
+++ b/tests/manual/lineage/test_extractor.py
@@ -13,8 +13,8 @@ async def test_extractor(test_root_dir):
     config = ManualLineageConfig.from_yaml_file(
         f"{test_root_dir}/manual/lineage/config.yml"
     )
-    extractor = ManualLineageExtractor()
+    extractor = ManualLineageExtractor(config)
 
-    events = [EventUtil.trim_event(e) for e in await extractor.extract(config)]
+    events = [EventUtil.trim_event(e) for e in await extractor.extract()]
 
     assert events == load_json(f"{test_root_dir}/manual/lineage/expected.json")

--- a/tests/metabase/test_extractor.py
+++ b/tests/metabase/test_extractor.py
@@ -1,10 +1,15 @@
+from metaphor.common.base_config import OutputConfig
 from metaphor.common.entity_id import to_dataset_entity_id
+from metaphor.metabase.config import MetabaseRunConfig
 from metaphor.metabase.extractor import DatabaseInfo, MetabaseExtractor
 from metaphor.models.metadata_change_event import Chart, ChartType, DataPlatform
 
 
 def test_parse_database_and_card():
-    extractor = MetabaseExtractor()
+    config = MetabaseRunConfig(
+        server_url="", username="", password="", output=OutputConfig()
+    )
+    extractor = MetabaseExtractor(config)
 
     database_json = {
         "name": "metaphor_bigquery",

--- a/tests/power_bi/test_extractor.py
+++ b/tests/power_bi/test_extractor.py
@@ -243,8 +243,8 @@ async def test_extractor(test_root_dir):
             secret="fake_secret",
             workspaces=["bar"],
         )
-        extractor = PowerBIExtractor()
+        extractor = PowerBIExtractor(config)
 
-        events = [EventUtil.trim_event(e) for e in await extractor.extract(config)]
+        events = [EventUtil.trim_event(e) for e in await extractor.extract()]
 
     assert events == load_json(f"{test_root_dir}/power_bi/expected.json")

--- a/tests/redshift/lineage/test_extractor.py
+++ b/tests/redshift/lineage/test_extractor.py
@@ -8,13 +8,7 @@ from metaphor.common.base_config import OutputConfig
 from metaphor.common.event_util import EventUtil
 from metaphor.redshift.lineage.config import RedshiftLineageRunConfig
 from metaphor.redshift.lineage.extractor import RedshiftLineageExtractor
-from tests.test_utils import load_json
-
-
-# python3.7 do not have AsyncMock
-class AsyncMock(MagicMock):
-    async def __call__(self, *args, **kwargs):
-        return super(AsyncMock, self).__call__(*args, **kwargs)
+from tests.test_utils import AsyncMock, load_json
 
 
 def mock_databases(mock: MagicMock, databases: List[str]):
@@ -87,17 +81,16 @@ async def test_extractor(test_root_dir):
     with patch(
         "metaphor.postgresql.extractor.PostgreSQLExtractor._fetch_databases",
         new_callable=AsyncMock,
-    ) as mock_fetch_databases:
-        with patch(
-            "metaphor.postgresql.extractor.PostgreSQLExtractor._connect_database",
-            new_callable=AsyncMock,
-        ) as mock_connect_database:
-            mock_databases(mock_fetch_databases, ["test"])
-            mock_records(mock_connect_database, records)
+    ) as mock_fetch_databases, patch(
+        "metaphor.postgresql.extractor.PostgreSQLExtractor._connect_database",
+        new_callable=AsyncMock,
+    ) as mock_connect_database:
+        mock_databases(mock_fetch_databases, ["test"])
+        mock_records(mock_connect_database, records)
 
-            extractor = RedshiftLineageExtractor()
+        extractor = RedshiftLineageExtractor(config)
 
-            events = [EventUtil.trim_event(e) for e in await extractor.extract(config)]
+        events = [EventUtil.trim_event(e) for e in await extractor.extract()]
 
     assert events == load_json(test_root_dir + "/redshift/lineage/data/result.json")
 
@@ -137,17 +130,16 @@ async def test_extractor_view(test_root_dir):
     with patch(
         "metaphor.postgresql.extractor.PostgreSQLExtractor._fetch_databases",
         new_callable=AsyncMock,
-    ) as mock_fetch_databases:
-        with patch(
-            "metaphor.postgresql.extractor.PostgreSQLExtractor._connect_database",
-            new_callable=AsyncMock,
-        ) as mock_connect_database:
-            mock_databases(mock_fetch_databases, ["test"])
-            mock_records(mock_connect_database, records)
+    ) as mock_fetch_databases, patch(
+        "metaphor.postgresql.extractor.PostgreSQLExtractor._connect_database",
+        new_callable=AsyncMock,
+    ) as mock_connect_database:
+        mock_databases(mock_fetch_databases, ["test"])
+        mock_records(mock_connect_database, records)
 
-            extractor = RedshiftLineageExtractor()
+        extractor = RedshiftLineageExtractor(config)
 
-            events = [EventUtil.trim_event(e) for e in await extractor.extract(config)]
+        events = [EventUtil.trim_event(e) for e in await extractor.extract()]
 
     assert events == load_json(
         test_root_dir + "/redshift/lineage/data/result_view.json"

--- a/tests/snowflake/usage/data/parse_query_log_result.json
+++ b/tests/snowflake/usage/data/parse_query_log_result.json
@@ -3,6 +3,7 @@
     "entityType": "DATASET",
     "logicalId": {
       "name": "snowflake.account_usage.query_history",
+      "account": "account",
       "platform": "SNOWFLAKE"
     },
     "usage": {
@@ -133,6 +134,7 @@
     "entityType": "DATASET",
     "logicalId": {
       "name": "snowflake.account_usage.access_history",
+      "account": "account",
       "platform": "SNOWFLAKE"
     },
     "usage": {

--- a/tests/tableau/test_extractor.py
+++ b/tests/tableau/test_extractor.py
@@ -1,5 +1,6 @@
 from tableauserverclient import WorkbookItem
 
+from metaphor.common.base_config import OutputConfig
 from metaphor.common.entity_id import to_dataset_entity_id, to_virtual_view_entity_id
 from metaphor.models.metadata_change_event import (
     Dashboard,
@@ -11,14 +12,24 @@ from metaphor.models.metadata_change_event import (
     SourceInfo,
     VirtualViewType,
 )
+from metaphor.tableau.config import TableauRunConfig, TableauTokenAuthConfig
 from metaphor.tableau.extractor import TableauExtractor
 from metaphor.tableau.query import WorkbookQueryResponse
+
+
+def dummy_config():
+    return TableauRunConfig(
+        server_url="url",
+        site_name="name",
+        access_token=TableauTokenAuthConfig(token_name="name", token_value="value"),
+        output=OutputConfig(),
+    )
 
 
 def test_view_url():
     view_name = "Regional/sheets/Obesity"
 
-    extractor = TableauExtractor()
+    extractor = TableauExtractor(dummy_config())
     extractor._base_url = "https://10ax.online.tableau.com/#/site/abc"
 
     view_url = extractor._build_view_url(view_name)
@@ -29,7 +40,7 @@ def test_view_url():
 
 
 def test_parse_workbook_url():
-    extractor = TableauExtractor()
+    extractor = TableauExtractor(dummy_config())
 
     # Tableau Online
     base_url, workbook_id = extractor._parse_workbook_url(
@@ -67,7 +78,7 @@ def test_parse_dashboard():
     )
     workbook._set_views([])
 
-    extractor = TableauExtractor()
+    extractor = TableauExtractor(dummy_config())
     extractor._parse_dashboard(workbook)
 
     assert len(extractor._dashboards) == 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import MagicMock
 
 
 def load_json(path):
@@ -14,3 +15,10 @@ def compare_list_ignore_order(a: list, b: list):
     except ValueError:
         return False
     return not t
+
+
+# Backport AsyncMock support to Python 3.7
+# https://stackoverflow.com/a/32498408
+class AsyncMock(MagicMock):
+    async def __call__(self, *args, **kwargs):
+        return super(AsyncMock, self).__call__(*args, **kwargs)


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

When the connectors were first written, the idea was to pass the config file to the `extract` function so the same class can be invoked multiple times with different configs. In reality, this is never the case, since whenever the CLI is invoked, the connector classes are created and subsequently destroyed without being reused.

By passing the config directly into the constructor, the initialization process can be simplified with improved type checking. It also allows some configs to be stored as instance variables and used across methods without needing to pass them around.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Pass the config directly into each connector's constructor, instead of the `extract` method.
- Replace abstract `platform` and `description` methods with arguments passed to the `BaseExtractor`'s constructor.
- Replace `config_class` method with `from_config_file` method for parsing connector-specific config file.
- Rename `metaphor/common/extractor.py` to `metaphor/common/base_extractor.py` for consistency.
- Rename `ThoughtspotExtractor` to `ThoughtSpotExtractor`.
- Move the backported `AsyncMock` to `tests/test_utils.py` so it can be shared across tests.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Manually ran every connector and compared the output against the output prior to the refactoring. Verified that there's only timestamp and other expected differences (e.g. additional queries & usage counts generated from the previous run). 
