### PR TITLE
Fix Power BI native query parsing for Redshift

### DIFF
--- a/metaphor/power_bi/power_query_parser.py
+++ b/metaphor/power_bi/power_query_parser.py
@@ -121,6 +121,13 @@ class PowerQueryParser:
     def parse_platform(
         exp: str,
     ) -> Tuple[Optional[DataPlatform], Optional[str], Optional[str]]:
+        """
+        Parse platform information from native query expression.
+
+        :param exp: the native query expression
+        :returns: a tuple of (platform_type, account, default_db)
+        """
+
         lower_exp = exp.lower()
         account = None
         default_db = None
@@ -145,6 +152,13 @@ class PowerQueryParser:
 
     @staticmethod
     def parse_tables(sql: str, default_db: Optional[str]) -> List[Tuple[str, str, str]]:
+        """
+        Parse source tables from a SQL statement.
+
+        :param sql: the sql query to parse
+        :returns: a list of (database_name, schema_name, table_name)
+        """
+
         parser = Parser(sql.replace('"', ""))
         tables = []
         for table_name in parser.tables:

--- a/metaphor/power_bi/power_query_parser.py
+++ b/metaphor/power_bi/power_query_parser.py
@@ -118,9 +118,12 @@ class PowerQueryParser:
         return parameters
 
     @staticmethod
-    def parse_platform(exp: str) -> Tuple[Optional[DataPlatform], Optional[str]]:
+    def parse_platform(
+        exp: str,
+    ) -> Tuple[Optional[DataPlatform], Optional[str], Optional[str]]:
         lower_exp = exp.lower()
         account = None
+        default_db = None
 
         if "snowflake" in lower_exp:
             url = PowerQueryParser.extract_function_parameter(
@@ -131,18 +134,25 @@ class PowerQueryParser:
         elif "bigquery" in lower_exp:
             platform = DataPlatform.BIGQUERY
         elif "redshift" in lower_exp:
+            default_db = PowerQueryParser.extract_function_parameter(
+                exp, "AmazonRedshift.Database"
+            )[1].replace('"', "")
             platform = DataPlatform.REDSHIFT
         else:
             raise AssertionError(f"Unknown platform for a native query: ${exp}")
 
-        return platform, account
+        return platform, account, default_db
 
     @staticmethod
-    def parse_tables(sql: str) -> List[Tuple[str, str, str]]:
+    def parse_tables(sql: str, default_db: Optional[str]) -> List[Tuple[str, str, str]]:
         parser = Parser(sql.replace('"', ""))
         tables = []
         for table_name in parser.tables:
             fields = table_name.split(".")
+
+            # Fallback to default database name if not specified in query
+            if len(fields) == 2 and default_db is not None:
+                fields.insert(0, default_db)
 
             assert (
                 len(fields) == 3
@@ -158,8 +168,8 @@ class PowerQueryParser:
         )
         assert len(parameters) >= 2, "expecting at least two parameter for NativeQuery"
 
-        platform, account = PowerQueryParser.parse_platform(parameters[0])
-        tables = PowerQueryParser.parse_tables(parameters[1])
+        platform, account, default_db = PowerQueryParser.parse_platform(parameters[0])
+        tables = PowerQueryParser.parse_tables(parameters[1], default_db)
 
         return [
             to_dataset_entity_id(dataset_fullname(db, schema, table), platform, account)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.23"
+version = "0.11.24"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/power_bi/test_parse_power_query.py
+++ b/tests/power_bi/test_parse_power_query.py
@@ -59,6 +59,14 @@ def test_parse_native_query_parameters():
         ),
     ]
 
+    exp = 'let\n    Source = Value.NativeQuery(AmazonRedshift.Database("redshift-cluster-1.account.us-east-1.redshift.amazonaws.com","db"), "SELECT *#(lf)FROM schema1.table1#(lf)WHERE is_active = 1", null, [EnableFolding=true]),)'
+    assert PowerQueryParser.parse_source_datasets(exp) == [
+        to_dataset_entity_id(
+            "db.schema1.table1",
+            platform=DataPlatform.REDSHIFT,
+        )
+    ]
+
 
 def test_extract_function_parameter():
     assert PowerQueryParser.extract_function_parameter(


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Power BI connector throws the following error while parsing Redshift native queries:

```
Traceback (most recent call last):
  File "/Users/marslan/Metaphor/connectors/metaphor/power_bi/extractor.py", line 396, in map_wi_datasets_to_virtual_views
    source_datasets.extend(PowerQueryParser.parse_source_datasets(expression))
  File "/Users/marslan/Metaphor/connectors/metaphor/power_bi/power_query_parser.py", line 176, in parse_source_datasets
    return PowerQueryParser.parse_native_query(power_query)
  File "/Users/marslan/Metaphor/connectors/metaphor/power_bi/power_query_parser.py", line 162, in parse_native_query
    tables = PowerQueryParser.parse_tables(parameters[1])
  File "/Users/marslan/Metaphor/connectors/metaphor/power_bi/power_query_parser.py", line 147, in parse_tables
    assert (
AssertionError: Expecting a fully-qualified table name, <schema_name>.<table_name>
```

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Extract the default database name from `AmazonRedshift.Database` and use it to form fully-qualified table names from native queries.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Tested against a production deployment.
