### PR TITLE
Catch Redshift connectors errors without failing the whole process

### DIFF
--- a/metaphor/redshift/extractor.py
+++ b/metaphor/redshift/extractor.py
@@ -41,6 +41,8 @@ class RedshiftExtractor(PostgreSQLExtractor):
                 await self._fetch_tables(conn, db, True)
                 await self._fetch_columns(conn, db, True)
                 await self._fetch_redshift_table_stats(conn, db)
+            except Exception as ex:
+                logger.exception(ex)
             finally:
                 await conn.close()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.55"
+version = "0.11.56"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Currently the Redshift connect will bail out completely if it hits any issue (e.g. permission) when crawling a specific database.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified end-to-end against a production instance.
