### PR TITLE
Fix Snowflake connector to work with the new timestamp unit

### DIFF
--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -226,10 +226,12 @@ class SnowflakeExtractor(BaseExtractor):
             dataset = self._datasets[fullname]
             assert dataset.schema.sql_schema is not None
 
+            # Timestamp is in nanosecond.
+            # See https://docs.snowflake.com/en/sql-reference/functions/system_last_change_commit_time.html
             timestamp = results[f"UPDATED_{fullname}"]
             if timestamp > 0:
                 dataset.statistics.last_updated = datetime.utcfromtimestamp(
-                    timestamp / 1000
+                    timestamp / 1000000000
                 ).replace(tzinfo=timezone.utc)
 
     def _fetch_unique_keys(self, cursor: SnowflakeCursor, database: str) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.21"
+version = "0.11.22"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Snowflake connector is currently broken with the following error:

```
ERROR:metaphor.common.extractor:year 51193146 is out of range
Traceback (most recent call last):
File "/usr/local/lib/python3.8/site-packages/metaphor/common/extractor.py", line 50, in run
entities = asyncio.run(self.extract(config))
File "/usr/local/lib/python3.8/asyncio/runners.py", line 44, in run
return loop.run_until_complete(main)
File "/usr/local/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
return future.result()
File "/usr/local/lib/python3.8/site-packages/metaphor/snowflake/extractor.py", line 91, in extract
self._fetch_table_info(conn, tables)
File "/usr/local/lib/python3.8/site-packages/metaphor/snowflake/extractor.py", line 231, in _fetch_table_info
dataset.statistics.last_updated = datetime.utcfromtimestamp(
ValueError: year 51193146 is out of range
```

Turns out that Snowflake suddenly changed the timestamp unit returned by [SYSTEM$LAST_CHANGE_COMMIT_TIME](https://docs.snowflake.com/en/sql-reference/functions/system_last_change_commit_time.html) from millisecond to nanosecond.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Manually tested against production deployment.
