### PR TITLE
Add an optional "warehouse" config to Snowflake connectors

### DIFF
--- a/metaphor/snowflake/auth.py
+++ b/metaphor/snowflake/auth.py
@@ -44,6 +44,9 @@ class SnowflakeAuthConfig(BaseConfig):
     # role to use when opening a connection
     role: Optional[str] = None
 
+    # warehouse to use when opening a connection
+    warehouse: Optional[str] = None
+
     # database context when opening a connection
     default_database: Optional[str] = None
 
@@ -83,6 +86,7 @@ def connect(config: SnowflakeAuthConfig) -> snowflake.connector.SnowflakeConnect
         password=config.password,
         private_key=pkb,
         role=config.role,
+        warehouse=config.warehouse,
         database=config.default_database,
         application=METAPHOR_DATA_SNOWFLAKE_CONNECTOR,
         session_parameters={

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.58"
+version = "0.11.59"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/snowflake/config.yml
+++ b/tests/snowflake/config.yml
@@ -3,6 +3,7 @@ account: account
 user: user
 password: password
 role: role
+warehouse: warehouse
 default_database: database
 filter:
   includes:

--- a/tests/snowflake/test_config.py
+++ b/tests/snowflake/test_config.py
@@ -15,6 +15,7 @@ def test_yaml_config(test_root_dir):
         user="user",
         password="password",
         role="role",
+        warehouse="warehouse",
         default_database="database",
         filter=DatasetFilter(
             includes={


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Allows users to change to set the Snowflake warehouse to use instead of relying on the default warehouse.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Manually verified against a production instance.