### PR TITLE
rollback snowflake crawler to use information [sc-15044]

### DIFF
--- a/metaphor/snowflake/README.md
+++ b/metaphor/snowflake/README.md
@@ -19,6 +19,14 @@ set password = '<password>';
 create role identifier($role) comment = 'Limited access role for Metaphor connector';
 grant usage on warehouse identifier($warehouse) to role identifier($role);
 grant usage on database identifier($db) to role identifier($role);
+grant usage on all schemas in database identifier($db) to role identifier($role);
+grant usage on future schemas in database identifier($db) to role identifier($role);
+grant references on all tables in database identifier($db) to role identifier($role);
+grant references on future tables in database identifier($db) to role identifier($role);
+grant references on all views in database identifier($db) to role identifier($role);
+grant references on future views in database identifier($db) to role identifier($role);
+grant references on all materialized views in database identifier($db) to role identifier($role);
+grant references on future materialized views in database identifier($db) to role identifier($role);
 -- Grant permissions to access the snowflake "Account Usage" views:
 grant imported privileges on database snowflake to role identifier($role);
 -- If there are inbound shared databases, grant permissions to "show shares"
@@ -31,7 +39,6 @@ create user identifier($user)
     default_role = $role
     comment = 'User for Metaphor connector';
 grant role identifier($role) to user identifier($user);
-alter user identifier($user) set DEFAULT_ROLE = $role;
 ```
 
 ### Key Pair Authentication (Optional)
@@ -40,21 +47,6 @@ If you intend to use key pair authentication instead of password, follow the [Sn
 
 ```sql
 alter user identifier($user) set rsa_public_key='<public_key_content>';
-```
-
-### Fetching extra info (Optional)
-
-To fetch extra table information such as the last modified time or DDL, please grant the following additional privileges to the newly created role.
-
-```sql
-grant usage on all schemas in database identifier($db) to role identifier($role);
-grant usage on future schemas in database identifier($db) to role identifier($role);
-grant references on all tables in database identifier($db) to role identifier($role);
-grant references on future tables in database identifier($db) to role identifier($role);
-grant references on all views in database identifier($db) to role identifier($role);
-grant references on future views in database identifier($db) to role identifier($role);
-grant references on all materialized views in database identifier($db) to role identifier($role);
-grant references on future materialized views in database identifier($db) to role identifier($role);
 ```
 
 ## Config File
@@ -98,14 +90,6 @@ See [Output Config](../common/docs/output.md) for more information on `output`.
 ### Optional Configurations
 
 See [Filter Configurations](../common/docs/filter.md) for more information on the optional `filter` config.
-
-#### Fetch Extra Table Information
-
-By default, the connector fetches extra table information such as LAST_CHANGE_COMMIT_TIME or DDL. This requires additional grants to all the tables. The connector will print warning messages if it has insufficient permissions. To disable this feature altogether, add the following to your config:
-
-```yaml
-fetch_extra_table_info: false
-```
 
 #### Query Logs
 

--- a/metaphor/snowflake/config.py
+++ b/metaphor/snowflake/config.py
@@ -30,9 +30,6 @@ class SnowflakeRunConfig(SnowflakeAuthConfig):
     # Include or exclude specific databases/schemas/tables
     filter: DatasetFilter = field(default_factory=lambda: DatasetFilter())
 
-    # Whether to fetch extra table information such as LAST_CHANGE_COMMIT_TIME and DDL
-    fetch_extra_table_info: bool = True
-
     # Max number of concurrent queries to database
     max_concurrency: int = DEFAULT_THREAD_POOL_SIZE
 

--- a/metaphor/snowflake/profile/extractor.py
+++ b/metaphor/snowflake/profile/extractor.py
@@ -84,24 +84,17 @@ class SnowflakeProfileExtractor(BaseExtractor):
 
         return self._datasets.values()
 
-    FETCH_TABLE_QUERY = """
-    SELECT table_schema, table_name, table_type, COMMENT, row_count, bytes
-    FROM information_schema.tables
-    WHERE table_schema != 'INFORMATION_SCHEMA'
-    ORDER BY table_schema, table_name
-    """
-
     def _fetch_tables(self, cursor, database: str) -> Dict[str, DatasetInfo]:
         try:
             cursor.execute("USE " + database)
         except ProgrammingError:
             raise ValueError(f"Invalid or inaccessible database {database}")
 
-        cursor.execute(self.FETCH_TABLE_QUERY)
+        cursor.execute(SnowflakeExtractor.FETCH_TABLE_QUERY)
 
         tables: Dict[str, DatasetInfo] = {}
         for row in cursor:
-            schema, name, table_type, row_count = row[0], row[1], row[2], row[4]
+            schema, name, table_type, row_count = row[1], row[2], row[3], row[5]
             if (
                 not self._include_views
                 and table_type != SnowflakeTableType.BASE_TABLE.value

--- a/metaphor/snowflake/utils.py
+++ b/metaphor/snowflake/utils.py
@@ -4,7 +4,7 @@ from concurrent import futures
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Callable, Collection, Dict, List, Optional, Set, Tuple
+from typing import Callable, Dict, List, Optional, Set, Tuple
 
 from snowflake.connector import SnowflakeConnection
 from snowflake.connector.cursor import SnowflakeCursor
@@ -95,11 +95,6 @@ def async_execute(
                 results_processor(key, results)
 
         return results_map
-
-
-def term_in_clause(term: str, values: Collection[str]) -> str:
-    """Builds a multi-value IN clause for term matching"""
-    return f"and {term} IN (%s)" if len(values) > 0 else ""
 
 
 def exclude_username_clause(excluded_usernames: Set[str]) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.100"
+version = "0.11.101"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/snowflake/profile/test_extractor.py
+++ b/tests/snowflake/profile/test_extractor.py
@@ -71,8 +71,8 @@ def test_fetch_tables():
 
     mock_cursor.__iter__.return_value = iter(
         [
-            (schema, table_name, table_type, "comment1", 10, 20000),
-            (schema, table_name, SnowflakeTableType.VIEW.value, "", 0, 0),
+            (database, schema, table_name, table_type, "comment1", 10, 20000),
+            (database, schema, table_name, SnowflakeTableType.VIEW.value, "", 0, 0),
         ]
     )
 

--- a/tests/snowflake/test_extractor.py
+++ b/tests/snowflake/test_extractor.py
@@ -74,7 +74,6 @@ def test_fetch_tables():
         [
             (database, schema, table_name, table_type, "comment1", 10, 20000),
             (database, schema, "foo.bar", table_type, "", 0, 0),
-            ("excluded_db", schema, table_name, table_type, "", 0, 0),
         ]
     )
 
@@ -87,7 +86,7 @@ def test_fetch_tables():
             )
         )
 
-        extractor._fetch_tables(mock_cursor, [])
+        extractor._fetch_tables(mock_cursor, database)
 
         assert len(extractor._datasets) == 1
         dataset = extractor._datasets[normalized_name]
@@ -105,8 +104,8 @@ def test_fetch_columns():
 
     mock_cursor.__iter__.return_value = iter(
         [
-            (database, schema, table_name, column, "int", 10, 1, "YES", 0, "comment1"),
-            (database, schema, "foo.bar", column, "str", 0, 0, "NO", 0, ""),
+            (schema, table_name, column, "int", 10, 1, "YES", 0, "comment1"),
+            (schema, "foo.bar", column, "str", 0, 0, "NO", 0, ""),
         ]
     )
 
@@ -118,7 +117,7 @@ def test_fetch_columns():
         )
         extractor._datasets[normalized_name] = dataset
 
-        extractor._fetch_columns(mock_cursor, [])
+        extractor._fetch_columns(mock_cursor, database)
 
         assert len(dataset.schema.fields) == 1
         assert dataset.schema.fields[0].field_path == column
@@ -151,7 +150,7 @@ def test_fetch_table_info():
         )
         extractor._datasets[normalized_name] = dataset
 
-        extractor._fetch_table_info({normalized_name: table_info}, [])
+        extractor._fetch_table_info({normalized_name: table_info}, False)
 
         assert dataset.schema.sql_schema.table_schema == "ddl"
         assert dataset.statistics.last_updated == datetime.utcfromtimestamp(0).replace(


### PR DESCRIPTION
### 🤔 Why?

The account_usage views have significant delay which can cause the crawler not able to fetch any information after a table recreation. 

### 🤓 What?

- revert back to use information_schema to fetch metadata

### 🧪 Tested?

tested against snowflake instance. 
