### PR TITLE
Allow adding debug files to log.zip

### DIFF
--- a/metaphor/common/file_sink.py
+++ b/metaphor/common/file_sink.py
@@ -10,12 +10,16 @@ from zipfile import ZIP_DEFLATED, ZipFile
 
 from pydantic.dataclasses import dataclass
 
+from metaphor.common.event_util import EventUtil
+from metaphor.common.logger import LOG_FILE, debug_files, get_logger
+from metaphor.common.sink import Sink
+from metaphor.common.storage import (
+    BaseStorage,
+    LocalStorage,
+    S3Storage,
+    S3StorageConfig,
+)
 from metaphor.models.crawler_run_metadata import CrawlerRunMetadata
-
-from .event_util import EventUtil
-from .logger import LOG_FILE, get_logger
-from .sink import Sink
-from .storage import BaseStorage, LocalStorage, S3Storage, S3StorageConfig
 
 logger = get_logger()
 
@@ -83,10 +87,15 @@ class FileSink(Sink):
         logging.shutdown()
 
         _, zip_file = tempfile.mkstemp(suffix=".zip")
-        timestamp = datetime.now(timezone.utc).isoformat()
-        log_filename = f"{path.basename(self.path)}_{timestamp}.log"
+        dir_name = datetime.now(timezone.utc).strftime("%Y-%m-%d %H-%M-%S")
+
         with ZipFile(zip_file, "w", ZIP_DEFLATED) as file:
-            file.write(LOG_FILE, arcname=log_filename)
+            arcname = f"{dir_name}/{path.basename(self.path)}.log"
+            file.write(LOG_FILE, arcname=arcname)
+
+            for debug_file in debug_files:
+                arcname = f"{dir_name}/{path.basename(debug_file)}"
+                file.write(debug_file, arcname=arcname)
 
         with open(zip_file, "rb") as file:
             self._storage.write_file(f"{self.path}/log.zip", file.read(), True)

--- a/metaphor/common/logger.py
+++ b/metaphor/common/logger.py
@@ -23,3 +23,10 @@ def get_logger() -> logging.Logger:
     logger.addHandler(file)
 
     return logger
+
+
+debug_files = []
+
+
+def add_debug_file(file: str) -> None:
+    debug_files.append(file)

--- a/metaphor/dbt/cloud/extractor.py
+++ b/metaphor/dbt/cloud/extractor.py
@@ -1,5 +1,7 @@
 import json
+import shutil
 import tempfile
+from os import path
 from typing import Collection, Dict, Optional, Tuple
 
 import requests
@@ -92,10 +94,13 @@ class DbtAdminAPIClient:
         # https://docs.getdbt.com/dbt-cloud/api-v2#operation/getArtifactsByRunId
         artifact_json = self._get(f"runs/{run_id}/artifacts/{artifact}")
 
-        fd, name = tempfile.mkstemp()
+        fd, temp_name = tempfile.mkstemp()
         with open(fd, "w") as fp:
             json.dump(artifact_json, fp)
-            return name
+
+        pretty_name = f"{path.dirname(temp_name)}/{artifact}"
+        shutil.copyfile(temp_name, pretty_name)
+        return pretty_name
 
 
 class DbtCloudExtractor(BaseExtractor):

--- a/metaphor/dbt/extractor.py
+++ b/metaphor/dbt/extractor.py
@@ -3,7 +3,7 @@ from typing import Collection, Dict, List, Union
 
 from metaphor.common.base_extractor import BaseExtractor
 from metaphor.common.event_util import ENTITY_TYPES
-from metaphor.common.logger import get_logger
+from metaphor.common.logger import add_debug_file, get_logger
 from metaphor.dbt.config import DbtRunConfig
 from metaphor.models.crawler_run_metadata import Platform
 from metaphor.models.metadata_change_event import (
@@ -41,6 +41,10 @@ class DbtExtractor(BaseExtractor):
         self._datasets: Dict[str, Dataset] = {}
         self._virtual_views: Dict[str, VirtualView] = {}
         self._metrics: Dict[str, Metric] = {}
+
+        add_debug_file(config.manifest)
+        if config.catalog:
+            add_debug_file(config.catalog)
 
     async def extract(self) -> Collection[ENTITY_TYPES]:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.79"
+version = "0.11.81"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.81"
+version = "0.11.80"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/common/test_file_sink.py
+++ b/tests/common/test_file_sink.py
@@ -1,8 +1,11 @@
 import tempfile
 from datetime import datetime
+from os import path
+from zipfile import ZipFile
 
 from metaphor.common.event_util import EventUtil
 from metaphor.common.file_sink import FileSink, FileSinkConfig
+from metaphor.common.logger import add_debug_file
 from metaphor.models.crawler_run_metadata import CrawlerRunMetadata, Status
 from metaphor.models.metadata_change_event import (
     MetadataChangeEvent,
@@ -65,3 +68,22 @@ def test_sink_metadata(test_root_dir):
     assert EventUtil.clean_nones(metadata.to_dict()) == load_json(
         f"{directory}/run.metadata"
     )
+
+
+def test_sink_logs(test_root_dir):
+    _, debug_file = tempfile.mkstemp()
+    add_debug_file(debug_file)
+
+    directory = tempfile.mkdtemp()
+
+    sink = FileSink(FileSinkConfig(directory=directory, batch_size=2))
+    sink.sink_logs()
+
+    zip_file = f"{directory}/log.zip"
+
+    assert path.exists(zip_file)
+    with ZipFile(zip_file) as file:
+        base_names = set([path.basename(name) for name in file.namelist()])
+
+    assert path.basename(f"{path.basename(directory)}.log") in base_names
+    assert path.basename(debug_file) in base_names


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

To make it easier to debug.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled. Also added `manifest.json` & `catalog.json` to `log.zip` for `dbt` & `dbt.cloud` connectors.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Ran the connector locally and verified the content of the zip file:

<img width="714" alt="Screenshot 2022-11-13 at 7 21 00 AM" src="https://user-images.githubusercontent.com/24240669/201529417-102aaec7-f31d-449f-a45d-1186ab167a8a.png">

