### PR TITLE
Fill dataset structure from crawler

### DIFF
--- a/metaphor/airflow_plugin/lineage/entity.py
+++ b/metaphor/airflow_plugin/lineage/entity.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import attr
 
-from metaphor.common.entity_id import dataset_fullname
+from metaphor.common.entity_id import dataset_normalized_name
 from metaphor.models.metadata_change_event import DataPlatform, DatasetLogicalID
 
 
@@ -22,5 +22,7 @@ class MetaphorDataset:
             account = obj.snowflake_account
 
         return DatasetLogicalID(
-            account, dataset_fullname(obj.database, obj.schema, obj.table), obj.platform
+            account,
+            dataset_normalized_name(obj.database, obj.schema, obj.table),
+            obj.platform,
         )

--- a/metaphor/bigquery/extractor.py
+++ b/metaphor/bigquery/extractor.py
@@ -35,6 +35,7 @@ from metaphor.models.metadata_change_event import (
     DatasetLogicalID,
     DatasetSchema,
     DatasetStatistics,
+    DatasetStructure,
     MaterializationType,
     QueriedDataset,
     QueryLog,
@@ -163,6 +164,9 @@ class BigQueryExtractor(BaseExtractor):
             logical_id=dataset_id,
             schema=schema,
             statistics=statistics,
+            structure=DatasetStructure(
+                database=project_id, schema=bq_table.dataset_id, table=bq_table.table_id
+            ),
         )
 
     # See https://googleapis.dev/python/bigquery/latest/generated/google.cloud.bigquery.table.Table.html#google.cloud.bigquery.table.Table

--- a/metaphor/bigquery/profile/extractor.py
+++ b/metaphor/bigquery/profile/extractor.py
@@ -303,11 +303,11 @@ class BigQueryProfileExtractor(BaseExtractor):
         )
 
     @staticmethod
-    def _init_dataset(full_name: str) -> Dataset:
+    def _init_dataset(normalized_name: str) -> Dataset:
         dataset = Dataset()
         dataset.entity_type = EntityType.DATASET
         dataset.logical_id = DatasetLogicalID(
-            name=full_name, platform=DataPlatform.BIGQUERY
+            name=normalized_name, platform=DataPlatform.BIGQUERY
         )
 
         dataset.field_statistics = DatasetFieldStatistics(field_statistics=[])

--- a/metaphor/bigquery/profile/extractor.py
+++ b/metaphor/bigquery/profile/extractor.py
@@ -14,6 +14,7 @@ from metaphor.bigquery.extractor import BigQueryExtractor, build_client
 from metaphor.bigquery.profile.config import BigQueryProfileRunConfig, SamplingConfig
 from metaphor.common.base_extractor import BaseExtractor
 from metaphor.common.column_statistics import ColumnStatistics
+from metaphor.common.entity_id import dataset_fullname
 from metaphor.common.event_util import ENTITY_TYPES
 from metaphor.common.filter import DatasetFilter
 from metaphor.common.logger import get_logger
@@ -139,7 +140,9 @@ class BigQueryProfileExtractor(BaseExtractor):
             jobs.remove(job.job_id)
 
         dataset = BigQueryProfileExtractor._init_dataset(
-            f"{table.project}.{table.dataset_id}.{table.table_id}"
+            dataset_fullname(
+                db=table.project, schema=table.dataset_id, table=table.table_id
+            )
         )
         bq_table = self._client.get_table(table)
         row_count = bq_table.num_rows

--- a/metaphor/bigquery/profile/extractor.py
+++ b/metaphor/bigquery/profile/extractor.py
@@ -14,7 +14,7 @@ from metaphor.bigquery.extractor import BigQueryExtractor, build_client
 from metaphor.bigquery.profile.config import BigQueryProfileRunConfig, SamplingConfig
 from metaphor.common.base_extractor import BaseExtractor
 from metaphor.common.column_statistics import ColumnStatistics
-from metaphor.common.entity_id import dataset_fullname
+from metaphor.common.entity_id import dataset_normalized_name
 from metaphor.common.event_util import ENTITY_TYPES
 from metaphor.common.filter import DatasetFilter
 from metaphor.common.logger import get_logger
@@ -140,7 +140,7 @@ class BigQueryProfileExtractor(BaseExtractor):
             jobs.remove(job.job_id)
 
         dataset = BigQueryProfileExtractor._init_dataset(
-            dataset_fullname(
+            dataset_normalized_name(
                 db=table.project, schema=table.dataset_id, table=table.table_id
             )
         )

--- a/metaphor/common/entity_id.py
+++ b/metaphor/common/entity_id.py
@@ -77,6 +77,8 @@ def to_person_entity_id(email: str) -> EntityId:
     )
 
 
-def dataset_fullname(db: str, schema: str, table: str) -> str:
-    """builds dataset fullname"""
-    return f"{db}.{schema}.{table}".lower()
+def dataset_normalized_name(
+    db: Optional[str] = None, schema: Optional[str] = None, table: Optional[str] = None
+) -> str:
+    """builds dataset normalized name"""
+    return ".".join([part for part in [db, schema, table] if part]).lower()

--- a/metaphor/common/entity_id.py
+++ b/metaphor/common/entity_id.py
@@ -39,14 +39,14 @@ class EntityId:
 
 
 def to_dataset_entity_id(
-    full_name: str, platform: DataPlatform, account: Optional[str] = None
+    normalized_name: str, platform: DataPlatform, account: Optional[str] = None
 ) -> EntityId:
     """
     converts a dataset name, platform and account into a dataset entity ID
     """
     return EntityId(
         EntityType.DATASET,
-        DatasetLogicalID(name=full_name, platform=platform, account=account),
+        DatasetLogicalID(name=normalized_name, platform=platform, account=account),
     )
 
 

--- a/metaphor/common/usage_util.py
+++ b/metaphor/common/usage_util.py
@@ -19,14 +19,14 @@ from metaphor.models.metadata_change_event import (
 class UsageUtil:
     @staticmethod
     def init_dataset(
-        full_name: str,
+        normalized_name: str,
         platform: DataPlatform,
         account: Optional[str] = None,
     ) -> Dataset:
         dataset = Dataset(
             entity_type=EntityType.DATASET,
             logical_id=DatasetLogicalID(
-                name=full_name, account=account, platform=platform
+                name=normalized_name, account=account, platform=platform
             ),
         )
 

--- a/metaphor/dbt/manifest_parser_v3.py
+++ b/metaphor/dbt/manifest_parser_v3.py
@@ -2,7 +2,11 @@ from typing import Dict, Union
 
 from pydantic.utils import unique_list
 
-from metaphor.common.entity_id import EntityId, dataset_fullname, to_dataset_entity_id
+from metaphor.common.entity_id import (
+    EntityId,
+    dataset_normalized_name,
+    to_dataset_entity_id,
+)
 from metaphor.common.logger import get_logger
 from metaphor.dbt.config import DbtRunConfig
 from metaphor.models.metadata_change_event import (
@@ -107,7 +111,9 @@ class ManifestParserV3:
         for key, source in sources.items():
             assert source.database is not None
             source_map[key] = to_dataset_entity_id(
-                dataset_fullname(source.database, source.schema_, source.identifier),
+                dataset_normalized_name(
+                    source.database, source.schema_, source.identifier
+                ),
                 self._platform,
                 self._account,
             )
@@ -216,7 +222,7 @@ class ManifestParserV3:
                 type=materialization_type,
                 target_dataset=str(
                     to_dataset_entity_id(
-                        dataset_fullname(
+                        dataset_normalized_name(
                             model.database, model.schema_, model.alias or model.name
                         ),
                         self._platform,

--- a/metaphor/dbt/manifest_parser_v5.py
+++ b/metaphor/dbt/manifest_parser_v5.py
@@ -2,7 +2,11 @@ from typing import Dict, List, Optional, Tuple, Union
 
 from pydantic.utils import unique_list
 
-from metaphor.common.entity_id import EntityId, dataset_fullname, to_dataset_entity_id
+from metaphor.common.entity_id import (
+    EntityId,
+    dataset_normalized_name,
+    to_dataset_entity_id,
+)
 from metaphor.common.logger import get_logger
 from metaphor.dbt.config import DbtRunConfig
 from metaphor.models.metadata_change_event import (
@@ -117,7 +121,9 @@ class ManifestParserV5:
         for key, source in sources.items():
             assert source.database is not None
             source_map[key] = to_dataset_entity_id(
-                dataset_fullname(source.database, source.schema_, source.identifier),
+                dataset_normalized_name(
+                    source.database, source.schema_, source.identifier
+                ),
                 self._platform,
                 self._account,
             )
@@ -227,7 +233,7 @@ class ManifestParserV5:
                 type=materialization_type,
                 target_dataset=str(
                     to_dataset_entity_id(
-                        dataset_fullname(
+                        dataset_normalized_name(
                             model.database, model.schema_, model.alias or model.name
                         ),
                         self._platform,

--- a/metaphor/dbt/manifest_parser_v6.py
+++ b/metaphor/dbt/manifest_parser_v6.py
@@ -2,7 +2,11 @@ from typing import Dict, List, Optional, Tuple, Union
 
 from pydantic.utils import unique_list
 
-from metaphor.common.entity_id import EntityId, dataset_fullname, to_dataset_entity_id
+from metaphor.common.entity_id import (
+    EntityId,
+    dataset_normalized_name,
+    to_dataset_entity_id,
+)
 from metaphor.common.logger import get_logger
 from metaphor.dbt.config import DbtRunConfig
 from metaphor.models.metadata_change_event import (
@@ -116,7 +120,9 @@ class ManifestParserV6:
         for key, source in sources.items():
             assert source.database is not None
             source_map[key] = to_dataset_entity_id(
-                dataset_fullname(source.database, source.schema_, source.identifier),
+                dataset_normalized_name(
+                    source.database, source.schema_, source.identifier
+                ),
                 self._platform,
                 self._account,
             )
@@ -226,7 +232,7 @@ class ManifestParserV6:
                 type=materialization_type,
                 target_dataset=str(
                     to_dataset_entity_id(
-                        dataset_fullname(
+                        dataset_normalized_name(
                             model.database, model.schema_, model.alias or model.name
                         ),
                         self._platform,

--- a/metaphor/dbt/util.py
+++ b/metaphor/dbt/util.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional, Union
 
 from metaphor.common.entity_id import (
     EntityId,
-    dataset_fullname,
+    dataset_normalized_name,
     to_dataset_entity_id,
     to_person_entity_id,
     to_virtual_view_entity_id,
@@ -50,7 +50,7 @@ EMAIL_REGEX = re.compile(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)")
 
 def get_dataset_entity_id(self, db: str, schema: str, table: str) -> EntityId:
     return to_dataset_entity_id(
-        dataset_fullname(db, schema, table), self._platform, self._account
+        dataset_normalized_name(db, schema, table), self._platform, self._account
     )
 
 
@@ -130,7 +130,7 @@ def init_dataset(
     if unique_id not in datasets:
         datasets[unique_id] = Dataset(
             logical_id=DatasetLogicalID(
-                name=dataset_fullname(database, schema, name),
+                name=dataset_normalized_name(database, schema, name),
                 platform=platform,
                 account=account,
             )

--- a/metaphor/glue/extractor.py
+++ b/metaphor/glue/extractor.py
@@ -6,6 +6,7 @@ import boto3
 from aws_assume_role_lib import assume_role
 
 from metaphor.common.base_extractor import BaseExtractor
+from metaphor.common.entity_id import dataset_normalized_name
 from metaphor.common.event_util import ENTITY_TYPES
 from metaphor.common.logger import get_logger
 from metaphor.common.utils import unique_list
@@ -110,7 +111,7 @@ class GlueExtractor(BaseExtractor):
 
                 dataset = self._init_dataset(
                     schema=database,
-                    table_name=name,
+                    name=name,
                     table_type="TABLE",
                     description=description,
                     row_count=row_count,
@@ -142,13 +143,13 @@ class GlueExtractor(BaseExtractor):
     def _init_dataset(
         self,
         schema: str,
-        table_name: str,
+        name: str,
         table_type: str,
         description: str,
         row_count: int,
         last_updated: datetime,
     ) -> Dataset:
-        full_name = f"{schema}.{table_name}"
+        full_name = dataset_normalized_name(schema=schema, table=name)
         dataset = Dataset()
         dataset.logical_id = DatasetLogicalID()
         dataset.logical_id.platform = DataPlatform.GLUE
@@ -171,7 +172,7 @@ class GlueExtractor(BaseExtractor):
         dataset.statistics.record_count = float(row_count) if row_count else None
         dataset.statistics.last_updated = last_updated
 
-        dataset.structure = DatasetStructure(schema=schema, table=table_name)
+        dataset.structure = DatasetStructure(schema=schema, table=name)
 
         self._datasets[full_name] = dataset
 

--- a/metaphor/glue/extractor.py
+++ b/metaphor/glue/extractor.py
@@ -149,11 +149,11 @@ class GlueExtractor(BaseExtractor):
         row_count: int,
         last_updated: datetime,
     ) -> Dataset:
-        full_name = dataset_normalized_name(schema=schema, table=name)
+        normalized_name = dataset_normalized_name(schema=schema, table=name)
         dataset = Dataset()
         dataset.logical_id = DatasetLogicalID()
         dataset.logical_id.platform = DataPlatform.GLUE
-        dataset.logical_id.name = full_name
+        dataset.logical_id.name = normalized_name
 
         dataset.schema = DatasetSchema()
         dataset.schema.schema_type = SchemaType.SQL
@@ -174,6 +174,6 @@ class GlueExtractor(BaseExtractor):
 
         dataset.structure = DatasetStructure(schema=schema, table=name)
 
-        self._datasets[full_name] = dataset
+        self._datasets[normalized_name] = dataset
 
         return dataset

--- a/metaphor/glue/extractor.py
+++ b/metaphor/glue/extractor.py
@@ -19,6 +19,7 @@ from metaphor.models.metadata_change_event import (
     DatasetLogicalID,
     DatasetSchema,
     DatasetStatistics,
+    DatasetStructure,
     MaterializationType,
     SchemaField,
     SchemaType,
@@ -108,7 +109,8 @@ class GlueExtractor(BaseExtractor):
                 description = table.get("Description")
 
                 dataset = self._init_dataset(
-                    full_name=f"{database}.{name}",
+                    schema=database,
+                    table_name=name,
                     table_type="TABLE",
                     description=description,
                     row_count=row_count,
@@ -139,12 +141,14 @@ class GlueExtractor(BaseExtractor):
 
     def _init_dataset(
         self,
-        full_name: str,
+        schema: str,
+        table_name: str,
         table_type: str,
         description: str,
         row_count: int,
         last_updated: datetime,
     ) -> Dataset:
+        full_name = f"{schema}.{table_name}"
         dataset = Dataset()
         dataset.logical_id = DatasetLogicalID()
         dataset.logical_id.platform = DataPlatform.GLUE
@@ -166,6 +170,8 @@ class GlueExtractor(BaseExtractor):
         dataset.statistics = DatasetStatistics()
         dataset.statistics.record_count = float(row_count) if row_count else None
         dataset.statistics.last_updated = last_updated
+
+        dataset.structure = DatasetStructure(schema=schema, table=table_name)
 
         self._datasets[full_name] = dataset
 

--- a/metaphor/metabase/extractor.py
+++ b/metaphor/metabase/extractor.py
@@ -6,7 +6,7 @@ import requests
 from sql_metadata import Parser
 
 from metaphor.common.base_extractor import BaseExtractor
-from metaphor.common.entity_id import dataset_fullname, to_dataset_entity_id
+from metaphor.common.entity_id import dataset_normalized_name, to_dataset_entity_id
 from metaphor.common.event_util import ENTITY_TYPES
 from metaphor.common.logger import get_logger
 from metaphor.metabase.config import MetabaseRunConfig
@@ -268,7 +268,9 @@ class MetabaseExtractor(BaseExtractor):
 
         dataset_id = str(
             to_dataset_entity_id(
-                dataset_fullname(database.database, schema or database.schema, name),
+                dataset_normalized_name(
+                    database.database, schema or database.schema, name
+                ),
                 database.platform,
                 database.account,
             )

--- a/metaphor/postgresql/extractor.py
+++ b/metaphor/postgresql/extractor.py
@@ -7,7 +7,7 @@ except ImportError:
     raise
 
 from metaphor.common.base_extractor import BaseExtractor
-from metaphor.common.entity_id import dataset_fullname
+from metaphor.common.entity_id import dataset_normalized_name
 from metaphor.common.event_util import ENTITY_TYPES
 from metaphor.common.logger import get_logger
 from metaphor.models.crawler_run_metadata import Platform
@@ -157,7 +157,7 @@ class PostgreSQLExtractor(BaseExtractor):
             table_size = table["table_size"]
             table_type = table["table_type"]
             if not self._filter.include_table(catalog, schema, name):
-                full_name = dataset_fullname(catalog, schema, name)
+                full_name = dataset_normalized_name(catalog, schema, name)
                 logger.info(f"Ignore {full_name} due to filter config")
                 continue
             datasets.append(
@@ -229,7 +229,7 @@ class PostgreSQLExtractor(BaseExtractor):
 
         for column in columns:
             schema, name = column["table_schema"], column["table_name"]
-            full_name = dataset_fullname(catalog, schema, name)
+            full_name = dataset_normalized_name(catalog, schema, name)
             if not self._filter.include_table(catalog, schema, name):
                 logger.info(f"Ignore {full_name} due to filter config")
                 continue
@@ -253,7 +253,7 @@ class PostgreSQLExtractor(BaseExtractor):
         for view_definition in view_definitions:
             schema = view_definition["schemaname"]
             name = view_definition["viewname"]
-            full_name = dataset_fullname(catalog, schema, name)
+            full_name = dataset_normalized_name(catalog, schema, name)
             if not self._filter.include_table(catalog, schema, name):
                 continue
 
@@ -303,7 +303,7 @@ class PostgreSQLExtractor(BaseExtractor):
             return
 
         for constraint in constraints:
-            full_name = dataset_fullname(
+            full_name = dataset_normalized_name(
                 catalog, constraint["table_schema"], constraint["table_name"]
             )
             if full_name not in self._datasets:
@@ -325,7 +325,7 @@ class PostgreSQLExtractor(BaseExtractor):
         row_count: int,
         table_size: int,
     ) -> Dataset:
-        full_name = dataset_fullname(database, schema, table)
+        full_name = dataset_normalized_name(database, schema, table)
 
         dataset = Dataset()
         dataset.logical_id = DatasetLogicalID()
@@ -387,7 +387,7 @@ class PostgreSQLExtractor(BaseExtractor):
             foreign_key = ForeignKey()
             foreign_key.field_path = constraint["key_columns"]
             foreign_key.parent = DatasetLogicalID()
-            foreign_key.parent.name = dataset_fullname(
+            foreign_key.parent.name = dataset_normalized_name(
                 constraint["constraint_db"],
                 constraint["constraint_schema"],
                 constraint["constraint_table"],

--- a/metaphor/postgresql/profile/extractor.py
+++ b/metaphor/postgresql/profile/extractor.py
@@ -8,6 +8,7 @@ except ImportError:
     print("Please install metaphor[postgresql] extra\n")
     raise
 
+from metaphor.common.entity_id import dataset_fullname
 from metaphor.common.event_util import ENTITY_TYPES
 from metaphor.common.logger import get_logger
 from metaphor.common.sampling import SamplingConfig
@@ -203,14 +204,19 @@ class PostgreSQLProfileExtractor(PostgreSQLExtractor):
 
     def _init_dataset(
         self,
-        full_name: str,
+        database: str,
+        schema: str,
+        table: str,
         table_type: str,
         description: str,
         row_count: int,
         table_size: int,
     ) -> None:
         """Overwrite PostgreSQLExtractor._init_dataset"""
-        super()._init_dataset(full_name, table_type, description, row_count, table_size)
+        super()._init_dataset(
+            database, schema, table, table_type, description, row_count, table_size
+        )
+        full_name = dataset_fullname(database, schema, table)
         self._datasets[full_name].field_statistics = DatasetFieldStatistics(
             field_statistics=[]
         )

--- a/metaphor/postgresql/profile/extractor.py
+++ b/metaphor/postgresql/profile/extractor.py
@@ -216,8 +216,8 @@ class PostgreSQLProfileExtractor(PostgreSQLExtractor):
         super()._init_dataset(
             database, schema, table, table_type, description, row_count, table_size
         )
-        full_name = dataset_normalized_name(database, schema, table)
-        self._datasets[full_name].field_statistics = DatasetFieldStatistics(
+        normalized_name = dataset_normalized_name(database, schema, table)
+        self._datasets[normalized_name].field_statistics = DatasetFieldStatistics(
             field_statistics=[]
         )
 

--- a/metaphor/postgresql/profile/extractor.py
+++ b/metaphor/postgresql/profile/extractor.py
@@ -8,7 +8,7 @@ except ImportError:
     print("Please install metaphor[postgresql] extra\n")
     raise
 
-from metaphor.common.entity_id import dataset_fullname
+from metaphor.common.entity_id import dataset_normalized_name
 from metaphor.common.event_util import ENTITY_TYPES
 from metaphor.common.logger import get_logger
 from metaphor.common.sampling import SamplingConfig
@@ -216,7 +216,7 @@ class PostgreSQLProfileExtractor(PostgreSQLExtractor):
         super()._init_dataset(
             database, schema, table, table_type, description, row_count, table_size
         )
-        full_name = dataset_fullname(database, schema, table)
+        full_name = dataset_normalized_name(database, schema, table)
         self._datasets[full_name].field_statistics = DatasetFieldStatistics(
             field_statistics=[]
         )

--- a/metaphor/postgresql/usage/extractor.py
+++ b/metaphor/postgresql/usage/extractor.py
@@ -1,6 +1,6 @@
 from typing import Collection
 
-from metaphor.common.entity_id import dataset_fullname
+from metaphor.common.entity_id import dataset_normalized_name
 from metaphor.common.event_util import ENTITY_TYPES
 from metaphor.common.logger import get_logger
 from metaphor.common.usage_util import UsageUtil
@@ -47,7 +47,7 @@ class PostgreSQLUsageExtractor(PostgreSQLExtractor):
                     schema = row["schemaname"]
                     table_name = row["relname"]
                     read_count = row["seq_scan"]
-                    full_name = dataset_fullname(db, schema, table_name)
+                    full_name = dataset_normalized_name(db, schema, table_name)
 
                     if not self._filter.include_table(db, schema, table_name):
                         logger.info(f"Ignore {full_name} due to filter config")

--- a/metaphor/postgresql/usage/extractor.py
+++ b/metaphor/postgresql/usage/extractor.py
@@ -47,13 +47,15 @@ class PostgreSQLUsageExtractor(PostgreSQLExtractor):
                     schema = row["schemaname"]
                     table_name = row["relname"]
                     read_count = row["seq_scan"]
-                    full_name = dataset_normalized_name(db, schema, table_name)
+                    normalized_name = dataset_normalized_name(db, schema, table_name)
 
                     if not self._filter.include_table(db, schema, table_name):
-                        logger.info(f"Ignore {full_name} due to filter config")
+                        logger.info(f"Ignore {normalized_name} due to filter config")
                         continue
 
-                    dataset = UsageUtil.init_dataset(full_name, DataPlatform.POSTGRESQL)
+                    dataset = UsageUtil.init_dataset(
+                        normalized_name, DataPlatform.POSTGRESQL
+                    )
 
                     # don't have exact time of query, so set all time window to be same query count
                     dataset.usage.query_counts.last24_hours.count = float(read_count)

--- a/metaphor/power_bi/power_query_parser.py
+++ b/metaphor/power_bi/power_query_parser.py
@@ -3,7 +3,11 @@ from typing import List, Optional, Tuple
 
 from sql_metadata import Parser
 
-from metaphor.common.entity_id import EntityId, dataset_fullname, to_dataset_entity_id
+from metaphor.common.entity_id import (
+    EntityId,
+    dataset_normalized_name,
+    to_dataset_entity_id,
+)
 from metaphor.common.logger import get_logger
 from metaphor.models.metadata_change_event import DataPlatform
 
@@ -67,7 +71,7 @@ class PowerQueryParser:
             raise AssertionError(f"Unknown platform ${platform_str}")
 
         return to_dataset_entity_id(
-            dataset_fullname(db, schema, table), platform, account
+            dataset_normalized_name(db, schema, table), platform, account
         )
 
     @staticmethod
@@ -190,7 +194,9 @@ class PowerQueryParser:
         tables = PowerQueryParser.parse_tables(parameters[1], default_db)
 
         return [
-            to_dataset_entity_id(dataset_fullname(db, schema, table), platform, account)
+            to_dataset_entity_id(
+                dataset_normalized_name(db, schema, table), platform, account
+            )
             for db, schema, table in tables
         ]
 

--- a/metaphor/redshift/extractor.py
+++ b/metaphor/redshift/extractor.py
@@ -1,6 +1,6 @@
 from typing import Collection, List
 
-from metaphor.common.entity_id import dataset_fullname
+from metaphor.common.entity_id import dataset_normalized_name
 from metaphor.common.event_util import ENTITY_TYPES
 from metaphor.common.logger import get_logger
 from metaphor.common.query_history import chunk_query_logs
@@ -68,7 +68,9 @@ class RedshiftExtractor(PostgreSQLExtractor):
         )
 
         for result in results:
-            full_name = dataset_fullname(catalog, result["schema"], result["table"])
+            full_name = dataset_normalized_name(
+                catalog, result["schema"], result["table"]
+            )
             if full_name not in self._datasets:
                 logger.warning(f"table {full_name} not found")
                 continue

--- a/metaphor/redshift/extractor.py
+++ b/metaphor/redshift/extractor.py
@@ -68,14 +68,14 @@ class RedshiftExtractor(PostgreSQLExtractor):
         )
 
         for result in results:
-            full_name = dataset_normalized_name(
+            normalized_name = dataset_normalized_name(
                 catalog, result["schema"], result["table"]
             )
-            if full_name not in self._datasets:
-                logger.warning(f"table {full_name} not found")
+            if normalized_name not in self._datasets:
+                logger.warning(f"table {normalized_name} not found")
                 continue
 
-            dataset = self._datasets[full_name]
+            dataset = self._datasets[normalized_name]
             assert dataset.statistics is not None
 
             dataset.statistics.record_count = (

--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -28,6 +28,7 @@ from metaphor.models.metadata_change_event import (
     DatasetLogicalID,
     DatasetSchema,
     DatasetStatistics,
+    DatasetStructure,
     EntityType,
     MaterializationType,
     QueriedDataset,
@@ -167,7 +168,7 @@ class SnowflakeExtractor(BaseExtractor):
                 continue
 
             self._datasets[full_name] = self._init_dataset(
-                full_name, table_type, comment, row_count, table_bytes
+                database, schema, name, table_type, comment, row_count, table_bytes
             )
             tables[full_name] = DatasetInfo(database, schema, name, table_type)
 
@@ -449,12 +450,15 @@ class SnowflakeExtractor(BaseExtractor):
 
     def _init_dataset(
         self,
-        full_name: str,
+        database: str,
+        schema: str,
+        table: str,
         table_type: str,
         comment: str,
         row_count: Optional[int],
         table_bytes: Optional[float],
     ) -> Dataset:
+        full_name = dataset_fullname(database, schema, table)
         dataset = Dataset()
         dataset.entity_type = EntityType.DATASET
         dataset.logical_id = DatasetLogicalID(
@@ -483,6 +487,10 @@ class SnowflakeExtractor(BaseExtractor):
             dataset.statistics.record_count = float(row_count)
         if table_bytes:
             dataset.statistics.data_size = table_bytes / (1000 * 1000)  # in MB
+
+        dataset.structure = DatasetStructure(
+            database=database, schema=schema, table=table
+        )
 
         return dataset
 

--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -155,22 +155,22 @@ class SnowflakeExtractor(BaseExtractor):
 
         tables: Dict[str, DatasetInfo] = {}
         for schema, name, table_type, comment, row_count, table_bytes in cursor:
-            full_name = dataset_normalized_name(database, schema, name)
+            normalized_name = dataset_normalized_name(database, schema, name)
             if not self._filter.include_table(database, schema, name):
-                logger.info(f"Ignore {full_name} due to filter config")
+                logger.info(f"Ignore {normalized_name} due to filter config")
                 continue
 
             # TODO: Support dots in database/schema/table name
             if "." in database or "." in schema or "." in name:
                 logger.info(
-                    f"Ignore {full_name} due to dot in database, schema, or table name"
+                    f"Ignore {normalized_name} due to dot in database, schema, or table name"
                 )
                 continue
 
-            self._datasets[full_name] = self._init_dataset(
+            self._datasets[normalized_name] = self._init_dataset(
                 database, schema, name, table_type, comment, row_count, table_bytes
             )
-            tables[full_name] = DatasetInfo(database, schema, name, table_type)
+            tables[normalized_name] = DatasetInfo(database, schema, name, table_type)
 
         return tables
 
@@ -196,11 +196,13 @@ class SnowflakeExtractor(BaseExtractor):
             default,
             comment,
         ) in cursor:
-            full_name = dataset_normalized_name(database, table_schema, table_name)
-            if full_name not in self._datasets:
+            normalized_name = dataset_normalized_name(
+                database, table_schema, table_name
+            )
+            if normalized_name not in self._datasets:
                 continue
 
-            dataset = self._datasets[full_name]
+            dataset = self._datasets[normalized_name]
 
             assert dataset.schema is not None and dataset.schema.fields is not None
 
@@ -284,12 +286,12 @@ class SnowflakeExtractor(BaseExtractor):
                 entry[4],
                 entry[6],
             )
-            table = dataset_normalized_name(database, schema, table_name)
+            normalized_name = dataset_normalized_name(database, schema, table_name)
 
-            dataset = self._datasets.get(table)
+            dataset = self._datasets.get(normalized_name)
             if dataset is None or dataset.schema is None:
                 logger.warning(
-                    f"Table {table} schema not found for unique key {constraint_name}"
+                    f"Table {normalized_name} schema not found for unique key {constraint_name}"
                 )
                 continue
 
@@ -299,7 +301,7 @@ class SnowflakeExtractor(BaseExtractor):
             )
             if not field:
                 logger.warning(
-                    f"Column {column} not found in table {table} for unique key {constraint_name}"
+                    f"Column {column} not found in table {normalized_name} for unique key {constraint_name}"
                 )
                 continue
 
@@ -315,12 +317,12 @@ class SnowflakeExtractor(BaseExtractor):
                 entry[4],
                 entry[6],
             )
-            table = dataset_normalized_name(database, schema, table_name)
+            normalized_name = dataset_normalized_name(database, schema, table_name)
 
-            dataset = self._datasets.get(table)
+            dataset = self._datasets.get(normalized_name)
             if dataset is None or dataset.schema is None:
                 logger.error(
-                    f"Table {table} schema not found for primary key {constraint_name}"
+                    f"Table {normalized_name} schema not found for primary key {constraint_name}"
                 )
                 continue
 
@@ -342,12 +344,12 @@ class SnowflakeExtractor(BaseExtractor):
         )
 
         for key, value, database, schema, table_name in cursor:
-            table = dataset_normalized_name(database, schema, table_name)
+            normalized_name = dataset_normalized_name(database, schema, table_name)
 
-            dataset = self._datasets.get(table)
+            dataset = self._datasets.get(normalized_name)
             if dataset is None or dataset.schema is None:
                 logger.error(
-                    f"Table {table} not found for tag {self._build_tag_string(key, value)}"
+                    f"Table {normalized_name} not found for tag {self._build_tag_string(key, value)}"
                 )
                 continue
 
@@ -458,15 +460,15 @@ class SnowflakeExtractor(BaseExtractor):
         row_count: Optional[int],
         table_bytes: Optional[float],
     ) -> Dataset:
-        full_name = dataset_normalized_name(database, schema, table)
+        normalized_name = dataset_normalized_name(database, schema, table)
         dataset = Dataset()
         dataset.entity_type = EntityType.DATASET
         dataset.logical_id = DatasetLogicalID(
-            name=full_name, account=self._account, platform=DataPlatform.SNOWFLAKE
+            name=normalized_name, account=self._account, platform=DataPlatform.SNOWFLAKE
         )
 
         dataset.source_info = SourceInfo(
-            main_url=SnowflakeExtractor.build_table_url(self._account, full_name)
+            main_url=SnowflakeExtractor.build_table_url(self._account, normalized_name)
         )
 
         dataset.schema = DatasetSchema(

--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -18,7 +18,7 @@ except ImportError:
 
 
 from metaphor.common.base_extractor import BaseExtractor
-from metaphor.common.entity_id import dataset_fullname
+from metaphor.common.entity_id import dataset_normalized_name
 from metaphor.common.event_util import ENTITY_TYPES
 from metaphor.common.logger import get_logger
 from metaphor.models.crawler_run_metadata import Platform
@@ -155,7 +155,7 @@ class SnowflakeExtractor(BaseExtractor):
 
         tables: Dict[str, DatasetInfo] = {}
         for schema, name, table_type, comment, row_count, table_bytes in cursor:
-            full_name = dataset_fullname(database, schema, name)
+            full_name = dataset_normalized_name(database, schema, name)
             if not self._filter.include_table(database, schema, name):
                 logger.info(f"Ignore {full_name} due to filter config")
                 continue
@@ -196,7 +196,7 @@ class SnowflakeExtractor(BaseExtractor):
             default,
             comment,
         ) in cursor:
-            full_name = dataset_fullname(database, table_schema, table_name)
+            full_name = dataset_normalized_name(database, table_schema, table_name)
             if full_name not in self._datasets:
                 continue
 
@@ -284,7 +284,7 @@ class SnowflakeExtractor(BaseExtractor):
                 entry[4],
                 entry[6],
             )
-            table = dataset_fullname(database, schema, table_name)
+            table = dataset_normalized_name(database, schema, table_name)
 
             dataset = self._datasets.get(table)
             if dataset is None or dataset.schema is None:
@@ -315,7 +315,7 @@ class SnowflakeExtractor(BaseExtractor):
                 entry[4],
                 entry[6],
             )
-            table = dataset_fullname(database, schema, table_name)
+            table = dataset_normalized_name(database, schema, table_name)
 
             dataset = self._datasets.get(table)
             if dataset is None or dataset.schema is None:
@@ -342,7 +342,7 @@ class SnowflakeExtractor(BaseExtractor):
         )
 
         for key, value, database, schema, table_name in cursor:
-            table = dataset_fullname(database, schema, table_name)
+            table = dataset_normalized_name(database, schema, table_name)
 
             dataset = self._datasets.get(table)
             if dataset is None or dataset.schema is None:
@@ -458,7 +458,7 @@ class SnowflakeExtractor(BaseExtractor):
         row_count: Optional[int],
         table_bytes: Optional[float],
     ) -> Dataset:
-        full_name = dataset_fullname(database, schema, table)
+        full_name = dataset_normalized_name(database, schema, table)
         dataset = Dataset()
         dataset.entity_type = EntityType.DATASET
         dataset.logical_id = DatasetLogicalID(

--- a/metaphor/snowflake/lineage/extractor.py
+++ b/metaphor/snowflake/lineage/extractor.py
@@ -6,7 +6,7 @@ from pydantic import parse_raw_as
 
 from metaphor.common.base_extractor import BaseExtractor
 from metaphor.common.entity_id import (
-    dataset_fullname,
+    dataset_normalized_name,
     to_dataset_entity_id,
     to_dataset_entity_id_from_logical_id,
 )
@@ -190,7 +190,7 @@ class SnowflakeLineageExtractor(BaseExtractor):
                 continue
 
             database, schema, name = parts
-            full_name = dataset_fullname(database, schema, name)
+            full_name = dataset_normalized_name(database, schema, name)
             if not self._filter.include_table(database, schema, name):
                 logger.info(f"Excluding table {full_name}")
                 continue
@@ -237,14 +237,18 @@ class SnowflakeLineageExtractor(BaseExtractor):
             ):
                 continue
 
-            source_fullname = dataset_fullname(source_db, source_schema, source_table)
+            source_fullname = dataset_normalized_name(
+                source_db, source_schema, source_table
+            )
             source_entity_id_str = str(
                 to_dataset_entity_id(
                     source_fullname, DataPlatform.SNOWFLAKE, self._account
                 )
             )
 
-            target_fullname = dataset_fullname(target_db, target_schema, target_table)
+            target_fullname = dataset_normalized_name(
+                target_db, target_schema, target_table
+            )
 
             if not self._filter.include_table(target_db, target_schema, target_table):
                 logger.info(f"Excluding table {target_fullname}")

--- a/metaphor/snowflake/lineage/extractor.py
+++ b/metaphor/snowflake/lineage/extractor.py
@@ -165,9 +165,9 @@ class SnowflakeLineageExtractor(BaseExtractor):
             ):
                 continue
 
-            full_name = obj.objectName.lower().replace('"', "")
+            normalized_name = obj.objectName.lower().replace('"', "")
             entity_id = to_dataset_entity_id(
-                full_name, DataPlatform.SNOWFLAKE, self._account
+                normalized_name, DataPlatform.SNOWFLAKE, self._account
             )
             source_datasets.append(str(entity_id))
 
@@ -190,13 +190,15 @@ class SnowflakeLineageExtractor(BaseExtractor):
                 continue
 
             database, schema, name = parts
-            full_name = dataset_normalized_name(database, schema, name)
+            normalized_name = dataset_normalized_name(database, schema, name)
             if not self._filter.include_table(database, schema, name):
-                logger.info(f"Excluding table {full_name}")
+                logger.info(f"Excluding table {normalized_name}")
                 continue
 
             logical_id = DatasetLogicalID(
-                name=full_name, account=self._account, platform=DataPlatform.SNOWFLAKE
+                name=normalized_name,
+                account=self._account,
+                platform=DataPlatform.SNOWFLAKE,
             )
 
             filtered_source_datasets = source_datasets.copy()
@@ -212,7 +214,7 @@ class SnowflakeLineageExtractor(BaseExtractor):
                 source_datasets=filtered_source_datasets, transformation=query
             )
 
-            self._datasets[full_name] = Dataset(
+            self._datasets[normalized_name] = Dataset(
                 logical_id=logical_id, upstream=upstream
             )
 
@@ -237,35 +239,35 @@ class SnowflakeLineageExtractor(BaseExtractor):
             ):
                 continue
 
-            source_fullname = dataset_normalized_name(
+            source_normalized_name = dataset_normalized_name(
                 source_db, source_schema, source_table
             )
             source_entity_id_str = str(
                 to_dataset_entity_id(
-                    source_fullname, DataPlatform.SNOWFLAKE, self._account
+                    source_normalized_name, DataPlatform.SNOWFLAKE, self._account
                 )
             )
 
-            target_fullname = dataset_normalized_name(
+            target_normalized_name = dataset_normalized_name(
                 target_db, target_schema, target_table
             )
 
             if not self._filter.include_table(target_db, target_schema, target_table):
-                logger.info(f"Excluding table {target_fullname}")
+                logger.info(f"Excluding table {target_normalized_name}")
                 continue
 
             target_logical_id = DatasetLogicalID(
-                name=target_fullname,
+                name=target_normalized_name,
                 account=self._account,
                 platform=DataPlatform.SNOWFLAKE,
             )
 
-            if target_fullname in self._datasets:
-                self._datasets[target_fullname].upstream.source_datasets.append(
+            if target_normalized_name in self._datasets:
+                self._datasets[target_normalized_name].upstream.source_datasets.append(
                     source_entity_id_str
                 )
             else:
-                self._datasets[target_fullname] = Dataset(
+                self._datasets[target_normalized_name] = Dataset(
                     logical_id=target_logical_id,
                     upstream=DatasetUpstream(source_datasets=[source_entity_id_str]),
                 )

--- a/metaphor/snowflake/profile/extractor.py
+++ b/metaphor/snowflake/profile/extractor.py
@@ -10,7 +10,7 @@ except ImportError:
     raise
 
 from metaphor.common.base_extractor import BaseExtractor
-from metaphor.common.entity_id import dataset_fullname
+from metaphor.common.entity_id import dataset_normalized_name
 from metaphor.common.event_util import ENTITY_TYPES
 from metaphor.common.logger import get_logger
 from metaphor.common.sampling import SamplingConfig
@@ -102,7 +102,7 @@ class SnowflakeProfileExtractor(BaseExtractor):
                 # exclude both view and temporary table
                 continue
 
-            full_name = dataset_fullname(database, schema, name)
+            full_name = dataset_normalized_name(database, schema, name)
             if not self._filter.include_table(database, schema, name):
                 logger.info(f"Ignore {full_name} due to filter config")
                 continue
@@ -137,7 +137,7 @@ class SnowflakeProfileExtractor(BaseExtractor):
                 column_name,
                 data_type,
             ) = row
-            full_name = dataset_fullname(table_catalog, table_schema, table_name)
+            full_name = dataset_normalized_name(table_catalog, table_schema, table_name)
             if full_name not in tables:
                 continue
 

--- a/metaphor/snowflake/profile/extractor.py
+++ b/metaphor/snowflake/profile/extractor.py
@@ -301,11 +301,11 @@ class SnowflakeProfileExtractor(BaseExtractor):
         return data_type in ("VARIANT", "ARRAY", "OBJECT", "GEOGRAPHY")
 
     @staticmethod
-    def _init_dataset(account: str, full_name: str) -> Dataset:
+    def _init_dataset(account: str, normalized_name: str) -> Dataset:
         dataset = Dataset()
         dataset.entity_type = EntityType.DATASET
         dataset.logical_id = DatasetLogicalID(
-            name=full_name, account=account, platform=DataPlatform.SNOWFLAKE
+            name=normalized_name, account=account, platform=DataPlatform.SNOWFLAKE
         )
 
         dataset.field_statistics = DatasetFieldStatistics(field_statistics=[])

--- a/metaphor/thought_spot/extractor.py
+++ b/metaphor/thought_spot/extractor.py
@@ -6,7 +6,7 @@ from restapisdk.models.search_object_header_type_enum import SearchObjectHeaderT
 
 from metaphor.common.base_extractor import BaseExtractor
 from metaphor.common.entity_id import (
-    dataset_fullname,
+    dataset_normalized_name,
     to_dataset_entity_id,
     to_virtual_view_entity_id,
 )
@@ -190,7 +190,7 @@ class ThoughtSpotExtractor(BaseExtractor):
                 view.thought_spot.source_datasets = [
                     str(
                         to_dataset_entity_id(
-                            dataset_fullname(
+                            dataset_normalized_name(
                                 db=mapping.databaseName,
                                 schema=mapping.schemaName,
                                 table=mapping.tableName,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.64"
+version = "0.11.65"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/bigquery/expected.json
+++ b/tests/bigquery/expected.json
@@ -31,6 +31,11 @@
       "dataSize": 5.0,
       "recordCount": 100.0,
       "lastUpdated": "2000-01-02T00:00:00+00:00"
+    },
+    "structure": {
+      "database": "project1",
+      "schema": "dataset1",
+      "table": "table1"
     }
   },
   {
@@ -82,6 +87,11 @@
       "dataSize": 0.5,
       "recordCount": 1000.0,
       "lastUpdated": "2000-01-02T00:00:00+00:00"
+    },
+    "structure": {
+      "database": "project1",
+      "schema": "dataset1",
+      "table": "table2"
     }
   },
   {

--- a/tests/bigquery/profile/test_extractor.py
+++ b/tests/bigquery/profile/test_extractor.py
@@ -197,7 +197,7 @@ def test_parse_profiling_result_default():
         # json
         5,
     ]
-    dataset = BigQueryProfileExtractor._init_dataset(full_name="foo")
+    dataset = BigQueryProfileExtractor._init_dataset(normalized_name="foo")
 
     column_statistics = ColumnStatistics()
 

--- a/tests/common/test_entity_id.py
+++ b/tests/common/test_entity_id.py
@@ -1,4 +1,4 @@
-from metaphor.common.entity_id import EntityId
+from metaphor.common.entity_id import EntityId, dataset_normalized_name
 from metaphor.models.metadata_change_event import (
     DataPlatform,
     DatasetLogicalID,
@@ -24,3 +24,10 @@ def test_to_str():
 
     # md5({"account":"account","name":"name","platform":"SNOWFLAKE"}) == 5AC8814ADBAFDA3D2B6D1AC58782C5D4
     assert str(id) == "DATASET~5AC8814ADBAFDA3D2B6D1AC58782C5D4"
+
+
+def test_dataset_normalized_name():
+    assert "a.b.c" == dataset_normalized_name("A", "b", "C")
+    assert "b.c" == dataset_normalized_name("b", "C")
+    assert "b.c" == dataset_normalized_name(schema="b", table="C")
+    assert "a.c" == dataset_normalized_name(db="A", table="C")

--- a/tests/glue/expected.json
+++ b/tests/glue/expected.json
@@ -30,6 +30,10 @@
     "statistics": {
       "lastUpdated": "2022-09-20T08:30:00",
       "recordCount": 100000.0
+    },
+    "structure": {
+      "schema": "db1",
+      "table": "table1"
     }
   },
   {
@@ -63,6 +67,10 @@
     "statistics": {
       "lastUpdated": "2022-09-20T08:30:00",
       "recordCount": 100000.0
+    },
+    "structure": {
+      "schema": "db2",
+      "table": "table2"
     }
   }
 ]

--- a/tests/snowflake/profile/test_extractor.py
+++ b/tests/snowflake/profile/test_extractor.py
@@ -131,7 +131,9 @@ def test_parse_profiling_result():
         13,
         14,
     )
-    dataset = SnowflakeProfileExtractor._init_dataset(account="a", full_name="foo")
+    dataset = SnowflakeProfileExtractor._init_dataset(
+        account="a", normalized_name="foo"
+    )
 
     SnowflakeProfileExtractor._parse_profiling_result(
         columns, results, dataset, column_statistics_config()


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

Fill out the three level `DatasetStructure` to enable the next step of showing case sensitive name. Potentially we can support name with dots.

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

- Fill out the field for `Bigquery`, `Snowflake`, `Redshift`, `PostgreSQL`, and `Glue`.
- Use `dataset_fullname` to fill out the logical id as possible

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

- Unit tests.
- Run `Snowflake`, `Bigquery`, and `Redshift` crawler on local, ingest the MCEs, and verified the result on Metaphor.

<!--
  Describe how the change was tested end-to-end.
-->
