### PR TITLE
bigquery dataset name to lowercase

### DIFF
--- a/metaphor/bigquery/extractor.py
+++ b/metaphor/bigquery/extractor.py
@@ -12,6 +12,7 @@ from typing import (
 )
 
 from metaphor.bigquery.logEvent import JobChangeEvent
+from metaphor.common.entity_id import dataset_normalized_name
 from metaphor.common.query_history import chunk_query_logs
 from metaphor.common.utils import md5_digest, start_of_day
 
@@ -154,7 +155,9 @@ class BigQueryExtractor(BaseExtractor):
     def _parse_table(project_id, bq_table: bigquery.table.Table) -> Dataset:
         dataset_id = DatasetLogicalID(
             platform=DataPlatform.BIGQUERY,
-            name=f"{project_id}.{bq_table.dataset_id}.{bq_table.table_id}",
+            name=dataset_normalized_name(
+                project_id, bq_table.dataset_id, bq_table.table_id
+            ),
         )
 
         schema = BigQueryExtractor.parse_schema(bq_table)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.66"
+version = "0.11.67"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/bigquery/expected.json
+++ b/tests/bigquery/expected.json
@@ -91,7 +91,7 @@
     "structure": {
       "database": "project1",
       "schema": "dataset1",
-      "table": "table2"
+      "table": "Table2"
     }
   },
   {

--- a/tests/bigquery/test_extractor.py
+++ b/tests/bigquery/test_extractor.py
@@ -113,7 +113,7 @@ async def test_extractor(test_root_dir):
             {
                 "dataset1": [
                     mock_table("dataset1", "table1"),
-                    mock_table("dataset1", "table2"),
+                    mock_table("dataset1", "Table2"),
                 ],
             },
         )
@@ -144,9 +144,9 @@ async def test_extractor(test_root_dir):
                     num_bytes=5 * 1024 * 1024,
                     num_rows=100,
                 ),
-                ("dataset1", "table2"): mock_table_full(
+                ("dataset1", "Table2"): mock_table_full(
                     dataset_id="dataset1",
-                    table_id="table2",
+                    table_id="Table2",
                     table_type="VIEW",
                     description="description",
                     schema=[


### PR DESCRIPTION
### 🤔 Why?

BQ dataset logical name didn't use normalized name, causing customer data issue.

### 🤓 What?

- normalize BQ dataset name
- didn't change the name used in `structure` and kept the original case there

### 🧪 Tested?

unit tests
