### PR TITLE
add more dbt metadata to metrics page [sc-13485]

### DIFF
--- a/metaphor/dbt/manifest_parser_v5.py
+++ b/metaphor/dbt/manifest_parser_v5.py
@@ -292,6 +292,7 @@ class ManifestParserV5:
             description=metric.description or None,
             label=metric.label,
             tags=metric.tags,
+            timestamp=metric.timestamp,
             time_grains=metric.time_grains,
             dimensions=metric.dimensions,
             sql=metric.sql,

--- a/metaphor/dbt/manifest_parser_v6.py
+++ b/metaphor/dbt/manifest_parser_v6.py
@@ -291,6 +291,7 @@ class ManifestParserV6:
             description=metric.description or None,
             label=metric.label,
             tags=metric.tags,
+            timestamp=metric.timestamp,
             time_grains=metric.time_grains,
             dimensions=metric.dimensions,
             sql=metric.sql,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.62"
+version = "0.11.63"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/dbt/data/trial_v4/results.json
+++ b/tests/dbt/data/trial_v4/results.json
@@ -511,6 +511,7 @@
       "timeGrains": [
         "year"
       ],
+      "timestamp": "release_year",
       "type": "count"
     },
     "logicalId": {

--- a/tests/dbt/data/trial_v5/results.json
+++ b/tests/dbt/data/trial_v5/results.json
@@ -511,6 +511,7 @@
       "timeGrains": [
         "year"
       ],
+      "timestamp": "release_year",
       "type": "count"
     },
     "logicalId": {

--- a/tests/dbt/data/trial_v6/results.json
+++ b/tests/dbt/data/trial_v6/results.json
@@ -722,6 +722,7 @@
       "timeGrains": [
         "year"
       ],
+      "timestamp": "release_year",
       "type": "count"
     },
     "logicalId": {


### PR DESCRIPTION
### 🤔 Why?

Missed the `timestamp` field from dbt metric

### 🤓 What?

- retrieve timestamp field

### 🧪 Tested?

unit testes
