### PR TITLE
Add support for environment variable substitution in config files

### DIFF
--- a/metaphor/common/base_config.py
+++ b/metaphor/common/base_config.py
@@ -5,8 +5,9 @@ from pydantic import parse_obj_as
 from pydantic.dataclasses import dataclass
 from smart_open import open
 
-from .api_sink import ApiSinkConfig
-from .file_sink import FileSinkConfig
+from metaphor.common.api_sink import ApiSinkConfig
+from metaphor.common.file_sink import FileSinkConfig
+from metaphor.common.variable import variable_substitution
 
 
 @dataclass
@@ -30,4 +31,4 @@ class BaseConfig:
     def from_yaml_file(cls, path: str) -> "BaseConfig":
         with open(path, encoding="utf8") as fin:
             obj = yaml.safe_load(fin.read())
-            return parse_obj_as(cls, obj)
+            return parse_obj_as(cls, variable_substitution(obj))

--- a/metaphor/common/docs/env_var.md
+++ b/metaphor/common/docs/env_var.md
@@ -1,0 +1,13 @@
+# Environment Variable Substitution
+
+You can specify variables using the form `${VAR_NAME}` in the config file, which will be automatically replaced by the value of the matching environment variable. For example, you can set the client secret in the config file using the `SECRET` environment variable:  
+
+```yml
+client_secret: ${SECRET}
+```
+
+The variables can be used anywhere in the config where a string value is expected. It can also be used as part of the string,
+
+```yml
+url: http://${HOST_NAME}/${PATH}
+```

--- a/metaphor/common/variable.py
+++ b/metaphor/common/variable.py
@@ -1,0 +1,47 @@
+import os
+import re
+from typing import Any, Dict, List, TypeVar
+
+# Allowed variable pattern: ${ENV_VAR_NAME}
+var_pattern = r"\$\{([a-zA-Z_][a-zA-Z0-9_]*)\}"
+
+
+T = TypeVar("T")
+
+
+def variable_substitution(target: T) -> T:
+    """Recursively substitute strings with variable expression in the dictionary
+
+    A variable expression is in the form of ${VAR_NAME}. Its value will
+    be substitute with the value of a matching environment variable name.
+    If no matching environment variable is found, the expression will be
+    left as-is.
+    """
+
+    def sub_str(target_str: str) -> str:
+        def replacement(match: re.Match) -> str:
+            if match is not None:
+                env_val = os.environ.get(match.group(1))
+                if env_val is not None:
+                    return env_val
+            return target_str
+
+        return re.sub(var_pattern, replacement, target_str)
+
+    def sub_list(target_list: List) -> List:
+        return [sub_val(val) for val in target_list]
+
+    def sub_dict(target_dict: Dict) -> Dict:
+        return {key: sub_val(val) for key, val in target_dict.items()}
+
+    def sub_val(target_val: Any) -> Any:
+        if isinstance(target_val, dict):
+            return sub_dict(target_val)
+        elif isinstance(target_val, list):
+            return sub_list(target_val)
+        elif isinstance(target_val, str):
+            return sub_str(target_val)
+
+        return target_val
+
+    return sub_val(target)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.89"
+version = "0.11.91"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/common/test_variable.py
+++ b/tests/common/test_variable.py
@@ -1,0 +1,30 @@
+import os
+
+from metaphor.common.variable import variable_substitution
+
+
+def test_variable_substitution():
+
+    os.environ["FOO"] = "FOO"
+    os.environ["BAR"] = "BAR"
+    os.environ["BAZ"] = "BAZ"
+
+    target = {
+        "str": "something ${FOO} something",
+        "int": 1,
+        "dict": {
+            "key1": "${BAZ}",
+            "key2": "${NON_EXISTING}",
+            "list": ["${BAR}", "something"],
+        },
+    }
+
+    assert variable_substitution(target) == {
+        "str": "something FOO something",
+        "int": 1,
+        "dict": {
+            "key1": "BAZ",
+            "key2": "${NON_EXISTING}",
+            "list": ["BAR", "something"],
+        },
+    }


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

This makes it easier to specify sensitive configs (e.g. password, secrets) using environment variables, especially in the context of https://github.com/MetaphorData/connectors-action, where the only possible way to pass GitHub secrets is via environment variables.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Unit tests
