### PR TITLE
populate DBT metric URL [sc-13231]

### DIFF
--- a/metaphor/dbt/catalog_parser_v1.py
+++ b/metaphor/dbt/catalog_parser_v1.py
@@ -6,7 +6,7 @@ from metaphor.common.logger import get_logger
 from metaphor.dbt.config import DbtRunConfig
 from metaphor.dbt.generated.dbt_catalog_v1 import CatalogTable, DbtCatalog
 from metaphor.dbt.util import (
-    build_docs_url,
+    build_model_docs_url,
     init_dataset,
     init_documentation,
     init_field,
@@ -66,7 +66,7 @@ class CatalogParserV1:
         dbt_model = virtual_view.dbt_model
 
         dbt_model.description = dbt_model.description or model.metadata.comment
-        dbt_model.docs_url = dbt_model.docs_url or build_docs_url(
+        dbt_model.docs_url = dbt_model.docs_url or build_model_docs_url(
             self._docs_base_url, model.unique_id
         )
 

--- a/metaphor/dbt/cloud/extractor.py
+++ b/metaphor/dbt/cloud/extractor.py
@@ -15,7 +15,7 @@ from metaphor.models.crawler_run_metadata import Platform
 logger = get_logger()
 
 ADMIN_API_BASE_URL = "https://cloud.getdbt.com/api/v2"
-DBT_DOC_BASE_URL = "https://cloud.getdbt.com/accounts/%d/runs/%s/docs"
+DBT_DOC_BASE_URL = "https://cloud.getdbt.com/accounts/%d/jobs/%s/docs"
 
 
 class DbtAdminAPIClient:
@@ -136,7 +136,7 @@ class DbtCloudExtractor(BaseExtractor):
             DbtRunConfig(
                 manifest=manifest_json,
                 account=account,
-                docs_base_url=DBT_DOC_BASE_URL % (self._account_id, run_id),
+                docs_base_url=DBT_DOC_BASE_URL % (self._account_id, self._job_id),
                 output=self._output,
                 meta_ownerships=self._meta_ownerships,
                 meta_tags=self._meta_tags,

--- a/metaphor/dbt/manifest_parser_v3.py
+++ b/metaphor/dbt/manifest_parser_v3.py
@@ -33,7 +33,7 @@ from .generated.dbt_manifest_v3 import (
     ParsedSourceDefinition,
 )
 from .util import (
-    build_docs_url,
+    build_model_docs_url,
     build_source_code_url,
     get_ownerships_from_meta,
     get_tags_from_meta,
@@ -196,7 +196,7 @@ class ManifestParserV3:
             url=build_source_code_url(
                 self._project_source_url, model.original_file_path
             ),
-            docs_url=build_docs_url(self._docs_base_url, model.unique_id),
+            docs_url=build_model_docs_url(self._docs_base_url, model.unique_id),
             tags=model.tags,
             raw_sql=model.raw_sql,
             fields=[],

--- a/metaphor/dbt/manifest_parser_v5.py
+++ b/metaphor/dbt/manifest_parser_v5.py
@@ -38,7 +38,8 @@ from .generated.dbt_manifest_v5 import (
     ParsedSourceDefinition,
 )
 from .util import (
-    build_docs_url,
+    build_metric_docs_url,
+    build_model_docs_url,
     build_source_code_url,
     get_ownerships_from_meta,
     get_tags_from_meta,
@@ -209,7 +210,7 @@ class ManifestParserV5:
             url=build_source_code_url(
                 self._project_source_url, model.original_file_path
             ),
-            docs_url=build_docs_url(self._docs_base_url, model.unique_id),
+            docs_url=build_model_docs_url(self._docs_base_url, model.unique_id),
             tags=model.tags,
             raw_sql=model.raw_sql,
             fields=[],
@@ -306,6 +307,7 @@ class ManifestParserV5:
                 MetricFilter(field=f.field, operator=f.operator, value=f.value)
                 for f in metric.filters
             ],
+            url=build_metric_docs_url(self._docs_base_url, metric.unique_id),
         )
 
         dbt_metric = metric_entity.dbt_metric

--- a/metaphor/dbt/manifest_parser_v6.py
+++ b/metaphor/dbt/manifest_parser_v6.py
@@ -38,7 +38,8 @@ from .generated.dbt_manifest_v6 import (
     ParsedSourceDefinition,
 )
 from .util import (
-    build_docs_url,
+    build_metric_docs_url,
+    build_model_docs_url,
     build_source_code_url,
     get_ownerships_from_meta,
     get_tags_from_meta,
@@ -208,7 +209,7 @@ class ManifestParserV6:
             url=build_source_code_url(
                 self._project_source_url, model.original_file_path
             ),
-            docs_url=build_docs_url(self._docs_base_url, model.unique_id),
+            docs_url=build_model_docs_url(self._docs_base_url, model.unique_id),
             tags=model.tags,
             raw_sql=model.raw_sql,
             fields=[],
@@ -305,6 +306,7 @@ class ManifestParserV6:
                 MetricFilter(field=f.field, operator=f.operator, value=f.value)
                 for f in metric.filters
             ],
+            url=build_metric_docs_url(self._docs_base_url, metric.unique_id),
         )
 
         dbt_metric = metric_entity.dbt_metric

--- a/metaphor/dbt/util.py
+++ b/metaphor/dbt/util.py
@@ -216,8 +216,14 @@ def init_field_doc(dataset: Dataset, column: str) -> FieldDocumentation:
     return doc
 
 
-def build_docs_url(docs_base_url: Optional[str], unique_id: str) -> Optional[str]:
+def build_model_docs_url(docs_base_url: Optional[str], unique_id: str) -> Optional[str]:
     return f"{docs_base_url}/#!/model/{unique_id}" if docs_base_url else None
+
+
+def build_metric_docs_url(
+    docs_base_url: Optional[str], unique_id: str
+) -> Optional[str]:
+    return f"{docs_base_url}/#!/metric/{unique_id}" if docs_base_url else None
 
 
 def build_source_code_url(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.73"
+version = "0.11.74"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/dbt/cloud/test_extractor.py
+++ b/tests/dbt/cloud/test_extractor.py
@@ -45,7 +45,7 @@ async def test_extractor(test_root_dir):
             DbtRunConfig(
                 manifest="tempfile",
                 account="snowflake_account",
-                docs_base_url="https://cloud.getdbt.com/accounts/1111/runs/4444/docs",
+                docs_base_url="https://cloud.getdbt.com/accounts/1111/jobs/2222/docs",
                 output=OutputConfig(),
             )
         )

--- a/tests/dbt/data/trial_v4/results.json
+++ b/tests/dbt/data/trial_v4/results.json
@@ -512,7 +512,8 @@
         "year"
       ],
       "timestamp": "release_year",
-      "type": "count"
+      "type": "count",
+      "url": "http://localhost:8080/#!/metric/metric.trial.trial_metric_1"
     },
     "logicalId": {
       "name": "trial.trial_metric_1",

--- a/tests/dbt/data/trial_v5/results.json
+++ b/tests/dbt/data/trial_v5/results.json
@@ -512,7 +512,8 @@
         "year"
       ],
       "timestamp": "release_year",
-      "type": "count"
+      "type": "count",
+      "url": "http://localhost:8080/#!/metric/metric.trial.trial_metric_1"
     },
     "logicalId": {
       "name": "trial.trial_metric_1",

--- a/tests/dbt/data/trial_v6/results.json
+++ b/tests/dbt/data/trial_v6/results.json
@@ -723,7 +723,8 @@
         "year"
       ],
       "timestamp": "release_year",
-      "type": "count"
+      "type": "count",
+      "url": "http://localhost:8080/#!/metric/metric.trial.trial_metric_1"
     },
     "logicalId": {
       "name": "trial.trial_metric_1",


### PR DESCRIPTION
### 🤔 Why?

To be able to show direct link to the dbt metric docs page from metaphor UI

### 🤓 What?

- generate metric URL from base URL and metric id
- fix dbt cloud URL, it uses `job` instead of `run` now.

### 🧪 Tested?

Tested the dbt cloud crawler locally, and verified the URLs.
