### PR TITLE
Ignore shared databases when retrieving DDLs [sc-12169]

### DIFF
--- a/metaphor/snowflake/README.md
+++ b/metaphor/snowflake/README.md
@@ -29,6 +29,8 @@ grant references on all materialized views in database identifier($db) to role i
 grant references on future materialized views in database identifier($db) to role identifier($role);
 -- Grant permissions to access the snowflake "Account Usage" views:
 grant imported privileges on database snowflake to role identifier($role);
+-- If there are inbound shared databases, grant permissions to "show shares"
+grant imported share on account to identifier($role);
 
 -- Create metaphor_user
 create user identifier($user) 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.38"
+version = "0.11.39"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION

### 🤔 Why?

shared inbound databases don't support get_ddl()

### 🤓 What?

- fetch the `shared` DB info
- Ignore shared DB when get_ddl()

### 🧪 Tested?

tested locally fetching 'SNOWFLAKE' database
