### PR TITLE
Normalize dataset name specified in configs

### DIFF
--- a/metaphor/common/entity_id.py
+++ b/metaphor/common/entity_id.py
@@ -77,14 +77,21 @@ def to_person_entity_id(email: str) -> EntityId:
     )
 
 
+def normalize_full_dataset_name(name: str) -> str:
+    """
+    Normalizes a fully qualified dataset name
+    """
+    return name.lower().replace("`", "")
+
+
 def dataset_normalized_name(
     db: Optional[str] = None,
     schema: Optional[str] = None,
     table: Optional[str] = None,
 ) -> str:
-    """builds dataset normalized name"""
-    return (
-        ".".join([part for part in [db, schema, table] if part])
-        .lower()
-        .replace("`", "")
+    """
+    Builds a normalized dataset name from database, schema, & table names
+    """
+    return normalize_full_dataset_name(
+        ".".join([part for part in [db, schema, table] if part is not None])
     )

--- a/metaphor/common/models.py
+++ b/metaphor/common/models.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from pydantic.dataclasses import dataclass
 
-from metaphor.common.entity_id import to_dataset_entity_id
+from metaphor.common.entity_id import normalize_full_dataset_name, to_dataset_entity_id
 from metaphor.models.metadata_change_event import DataPlatform, DatasetLogicalID
 
 
@@ -14,10 +14,14 @@ class DeserializableDatasetLogicalID:
 
     def to_logical_id(self) -> DatasetLogicalID:
         return DatasetLogicalID(
-            name=self.name, platform=DataPlatform[self.platform], account=self.account
+            name=normalize_full_dataset_name(self.name),
+            platform=DataPlatform[self.platform],
+            account=self.account,
         )
 
     def to_entity_id(self):
         return to_dataset_entity_id(
-            self.name, DataPlatform[self.platform], self.account
+            normalize_full_dataset_name(self.name),
+            DataPlatform[self.platform],
+            self.account,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.84"
+version = "0.11.85"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/common/test_models.py
+++ b/tests/common/test_models.py
@@ -1,0 +1,22 @@
+from metaphor.common.models import DeserializableDatasetLogicalID
+from metaphor.models.metadata_change_event import DataPlatform, DatasetLogicalID
+
+
+def test_to_logical_id():
+    id = DeserializableDatasetLogicalID(
+        name="A.b.C",
+        platform="SNOWFLAKE",
+        account="account",
+    )
+    assert id.to_logical_id() == DatasetLogicalID(
+        name="a.b.c", platform=DataPlatform.SNOWFLAKE, account="account"
+    )
+
+
+def test_to_entity_id():
+    id = DeserializableDatasetLogicalID(
+        name="A.b.C",
+        platform="SNOWFLAKE",
+        account="account",
+    )
+    assert str(id.to_entity_id()) == "DATASET~F6E5D45A920F34DC65C17EF4FE00FF41"


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

The dataset name specified in the config, e.g. for [manual.governance](https://github.com/MetaphorData/connectors/blob/main/metaphor/manual/governance/README.md) connector, are not normalized, which can lead to IDs that don't match the actual table.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Tested end-to-end against a production deployment.