### PR TITLE
Ignore malformed Looker dashboards

### DIFF
--- a/metaphor/looker/extractor.py
+++ b/metaphor/looker/extractor.py
@@ -101,7 +101,14 @@ class LookerExtractor(BaseExtractor):
         dashboards: List[Dashboard] = []
         for basic_dashboard in self._sdk.all_dashboards():
             assert basic_dashboard.id is not None
-            dashboard = self._sdk.dashboard(dashboard_id=basic_dashboard.id)
+
+            try:
+                dashboard = self._sdk.dashboard(dashboard_id=basic_dashboard.id)
+            except looker_sdk.error.SDKError as error:
+                logger.error(f"Failed to fetch dashboard {basic_dashboard.id}: {error}")
+                continue
+
+            logger.info(f"Processing dashboard {basic_dashboard.id}")
 
             dashboard_info = DashboardInfo(
                 title=dashboard.title,

--- a/metaphor/looker/lookml_parser.py
+++ b/metaphor/looker/lookml_parser.py
@@ -21,6 +21,7 @@ from metaphor.common.entity_id import (
     to_dataset_entity_id,
     to_virtual_view_entity_id,
 )
+from metaphor.common.logger import get_logger
 from metaphor.models.metadata_change_event import (
     LookerExplore,
     LookerExploreJoin,
@@ -32,8 +33,7 @@ from metaphor.models.metadata_change_event import (
     VirtualViewType,
 )
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+logger = get_logger()
 
 # lkml parser's debug log can be very noisy
 logging.getLogger("lkml.parser").setLevel(logging.WARNING)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.70"
+version = "0.11.71"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

It's possible to create malformed dashboards in Looker which causes the Looker SDK to throw errors when deserializing returned the API content.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Catch and ignore SDK errors when encountering malformed dashboards. Also changed to the shared logger in `lookml_parser.py`.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Manually tested against a production instance containing malformed dashboards.
