### PR TITLE
Make column ID optional when parsing Snowflake's AccessObject

### DIFF
--- a/metaphor/snowflake/accessed_object.py
+++ b/metaphor/snowflake/accessed_object.py
@@ -1,10 +1,10 @@
-from typing import List
+from typing import List, Optional
 
 from pydantic import BaseModel, Field
 
 
 class AccessedObjectColumn(BaseModel):
-    columnId: int
+    columnId: Optional[int]
     columnName: str
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.27"
+version = "0.11.28"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/snowflake/lineage/test_parser.py
+++ b/tests/snowflake/lineage/test_parser.py
@@ -24,8 +24,8 @@ def test_parse_access_log(test_root_dir):
             },
             {
                 "columns": [
-                    {"columnId": 4, "columnName": "BAZ"},
-                    {"columnId": 5, "columnName": "QUX"},
+                    {"columnName": "BAZ"},
+                    {"columnName": "QUX"},
                 ],
                 "objectDomain": "View",
                 "objectId": 6,

--- a/tests/snowflake/usage/test_parser.py
+++ b/tests/snowflake/usage/test_parser.py
@@ -56,11 +56,9 @@ def test_parse_access_log(test_root_dir):
         {
             "columns": [
                 {
-                    "columnId": 1511734,
                     "columnName": "DIRECT_OBJECTS_ACCESSED"
                 },
                 {
-                    "columnId": 1511731,
                     "columnName": "QUERY_ID"
                 }
             ],


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

The Snowflake AccessHistory parser throws the following error:

```
Traceback (most recent call last):
 File "/usr/local/lib/python3.8/site-packages/metaphor/snowflake/lineage/extractor.py", line 157, in _parse_access_logs
 self._parse_access_log(base_objects_accessed, objects_modified, query)
 File "/usr/local/lib/python3.8/site-packages/metaphor/snowflake/lineage/extractor.py", line 171, in _parse_access_log
 source_objects = parse_raw_as(List[AccessedObject], objects_accessed)
 File "pydantic/tools.py", line 82, in pydantic.tools.parse_raw_as
 File "pydantic/tools.py", line 38, in pydantic.tools.parse_obj_as
 File "pydantic/main.py", line 342, in pydantic.main.BaseModel.__init__
 pydantic.error_wrappers.ValidationError: 5 validation errors for ParsingModel[List[metaphor.snowflake.accessed_object.AccessedObject]]
 __root__ -> 0 -> columns -> 0 -> columnId
 field required (type=value_error.missing)
```

Turns out that `columnId` isn't always required. 

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Tested locally.
