### PR TITLE
Add pagination to Tableau Metadata API

### DIFF
--- a/metaphor/tableau/graphql_utils.py
+++ b/metaphor/tableau/graphql_utils.py
@@ -1,0 +1,29 @@
+from typing import Dict, List
+
+import tableauserverclient as tableau
+
+from metaphor.common.logger import get_logger
+
+logger = get_logger()
+
+
+def paginate_connection(
+    server: tableau.Server, query: str, connection_name: str, batch_size=50
+) -> List[Dict]:
+    """Return all the nodes from GraphQL connection through pagination"""
+
+    offset = 0
+    result: List[Dict] = []
+
+    while True:
+        logger.info(f"Querying {connection_name} with offset {offset}")
+        resp = server.metadata.query(query, {"first": batch_size, "offset": offset})
+        if resp.get("errors"):
+            logger.error(f"Error when querying {connection_name}: {resp.get('errors')}")
+
+        nodes = resp["data"][connection_name]["nodes"]
+        if len(nodes) == 0:
+            return result
+
+        result.extend(nodes)
+        offset += batch_size

--- a/metaphor/tableau/graphql_utils.py
+++ b/metaphor/tableau/graphql_utils.py
@@ -22,8 +22,9 @@ def paginate_connection(
             logger.error(f"Error when querying {connection_name}: {resp.get('errors')}")
 
         nodes = resp["data"][connection_name]["nodes"]
+        result.extend(nodes)
+
         if len(nodes) < batch_size:
             return result
 
-        result.extend(nodes)
         offset += batch_size

--- a/metaphor/tableau/graphql_utils.py
+++ b/metaphor/tableau/graphql_utils.py
@@ -22,7 +22,7 @@ def paginate_connection(
             logger.error(f"Error when querying {connection_name}: {resp.get('errors')}")
 
         nodes = resp["data"][connection_name]["nodes"]
-        if len(nodes) == 0:
+        if len(nodes) < batch_size:
             return result
 
         result.extend(nodes)

--- a/metaphor/tableau/query.py
+++ b/metaphor/tableau/query.py
@@ -14,48 +14,50 @@ connection_type_map: Dict[str, DataPlatform] = {
 # NOTE!!! the id (uuid) of an entity from graphql api is different from
 # the id of the same entity from the REST api, use luid instead
 workbooks_graphql_query = """
-query {
-  workbooks {
-    luid
-    name
-    projectName
-    vizportalUrlId
-    upstreamDatasources {
-      id
+query($first: Int, $offset: Int) {
+  workbooksConnection(first: $first, offset: $offset) {
+    nodes {
       luid
-      vizportalUrlId
       name
-      description
-      fields {
+      projectName
+      vizportalUrlId
+      upstreamDatasources {
+        id
+        luid
+        vizportalUrlId
         name
         description
-      }
-      upstreamTables {
-        luid
-        name
-        fullName
-        schema
-        database {
+        fields {
           name
-          connectionType
+          description
+        }
+        upstreamTables {
+          luid
+          name
+          fullName
+          schema
+          database {
+            name
+            connectionType
+          }
         }
       }
-    }
-    embeddedDatasources {
-      id
-      name
-      fields {
+      embeddedDatasources {
+        id
         name
-        description
-      }
-      upstreamTables {
-        luid
-        name
-        fullName
-        schema
-        database {
+        fields {
           name
-          connectionType
+          description
+        }
+        upstreamTables {
+          luid
+          name
+          fullName
+          schema
+          database {
+            name
+            connectionType
+          }
         }
       }
     }
@@ -117,17 +119,19 @@ class WorkbookQueryResponse(BaseModel):
 # 1. Run this as a separate query from the workbooks GraphQL
 # 2. Only return the first column as the datasource ID is the same for every column
 custom_sql_graphql_query = """
-query {
-  customSQLTables {
-    id
-    query
-    connectionType
-    columnsConnection(first: 1, offset: 0) {
-      nodes {
-        ...on Column {
-          referencedByFields {
-            datasource {
-              id
+query($first: Int, $offset: Int) {
+  customSQLTablesConnection(first: $first, offset: $offset) {
+    nodes {
+      id
+      query
+      connectionType
+      columnsConnection(first: 1, offset: 0) {
+        nodes {
+          ...on Column {
+            referencedByFields {
+              datasource {
+                id
+              }
             }
           }
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.114"
+version = "0.11.115"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/tableau/test_extractor.py
+++ b/tests/tableau/test_extractor.py
@@ -233,109 +233,93 @@ async def test_extractor(test_root_dir):
         ),
     )
 
-    graphql_custom_sql_tables_response = {
-        "data": {
-            "customSQLTables": [
-                {
-                    "id": "custom_sql_1",
-                    "connectionType": "bigquery",
-                    "query": "select * from db.schema.table",
-                    "columnsConnection": {
-                        "nodes": [
-                            {
-                                "referencedByFields": [
-                                    {"datasource": {"id": "sourceId3"}}
-                                ]
-                            }
-                        ]
-                    },
-                }
-            ],
+    graphql_custom_sql_tables_response = [
+        {
+            "id": "custom_sql_1",
+            "connectionType": "bigquery",
+            "query": "select * from db.schema.table",
+            "columnsConnection": {
+                "nodes": [{"referencedByFields": [{"datasource": {"id": "sourceId3"}}]}]
+            },
         }
-    }
+    ]
 
-    graphql_workbooks_response = {
-        "data": {
-            "workbooks": [
+    graphql_workbooks_response = [
+        {
+            "luid": "abc",
+            "name": "Snowflake test1",
+            "projectName": "default",
+            "vizportalUrlId": "123",
+            "upstreamDatasources": [
                 {
-                    "luid": "abc",
-                    "name": "Snowflake test1",
-                    "projectName": "default",
-                    "vizportalUrlId": "123",
-                    "upstreamDatasources": [
+                    "id": "sourceId1",
+                    "luid": "sourceId1",
+                    "name": "source1",
+                    "vizportalUrlId": "777",
+                    "fields": [],
+                    "upstreamTables": [
                         {
-                            "id": "sourceId1",
-                            "luid": "sourceId1",
-                            "name": "source1",
-                            "vizportalUrlId": "777",
-                            "fields": [],
-                            "upstreamTables": [
-                                {
-                                    "luid": "4ba4462e",
-                                    "name": "CYCLE",
-                                    "fullName": "[LONDON].[CYCLE]",
-                                    "schema": "LONDON",
-                                    "database": {
-                                        "name": "DEV_DB",
-                                        "connectionType": "snowflake",
-                                    },
-                                }
-                            ],
+                            "luid": "4ba4462e",
+                            "name": "CYCLE",
+                            "fullName": "[LONDON].[CYCLE]",
+                            "schema": "LONDON",
+                            "database": {
+                                "name": "DEV_DB",
+                                "connectionType": "snowflake",
+                            },
                         }
                     ],
-                    "embeddedDatasources": [
-                        {
-                            "id": "sourceId2",
-                            "name": "source2",
-                            "fields": [],
-                            "upstreamTables": [
-                                {
-                                    "luid": "5dca51d8",
-                                    "name": "CYCLE_HIRE",
-                                    "fullName": "[BERLIN_BICYCLES].[CYCLE_HIRE]",
-                                    "schema": "BERLIN_BICYCLES",
-                                    "description": "",
-                                    "database": {
-                                        "name": "ACME",
-                                        "connectionType": "redshift",
-                                    },
-                                }
-                            ],
-                        },
-                        {
-                            "id": "sourceId3",
-                            "name": "source3",
-                            "fields": [],
-                            "upstreamTables": [],
-                        },
-                    ],
                 }
             ],
+            "embeddedDatasources": [
+                {
+                    "id": "sourceId2",
+                    "name": "source2",
+                    "fields": [],
+                    "upstreamTables": [
+                        {
+                            "luid": "5dca51d8",
+                            "name": "CYCLE_HIRE",
+                            "fullName": "[BERLIN_BICYCLES].[CYCLE_HIRE]",
+                            "schema": "BERLIN_BICYCLES",
+                            "description": "",
+                            "database": {
+                                "name": "ACME",
+                                "connectionType": "redshift",
+                            },
+                        }
+                    ],
+                },
+                {
+                    "id": "sourceId3",
+                    "name": "source3",
+                    "fields": [],
+                    "upstreamTables": [],
+                },
+            ],
         }
-    }
+    ]
 
     extractor._snowflake_account = "snow"
 
     mock_auth = MagicMock()
     mock_auth.sign_in = MagicMock()
 
-    mock_metadata = MagicMock()
-    mock_metadata.query.side_effect = [
-        graphql_custom_sql_tables_response,
-        graphql_workbooks_response,
-    ]
-
     mock_server = MagicMock()
     mock_server.auth = mock_auth
     mock_server.views = ViewsWrapper([view])
     mock_server.workbooks = WorkbooksWrapper([workbook])
-    mock_server.metadata = mock_metadata
 
     with patch("tableauserverclient.Server", return_value=mock_server), patch(
-        "tableauserverclient.Pager"
-    ) as mock_pager_cls:
+        "metaphor.tableau.extractor.paginate_connection"
+    ) as mock_paginate_connection, patch("tableauserverclient.Pager") as mock_pager_cls:
 
         mock_pager_cls.side_effect = MockPager
+
+        mock_paginate_connection.side_effect = [
+            graphql_custom_sql_tables_response,
+            graphql_workbooks_response,
+        ]
 
         events = [EventUtil.trim_event(e) for e in await extractor.extract()]
 

--- a/tests/tableau/test_graphql_utils.py
+++ b/tests/tableau/test_graphql_utils.py
@@ -1,0 +1,21 @@
+from unittest.mock import MagicMock
+
+from metaphor.tableau.graphql_utils import paginate_connection
+
+
+def test_paginate_connection():
+
+    batch1 = {"data": {"someConnection": {"nodes": [{"val": 1}]}}}
+
+    batch2 = {"data": {"someConnection": {"nodes": [{"val": 2}]}}}
+
+    batch3 = {"data": {"someConnection": {"nodes": []}}}
+
+    server = MagicMock()
+    server.metadata = MagicMock()
+    server.metadata.query.side_effect = [batch1, batch2, batch3]
+
+    assert paginate_connection(server, "query", "someConnection") == [
+        {"val": 1},
+        {"val": 2},
+    ]

--- a/tests/tableau/test_graphql_utils.py
+++ b/tests/tableau/test_graphql_utils.py
@@ -15,7 +15,7 @@ def test_paginate_connection():
     server.metadata = MagicMock()
     server.metadata.query.side_effect = [batch1, batch2, batch3]
 
-    assert paginate_connection(server, "query", "someConnection") == [
+    assert paginate_connection(server, "query", "someConnection", batch_size=1) == [
         {"val": 1},
         {"val": 2},
     ]

--- a/tests/tableau/test_graphql_utils.py
+++ b/tests/tableau/test_graphql_utils.py
@@ -5,17 +5,16 @@ from metaphor.tableau.graphql_utils import paginate_connection
 
 def test_paginate_connection():
 
-    batch1 = {"data": {"someConnection": {"nodes": [{"val": 1}]}}}
+    batch1 = {"data": {"someConnection": {"nodes": [{"val": 1}, {"val": 2}]}}}
 
-    batch2 = {"data": {"someConnection": {"nodes": [{"val": 2}]}}}
-
-    batch3 = {"data": {"someConnection": {"nodes": []}}}
+    batch2 = {"data": {"someConnection": {"nodes": [{"val": 3}]}}}
 
     server = MagicMock()
     server.metadata = MagicMock()
-    server.metadata.query.side_effect = [batch1, batch2, batch3]
+    server.metadata.query.side_effect = [batch1, batch2]
 
-    assert paginate_connection(server, "query", "someConnection", batch_size=1) == [
+    assert paginate_connection(server, "query", "someConnection", batch_size=2) == [
         {"val": 1},
         {"val": 2},
+        {"val": 3},
     ]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Tableau's [Metadata API](https://help.tableau.com/current/api/metadata_api/en-us/index.html) places a [limit](https://help.tableau.com/current/api/metadata_api/en-us/docs/meta_api_errors.html#:~:text=might%20be%20incomplete.-,NODE_LIMIT_EXCEEDED,-Warning) on the number of nodes returned. When exceeded, it'll return partial results, which can lead to incomplete lineage.

An example of the corresponding GraphQL error: 

```
    "errors": [
        {
            "message": "Showing partial results. The request exceeded the 20000 node limit. Use pagination, additional filtering, or both in the query to adjust results.",
            "extensions": {
                "severity": "WARNING",
                "code": "NODE_LIMIT_EXCEEDED",
                "properties": {
                    "nodeLimit": 20000
                }
            }
        }
    ]
```

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Add [pagination](https://help.tableau.com/current/api/metadata_api/en-us/docs/meta_api_examples.html#pagination) to the custom SQL tables & workbook GraphQL queries.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified against a production instance.
