### PR TITLE
Fix Power BI DAX parsing for Redshift sources

### DIFF
--- a/metaphor/power_bi/power_query_parser.py
+++ b/metaphor/power_bi/power_query_parser.py
@@ -43,7 +43,7 @@ class PowerQueryParser:
                 match
             ), "Can't parse AmazonRedshift database from power query expression"
 
-            db = match.group(2).split(",")[1].replace('"', "")
+            db = match.group(2).split(",")[1].strip().replace('"', "")
             schema = get_field(lines[2])
             table = get_field(lines[3])
         elif platform_str == "Snowflake":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.22"
+version = "0.11.23"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/power_bi/test_parse_power_query.py
+++ b/tests/power_bi/test_parse_power_query.py
@@ -4,7 +4,7 @@ from metaphor.power_bi.power_query_parser import PowerQueryParser
 
 
 def test_parse_dataset_redshift():
-    exp = 'let\n    Source = AmazonRedshift.Database("url:5439","db"),\n    public = Source{[Name="public"]}[Data],\n    table1 = public{[Name="table"]}[Data]\nin\n    table1'
+    exp = 'let\n    Source = AmazonRedshift.Database("url:5439", "db" ),\n    public = Source{[Name="public"]}[Data],\n    table1 = public{[Name="table"]}[Data]\nin\n    table1'
     assert PowerQueryParser.parse_source_datasets(exp) == [
         to_dataset_entity_id("db.public.table", platform=DataPlatform.REDSHIFT)
     ]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

The current parser implementation adds extra spaces for the Redshift database names, e.g. for the following DAX expression

```
let
    Source = AmazonRedshift.Database("url:5439", "db" )
    public = Source{[Name="public"]}[Data]
    table1 = public{[Name="table"]}[Data]
in
    table1'
```

the parser returns a dataset name ` db .public.test`

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Strip off the extra spaces.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Tested against a production deployment.
