### PR TITLE
Remove dependency on Snowflake Enterprise [sc-13398]

### DIFF
--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -365,7 +365,7 @@ class SnowflakeExtractor(BaseExtractor):
         end_date = start_of_day()
 
         has_access_history = check_access_history(self._conn)
-        logger.info(f"has access history: {has_access_history}")
+        logger.info(f"Using Snowflake Enterprise edition: {has_access_history}")
 
         count = fetch_query_history_count(
             self._conn,

--- a/metaphor/snowflake/utils.py
+++ b/metaphor/snowflake/utils.py
@@ -114,8 +114,8 @@ def check_access_history(
         LIMIT 1
         """
     )
-    result = cursor.fetchone()
-    return result is not None
+    result = cursor.fetchall()
+    return len(result) > 0
 
 
 def fetch_query_history_count(
@@ -123,7 +123,7 @@ def fetch_query_history_count(
     start_date: datetime,
     excluded_usernames: Set[str],
     end_date: datetime = datetime.now(),
-    has_access_history: bool = False,
+    has_access_history: bool = True,
 ) -> int:
     """
     Fetch query history count

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.67"
+version = "0.11.68"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
### 🤔 Why?

Non-enterprise snowflake accounts won't have access to the `access_history` view to get access logs.

### 🤓 What?

- check if the `access_history` view is available, if not, only fetch the raw query text from `query_history`

### 🧪 Tested?

tested against snowflake instance. Tested with the `has_access_history` set to both true and false.
