### PR TITLE
Statement exhausted compilation resources [sc-13029]

### DIFF
--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -218,64 +218,62 @@ class SnowflakeExtractor(BaseExtractor):
             )
 
     def _fetch_table_info(self, tables: Dict[str, DatasetInfo], shared: bool) -> None:
-        def _fetch_table_info_internal(
-            table_list: List[Tuple[str, DatasetInfo]]
-        ) -> None:
-            queries, params = [], []
-            ddl_tables, updated_time_tables = [], []
-            for fullname, table in table_list:
-                # fetch last_update_time and DDL for tables, and fetch only DDL for views
-                if table.type == SnowflakeTableType.BASE_TABLE.value:
-                    queries.append(
-                        f'SYSTEM$LAST_CHANGE_COMMIT_TIME(%s) as "UPDATED_{fullname}"'
-                    )
-                    params.append(fullname)
-                    updated_time_tables.append(fullname)
-
-                if not shared:
-                    queries.append(f"get_ddl('table', %s) as \"DDL_{fullname}\"")
-                    params.append(fullname)
-                    ddl_tables.append(fullname)
-
-            if not queries:
-                return
-            query = f"SELECT {','.join(queries)}"
-
-            cursor = self._conn.cursor(DictCursor)
-
-            try:
-                cursor.execute(query, tuple(params))
-            except Exception as e:
-                logger.exception(f"Failed to execute query:\n{query}\n{e}")
-                return
-
-            results = cursor.fetchone()
-            assert isinstance(results, Mapping)
-            cursor.close()
-
-            for fullname in ddl_tables:
-                dataset = self._datasets[fullname]
-                assert (
-                    dataset.schema is not None and dataset.schema.sql_schema is not None
-                )
-
-                dataset.schema.sql_schema.table_schema = results[f"DDL_{fullname}"]
-
-            for fullname in updated_time_tables:
-                dataset = self._datasets[fullname]
-                assert dataset.schema.sql_schema is not None
-
-                # Timestamp is in nanosecond.
-                # See https://docs.snowflake.com/en/sql-reference/functions/system_last_change_commit_time.html
-                timestamp = results[f"UPDATED_{fullname}"]
-                if timestamp > 0:
-                    dataset.statistics.last_updated = datetime.utcfromtimestamp(
-                        timestamp / 1000000000
-                    ).replace(tzinfo=timezone.utc)
-
         chunks = utils.chunks([item for item in tables.items()], TABLE_INFO_FETCH_SIZE)
         for chunk in chunks:
-            _fetch_table_info_internal(chunk)
+            self._fetch_table_info_internal(chunk, shared)
+
+    def _fetch_table_info_internal(
+        self, tables: List[Tuple[str, DatasetInfo]], shared: bool
+    ) -> None:
+        queries, params = [], []
+        ddl_tables, updated_time_tables = [], []
+        for fullname, table in tables:
+            # fetch last_update_time and DDL for tables, and fetch only DDL for views
+            if table.type == SnowflakeTableType.BASE_TABLE.value:
+                queries.append(
+                    f'SYSTEM$LAST_CHANGE_COMMIT_TIME(%s) as "UPDATED_{fullname}"'
+                )
+                params.append(fullname)
+                updated_time_tables.append(fullname)
+
+            if not shared:
+                queries.append(f"get_ddl('table', %s) as \"DDL_{fullname}\"")
+                params.append(fullname)
+                ddl_tables.append(fullname)
+
+        if not queries:
+            return
+        query = f"SELECT {','.join(queries)}"
+
+        cursor = self._conn.cursor(DictCursor)
+
+        try:
+            cursor.execute(query, tuple(params))
+        except Exception as e:
+            logger.exception(f"Failed to execute query:\n{query}\n{e}")
+            return
+
+        results = cursor.fetchone()
+        assert isinstance(results, Mapping)
+        cursor.close()
+
+        for fullname in ddl_tables:
+            dataset = self._datasets[fullname]
+            assert dataset.schema is not None and dataset.schema.sql_schema is not None
+
+            dataset.schema.sql_schema.table_schema = results[f"DDL_{fullname}"]
+
+        for fullname in updated_time_tables:
+            dataset = self._datasets[fullname]
+            assert dataset.schema.sql_schema is not None
+
+            # Timestamp is in nanosecond.
+            # See https://docs.snowflake.com/en/sql-reference/functions/system_last_change_commit_time.html
+            timestamp = results[f"UPDATED_{fullname}"]
+            if timestamp > 0:
+                dataset.statistics.last_updated = datetime.utcfromtimestamp(
+                    timestamp / 1000000000
+                ).replace(tzinfo=timezone.utc)
 
     def _fetch_unique_keys(self, cursor: SnowflakeCursor, database: str) -> None:
         cursor.execute(f"SHOW UNIQUE KEYS IN DATABASE {database}")

--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -4,10 +4,9 @@ from typing import Collection, Dict, List, Mapping, Optional, Tuple
 
 from pydantic import parse_raw_as
 
-from metaphor.common import utils
 from metaphor.common.filter import DatabaseFilter, DatasetFilter
 from metaphor.common.query_history import chunk_query_logs
-from metaphor.common.utils import md5_digest, start_of_day
+from metaphor.common.utils import chunks, md5_digest, start_of_day
 from metaphor.snowflake.accessed_object import AccessedObject
 
 try:
@@ -218,8 +217,7 @@ class SnowflakeExtractor(BaseExtractor):
             )
 
     def _fetch_table_info(self, tables: Dict[str, DatasetInfo], shared: bool) -> None:
-        chunks = utils.chunks([item for item in tables.items()], TABLE_INFO_FETCH_SIZE)
-        for chunk in chunks:
+        for chunk in chunks([item for item in tables.items()], TABLE_INFO_FETCH_SIZE):
             self._fetch_table_info_internal(chunk, shared)
 
     def _fetch_table_info_internal(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.52"
+version = "0.11.53"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
### 🤔 Why?

For a snowflake database with a large number of tables, the query to get table info including DDL can get exceedingly long. 

### 🤓 What?

- Cap the number of tables info to fetch in one query to 100

### 🧪 Tested?

tested against snowflake instance, and verified the output is the same as before. 
