### PR TITLE
Map Power BI report pages to charts

### DIFF
--- a/metaphor/power_bi/README.md
+++ b/metaphor/power_bi/README.md
@@ -13,6 +13,7 @@ We recommend creating a dedicated Azure AD Application and a dedicated security 
 2. Follow [this doc](https://docs.microsoft.com/en-us/azure/active-directory/fundamentals/active-directory-groups-create-azure-portal#create-a-basic-group-and-add-members) to create a security group and add the app's service principal as a member.
 
 3. Log into [Power BI Admin Portal](https://app.powerbi.com/admin-portal/tenantSettings) as a Power BI admin, enable the following settings under **Admin API settings** for the security group created in the previous step:
+    - Allow service principals to use Power BI APIs
     - Allow service principals to use read-only Power BI admin APIs
     - Enhance admin APIs responses with detailed metadata
     - Enhance admin APIs responses with DAX and mashup expressions

--- a/metaphor/power_bi/README.md
+++ b/metaphor/power_bi/README.md
@@ -22,6 +22,8 @@ For example,
 
 ![](https://docs.microsoft.com/en-us/power-bi/enterprise/media/read-only-apis-service-principal-auth/allow-service-principals-tenant-setting.png)
 
+4. [Add the service principal](https://docs.microsoft.com/en-us/power-bi/developer/embedded/embed-service-principal#step-4---add-the-service-principal-to-your-workspace) to all workspaces of interest, except "My Workspaces". Note that it may take an hour before the permission is fully propagated.
+
 ## Config File
 
 Create a YAML config file based on the following template.

--- a/metaphor/power_bi/extractor.py
+++ b/metaphor/power_bi/extractor.py
@@ -1,6 +1,5 @@
 import json
 import tempfile
-from multiprocessing import AuthenticationError
 from time import sleep
 from typing import Any, Callable, Collection, Dict, List, Optional, Type, TypeVar
 
@@ -159,7 +158,7 @@ class WorkspaceInfo(BaseModel):
     dashboards: List[WorkspaceInfoDashboard] = []
 
 
-class NotAuthorizedError(Exception):
+class AuthenticationError(Exception):
     def __init__(self, body) -> None:
         super().__init__(
             f"Authentication error: {body}.\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.28"
+version = "0.11.29"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/power_bi/expected.json
+++ b/tests/power_bi/expected.json
@@ -130,7 +130,17 @@
           "id": "workspace-1",
           "name": "Workspace"
         }
-      }
+      },
+      "charts": [
+        {
+          "title": "First Page",
+          "chartType": "OTHER"
+        },
+        {
+          "title": "Second Page",
+          "chartType": "OTHER"
+        }
+      ]
     },
     "sourceInfo": {
       "mainUrl": "https://powerbi.com/report/report-2"

--- a/tests/power_bi/test_extractor.py
+++ b/tests/power_bi/test_extractor.py
@@ -12,6 +12,7 @@ from metaphor.power_bi.extractor import (
     PowerBIDashboard,
     PowerBIDataset,
     PowerBIExtractor,
+    PowerBIPage,
     PowerBIReport,
     PowerBITable,
     PowerBITableColumn,
@@ -102,6 +103,12 @@ async def test_extractor(test_root_dir):
     )
 
     tiles = {dashboard1_id: [tile1, tile3], dashboard2_id: [tile2, tile3]}
+
+    page1 = PowerBIPage(name="name-1", displayName="First Page", order=1)
+
+    page2 = PowerBIPage(name="name-2", displayName="Second Page", order=2)
+
+    pages = {workspace1_id: {report1_id: [], report2_id: [page1, page2]}}
 
     mock_instance.get_workspace_info = MagicMock(
         return_value=[
@@ -213,6 +220,9 @@ async def test_extractor(test_root_dir):
     def fake_get_tiles(dashboard_id) -> List[PowerBITile]:
         return tiles.get(dashboard_id)
 
+    def fake_get_pages(workspace_id, report_id) -> List[PowerBIPage]:
+        return pages.get(workspace_id).get(report_id)
+
     def fake_get_apps() -> List[PowerBIApp]:
         return [app1, app2]
 
@@ -220,6 +230,7 @@ async def test_extractor(test_root_dir):
     mock_instance.get_reports.side_effect = fake_get_reports
     mock_instance.get_dashboards.side_effect = fake_get_dashboards
     mock_instance.get_tiles.side_effect = fake_get_tiles
+    mock_instance.get_pages.side_effect = fake_get_pages
     mock_instance.get_apps.side_effect = fake_get_apps
 
     with patch("metaphor.power_bi.extractor.PowerBIClient") as mock_client:


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Power BI's [REST API](https://docs.microsoft.com/en-us/rest/api/power-bi/) doesn't include any visualization information (charts) for [reports](https://docs.microsoft.com/en-us/power-bi/fundamentals/service-basic-concepts#reports). However, the name of the pages (tabs) in the report is considered a good proxy for the visualizations and should therefore be mapped to charts.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled. Use the [Get Pages in Group](https://docs.microsoft.com/en-us/rest/api/power-bi/reports/get-pages-in-group) API to retrieve the information, which requires additional permissions. 

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Tested against a production deployment.
