### PR TITLE
Add column-level tagging to manual governance connector

### DIFF
--- a/metaphor/manual/governance/README.md
+++ b/metaphor/manual/governance/README.md
@@ -66,7 +66,7 @@ output:
     directory: /output
 ```
 
-Here's another example showing how to tag a Snowflake table as `golden`, and a the `email` column as `pii`.
+Here's another example showing how to tag a Snowflake table as `golden`, and the `email` column as `pii`.
 
 ```yaml
 datasets:

--- a/metaphor/manual/governance/README.md
+++ b/metaphor/manual/governance/README.md
@@ -27,9 +27,16 @@ datasets:
     tags:
       - <tag_name>
       ...
+    column_tags:
+      - column: <column_name>
+        tags:
+          - <tag_name>
+          ...
+      ...
     descriptions:
       - description: <description_text>
         email: <author_email>
+      ...
   ...
 output:
   file:
@@ -59,7 +66,7 @@ output:
     directory: /output
 ```
 
-Here's another example showing how to tag a Snowflake table as `pii` and `golden`.
+Here's another example showing how to tag a Snowflake table as `golden`, and a the `email` column as `pii`.
 
 ```yaml
 datasets:
@@ -68,8 +75,11 @@ datasets:
       account: test_account
       name: database.schema.table1
     tags:
-      - pii
-      - golden 
+      - golden
+    column_tags:
+      - column: email
+        tags:
+          - pii
 output:
   file:
     directory: /output

--- a/metaphor/manual/governance/config.py
+++ b/metaphor/manual/governance/config.py
@@ -17,6 +17,15 @@ class Ownership:
 
 
 @dataclass
+class ColumnTags:
+    # Name of the column
+    column: str
+
+    # List of associated tags
+    tags: List[str]
+
+
+@dataclass
 class Description:
     # The description to assign
     description: str
@@ -32,6 +41,8 @@ class DatasetGovernance:
     ownerships: List[Ownership] = dataclass_field(default_factory=lambda: [])
 
     tags: List[str] = dataclass_field(default_factory=lambda: [])
+
+    column_tags: List[ColumnTags] = dataclass_field(default_factory=lambda: [])
 
     descriptions: List[Description] = dataclass_field(default_factory=lambda: [])
 

--- a/metaphor/manual/governance/extractor.py
+++ b/metaphor/manual/governance/extractor.py
@@ -6,6 +6,7 @@ from metaphor.common.logger import get_logger
 from metaphor.manual.governance.config import ManualGovernanceConfig
 from metaphor.models.metadata_change_event import (
     AssetDescription,
+    ColumnTagAssignment,
     Dataset,
     DescriptionAssignment,
     MetadataChangeEvent,
@@ -53,6 +54,17 @@ class ManualGovernanceExtractor(BaseExtractor):
 
             if len(governance.tags) > 0:
                 dataset.tag_assignment = TagAssignment(tag_names=governance.tags)
+
+            if len(governance.column_tags) > 0:
+                if dataset.tag_assignment is None:
+                    dataset.tag_assignment = TagAssignment()
+
+                dataset.tag_assignment.column_tag_assignments = [
+                    ColumnTagAssignment(
+                        column_name=column_tag.column, tag_names=column_tag.tags
+                    )
+                    for column_tag in governance.column_tags
+                ]
 
             if len(governance.descriptions) > 0:
                 asset_descriptions = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -1737,7 +1737,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "metaphor-models"
-version = "0.15.1"
+version = "0.16.0"
 description = ""
 category = "main"
 optional = false
@@ -2886,7 +2886,7 @@ unity-catalog = ["databricks-cli"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<3.11"  # See https://github.com/googleapis/python-bigquery/issues/856
-content-hash = "0fe8c832d6117d2bd746f82b2c6da98bb7fad568039ead1636696190f9dac582"
+content-hash = "74c5fbbfc4f83f27204e230ce7a443a1a45dbbb2f6e48e3f75012a7dc4346add"
 
 [metadata.files]
 alembic = [
@@ -3766,8 +3766,8 @@ mdurl = [
     {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
 ]
 metaphor-models = [
-    {file = "metaphor-models-0.15.1.tar.gz", hash = "sha256:83a96fd9f2973c72e1d3ad7e764220757e8daf40b3fd57c9d4b5dd95acc77b64"},
-    {file = "metaphor_models-0.15.1-py3-none-any.whl", hash = "sha256:b94e21f7df019c52a2fdd8d385a86839295ce3c3cac194c6f6ab743ef9bbb5fe"},
+    {file = "metaphor-models-0.16.0.tar.gz", hash = "sha256:e140c10f54c6f0ed9a2062d59a6c444e06a0650d646ff2acccedd04195ac71a4"},
+    {file = "metaphor_models-0.16.0-py3-none-any.whl", hash = "sha256:bb236cb09927cb60dc8c2f4cab9b0e0f70320f11612f0ef57b8f2ffe29ada7c4"},
 ]
 metaphor-sqllineage = [
     {file = "metaphor-sqllineage-1.3.6.tar.gz", hash = "sha256:0c96c67aa938211f984fbe9b06d801c14f4c25ffa65a448ecba83778d7ace8ee"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.83"
+version = "0.11.84"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]
@@ -27,7 +27,7 @@ google-cloud-bigquery = { version = "^2.34.4", optional = true }
 google-cloud-logging = { version = "^3.1.0", optional = true }
 lkml = { version = "^1.2.0", optional = true }
 looker-sdk = { version = "^22.4.0", optional = true }
-metaphor-models = "^0.15.1"
+metaphor-models = "^0.16.0"
 metaphor-sqllineage = { version = "^1.3.6", optional = true }
 msal = { version = "^1.17.0", optional = true }
 pydantic = "~=1.9.0"

--- a/tests/manual/governance/config.yml
+++ b/tests/manual/governance/config.yml
@@ -11,6 +11,14 @@ datasets:
     tags:
       - pii
       - golden
+    column_tags:
+      - column: col1
+        tags:
+          - phi
+      - column: col2
+        tags:
+          - deprecated
+          - do_not_use
     descriptions:
       - description: Quick brown fox
         email: foo3@bar.com

--- a/tests/manual/governance/expected.json
+++ b/tests/manual/governance/expected.json
@@ -20,6 +20,21 @@
       "tagNames": [
         "pii",
         "golden"
+      ],
+      "columnTagAssignments": [
+        {
+          "columnName": "col1",
+          "tagNames": [
+            "phi"
+          ]
+        },
+        {
+          "columnName": "col2",
+          "tagNames": [
+            "deprecated",
+            "do_not_use"
+          ]
+        }
       ]
     },
     "descriptionAssignment": {

--- a/tests/manual/governance/test_config.py
+++ b/tests/manual/governance/test_config.py
@@ -1,5 +1,6 @@
 from metaphor.common.base_config import OutputConfig
 from metaphor.manual.governance.config import (
+    ColumnTags,
     DatasetGovernance,
     Description,
     DeserializableDatasetLogicalID,
@@ -22,6 +23,10 @@ def test_yaml_config(test_root_dir):
                     Ownership(type="Maintainer", email="foo2@bar.com"),
                 ],
                 tags=["pii", "golden"],
+                column_tags=[
+                    ColumnTags(column="col1", tags=["phi"]),
+                    ColumnTags(column="col2", tags=["deprecated", "do_not_use"]),
+                ],
                 descriptions=[
                     Description(description="Quick brown fox", email="foo3@bar.com")
                 ],


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

To allow users to manually specify governed tags at the column-level.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Add `column_tags` to `DatasetGovernance` config class
- Map `column_tags` to `column_tag_assignments` field in `TagAssignment`
- Update tests & README

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Unit tests + manually verified the output.

