### PR TITLE
fix query log _id

### DIFF
--- a/metaphor/bigquery/extractor.py
+++ b/metaphor/bigquery/extractor.py
@@ -302,7 +302,7 @@ class BigQueryExtractor(BaseExtractor):
         )
 
         return QueryLog(
-            id=f"{str(DataPlatform.BIGQUERY)}:{job_change.job_name}",
+            id=f"{DataPlatform.BIGQUERY.name}:{job_change.job_name}",
             query_id=job_change.job_name,
             platform=DataPlatform.BIGQUERY,
             start_time=job_change.start_time,

--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -421,7 +421,7 @@ class SnowflakeExtractor(BaseExtractor):
                 targets = self._parse_accessed_objects(modified_objects)
 
                 query_log = QueryLog(
-                    id=f"{str(DataPlatform.SNOWFLAKE)}:{query_id}",
+                    id=f"{DataPlatform.SNOWFLAKE.name}:{query_id}",
                     query_id=query_id,
                     platform=DataPlatform.SNOWFLAKE,
                     start_time=start_time,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.53"
+version = "0.11.55"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/bigquery/expected.json
+++ b/tests/bigquery/expected.json
@@ -87,7 +87,7 @@
   {
     "logs": [
       {
-        "_id": "DataPlatform.BIGQUERY:projects/metaphor-data/jobs/bquxjob_70ddc06_17f574eca64",
+        "_id": "BIGQUERY:projects/metaphor-data/jobs/bquxjob_70ddc06_17f574eca64",
         "queryId": "projects/metaphor-data/jobs/bquxjob_70ddc06_17f574eca64",
         "bytesRead": 216.0,
         "duration": 0.26,
@@ -113,7 +113,7 @@
         ]
       },
       {
-        "_id": "DataPlatform.BIGQUERY:projects/metaphor-data/jobs/job_BSqXkGDLhaGKKQDJtesGJt3gjwG5",
+        "_id": "BIGQUERY:projects/metaphor-data/jobs/job_BSqXkGDLhaGKKQDJtesGJt3gjwG5",
         "queryId": "projects/metaphor-data/jobs/job_BSqXkGDLhaGKKQDJtesGJt3gjwG5",
         "bytesRead": 72.0,
         "duration": 0.376,


### PR DESCRIPTION
### 🤔 Why?

The `_id` currentlly looks like `DataPlatform.BIGQUERY:xxx` where the `DataPlatform` is useless and should be removed 

### 🤓 What?

- use Enum.name instead of `str` to stringify enum

### 🧪 Tested?

verified in local run
