### PR TITLE
Improve logger

### DIFF
--- a/metaphor/common/logger.py
+++ b/metaphor/common/logger.py
@@ -3,7 +3,7 @@ import tempfile
 
 _, LOG_FILE = tempfile.mkstemp(suffix=".log")
 
-logging.basicConfig(level=logging.DEBUG, filename=LOG_FILE, filemode="w")
+logging.basicConfig(level=logging.DEBUG, filename=LOG_FILE, filemode="a")
 
 console = logging.StreamHandler()
 console.setLevel(logging.INFO)

--- a/metaphor/thought_spot/utils.py
+++ b/metaphor/thought_spot/utils.py
@@ -198,7 +198,7 @@ class ThoughtSpot:
         logger.info(f"{mtype} ids: {ids}")
 
         obj = ThoughtSpot._fetch_object_detail(client.metadata, ids, detail_type)
-        logger.debug(f"fetch_object_detail: {obj}")
+        logger.debug(f"[{mtype}] fetch_object_detail: {json.dumps(obj)}")
 
         # Because mypy can't handle dynamic type variables properly, we skip type-checking here.
         return parse_obj_as(List[target_type], obj)  # type: ignore


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

`logger` module can be imported multiple time, and different loggers use the same output file. The last logger output will overwrite other logs.

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

- Change file logger mode from 'w' to 'a'

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

Run ThoughtSpot connector locally to verified.

<!--
  Describe how the change was tested end-to-end.
-->
