### PR TITLE
Add M1-specific build instruction for pymssql

### DIFF
--- a/docs/apple_silicon.md
+++ b/docs/apple_silicon.md
@@ -1,0 +1,19 @@
+# Building for Apple Silicon
+
+For packages that use native C extensions, `poetry install` will attempt to download and install an OS-specific [wheel](https://pythonwheels.com/). However, not every package is published with a pre-built C extension for Apple Silicon (`arm64` architecture). When the wheel is missing, `pip` will attempt to compile the extension as part of the installation. This requires XCode Command Line Tools, which should be installed as part of [Homebrew](https://brew.sh/).
+
+This page lists additional steps needed in order to build some of these packages.
+
+## pymssql
+
+1. Install required homebrew packages:
+    ```
+    brew install FreeTDS openssl@1.1
+    ```
+
+2. Specify `LDFLAGS` & `CFLAGS` environment variables when running `poetry install`:
+    ```
+    LDFLAGS="-L$(brew --prefix)/opt/freetds/lib -L$(brew --prefix)/opt/openssl@1.1/lib" \
+    CFLAGS="-I$(brew --prefix)/opt/freetds/include -I$(brew --prefix)/opt/openssl@1.1/include" \
+    poetry install -E all
+    ```

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -53,6 +53,8 @@ exit
 
 To make life easier, we recommend to always develop in a poetry shell. Many of the following commands will only work inside a poetry shell as well.
 
+> See [Building for Apple Silicon](apple_silicon.md) for more information on installing the dependencies on Apple Silicon machines.
+
 ## Setup Pre-commit
 
 Install [pre-commit](https://pre-commit.com/#installation) then setup git hooks


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

`poetry install -E all` failed on M1 with the following error similar to https://github.com/pymssql/pymssql/issues/727

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Manually verified the build on M1.