### PR TITLE
Fix dbt's JSON schema to match the reality

### DIFF
--- a/metaphor/dbt/generated/dbt_manifest_v5.py
+++ b/metaphor/dbt/generated/dbt_manifest_v5.py
@@ -417,7 +417,7 @@ class ParsedDocumentation(BaseModel):
     root_path: str
     path: str
     original_file_path: str
-    name: str
+    name: Optional[str]
     block_contents: str
 
 

--- a/metaphor/dbt/generated/dbt_manifest_v6.py
+++ b/metaphor/dbt/generated/dbt_manifest_v6.py
@@ -423,7 +423,7 @@ class ParsedDocumentation(BaseModel):
     root_path: str
     path: str
     original_file_path: str
-    name: str
+    name: Optional[str]
     block_contents: str
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.26"
+version = "0.11.27"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.25"
+version = "0.11.26"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

While the JSON schema specifies that the `name` field of the `docs` block is [required](https://schemas.getdbt.com/dbt/manifest/v5/index.html#docs_additionalProperties_name), in reality it can be `null` for some special cases, e.g.

```
    "docs":
    {
        "<project>.None":
        {
            "unique_id": "<id>",
            "package_name": "<package>",
            "root_path": "/tmp/jobs/<job_id>/target",
            "path": "README.md",
            "original_file_path": "docs/README.md",
            "name": null,
            "block_contents": "## content\n  ## supports markdown"
        },
        ...
    }
``` 

This can lead to the following error when validating `manifest.json`:

```
Traceback (most recent call last):
  File "/Users/marslan/Metaphor/connectors/metaphor/common/extractor.py", line 50, in run
    entities = asyncio.run(self.extract(config))
  File "/Users/marslan/.pyenv/versions/3.9.6/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/Users/marslan/.pyenv/versions/3.9.6/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
    return future.result()
  File "/Users/marslan/Metaphor/connectors/metaphor/dbt/cloud/extractor.py", line 133, in extract
    return await DbtExtractor().extract(
  File "/Users/marslan/Metaphor/connectors/metaphor/dbt/extractor.py", line 96, in extract
    manifest_parser.parse(manifest_json)
  File "/Users/marslan/Metaphor/connectors/metaphor/dbt/manifest_parser_v5.py", line 87, in parse
    raise e
  File "/Users/marslan/Metaphor/connectors/metaphor/dbt/manifest_parser_v5.py", line 84, in parse
    manifest = DbtManifest.parse_obj(manifest_json)
  File "pydantic/main.py", line 521, in pydantic.main.BaseModel.parse_obj
  File "pydantic/main.py", line 341, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for DbtManifest
docs -> thrasio_warehouse.None -> name
  none is not an allowed value (type=type_error.none.not_allowed)
```

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Make the field optional to fix the validation error.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Tested against a production deployment.
