### PR TITLE
reduce unnecessary log in snowflake lineage crawler

### DIFF
--- a/metaphor/snowflake/lineage/extractor.py
+++ b/metaphor/snowflake/lineage/extractor.py
@@ -192,7 +192,7 @@ class SnowflakeLineageExtractor(BaseExtractor):
             database, schema, name = parts
             normalized_name = dataset_normalized_name(database, schema, name)
             if not self._filter.include_table(database, schema, name):
-                logger.info(f"Excluding table {normalized_name}")
+                logger.debug(f"Excluding table {normalized_name}")
                 continue
 
             logical_id = DatasetLogicalID(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.103"
+version = "0.11.104"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
### 🤔 Why?

Some customers may have a lot of query logs on tables that are filtered out by config, causing a flood of info logs and drowning the useful info. 

### 🤓 What?

- use debug instead of info for logging filtered tables

### 🧪 Tested?

n/a
