### PR TITLE
Replace custom checking code with Poetry's --skip-existing option when publishing to PyPI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -98,11 +98,9 @@ jobs:
 
       - name: Publish to PyPI
         run: >
-          poetry publish --build
+          poetry publish --build --skip-existing
           -u ${{ secrets.PYPI_USERNAME }}
           -p ${{ secrets.PYPI_PASSWORD }}
-          2>&1 | tee ${{ runner.temp }}/logs
-          || grep -qiE 'File already exists' ${{ runner.temp }}/logs
 
       - name: Create tag
         uses: actions/github-script@v5


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Poetry 1.2 added the new [--skip-existing](https://python-poetry.org/docs/cli/#:~:text=%2D%2Dskip-,%2D,-existing%3A%20Ignore%20errors) option to the `publish` command, which obviate the need of our custom checking code.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

https://github.com/MetaphorData/connectors/actions/runs/3525187389/jobs/5911594661

<img width="917" alt="Screenshot 2022-11-22 at 8 24 50 AM" src="https://user-images.githubusercontent.com/24240669/203367691-ee0e489d-f391-4610-b5c3-a5c368bf6ecd.png">

