### PR TITLE
Fix Power BI cross-workspace dataset references

### DIFF
--- a/metaphor/power_bi/extractor.py
+++ b/metaphor/power_bi/extractor.py
@@ -150,12 +150,8 @@ class PowerBIExtractor(BaseExtractor):
 
             last_refreshed = None
             if ds.isRefreshable:
-                try:
-                    # Log errors instead of throwing exceptions as this API call requires extra permissions
-                    refreshes = self._client.get_refreshes(workspace.id, wds.id)
-                    last_refreshed = self._find_last_completed_refresh(refreshes)
-                except Exception as e:
-                    logger.exception(e)
+                refreshes = self._client.get_refreshes(workspace.id, wds.id)
+                last_refreshed = self._find_last_completed_refresh(refreshes)
 
             virtual_view = VirtualView(
                 logical_id=VirtualViewLogicalID(
@@ -205,12 +201,8 @@ class PowerBIExtractor(BaseExtractor):
             # The "app" version of report doesn't have pages
             charts = None
             if wi_report.appId is None:
-                # Log errors instead of throwing exceptions as this API call requires extra permissions
-                try:
-                    pages = self._client.get_pages(workspace.id, wi_report.id)
-                    charts = self.transform_pages_to_charts(pages)
-                except Exception as e:
-                    logger.error(e)
+                pages = self._client.get_pages(workspace.id, wi_report.id)
+                charts = self.transform_pages_to_charts(pages)
 
             dashboard = Dashboard(
                 logical_id=DashboardLogicalID(

--- a/metaphor/power_bi/extractor.py
+++ b/metaphor/power_bi/extractor.py
@@ -79,20 +79,20 @@ class PowerBIExtractor(BaseExtractor):
         apps = self._client.get_apps()
         app_map = {app.id: app for app in apps}
 
+        workspaces = []
         for workspace_ids in chunks(
             self._workspaces, PowerBIClient.MAX_WORKSPACES_PER_SCAN
         ):
-            for workspace in self._client.get_workspace_info(workspace_ids):
-                logger.info(
-                    f"Fetching metadata from Power BI workspace ID: {workspace.id}"
-                )
+            workspaces.extend(self._client.get_workspace_info(workspace_ids))
 
-                try:
-                    self.map_wi_datasets_to_virtual_views(workspace)
-                    self.map_wi_reports_to_dashboard(workspace, app_map)
-                    self.map_wi_dashboards_to_dashboard(workspace, app_map)
-                except Exception as e:
-                    logger.exception(e)
+        # As there may be cross-workspace reference in dashboards & reports,
+        # we must process the datasets across all workspaces first
+        for workspace in workspaces:
+            self.map_wi_datasets_to_virtual_views(workspace)
+
+        for workspace in workspaces:
+            self.map_wi_reports_to_dashboard(workspace, app_map)
+            self.map_wi_dashboards_to_dashboard(workspace, app_map)
 
         self.dedupe_app_version_dashboards()
 
@@ -140,9 +140,8 @@ class PowerBIExtractor(BaseExtractor):
                     )
                 except Exception as e:
                     logger.error(
-                        f"Failed to parse expression: {expression} for dataset {wds.id}"
+                        f"Failed to parse expression for dataset {wds.id}: {e}"
                     )
-                    logger.exception(e)
 
             ds = dataset_map.get(wds.id, None)
             if ds is None:
@@ -185,11 +184,13 @@ class PowerBIExtractor(BaseExtractor):
                 logger.warn(f"Skipping report without datasetId: {wi_report.id}")
                 continue
 
+            virtual_view = self._virtual_views.get(wi_report.datasetId)
+            if virtual_view is None:
+                logger.error(f"Referenced non-existing dataset {wi_report.datasetId}")
+                continue
+
             upstream_id = str(
-                EntityId(
-                    EntityType.VIRTUAL_VIEW,
-                    self._virtual_views[wi_report.datasetId].logical_id,
-                )
+                EntityId(EntityType.VIRTUAL_VIEW, virtual_view.logical_id)
             )
 
             report = report_map.get(wi_report.id, None)
@@ -209,7 +210,7 @@ class PowerBIExtractor(BaseExtractor):
                     pages = self._client.get_pages(workspace.id, wi_report.id)
                     charts = self.transform_pages_to_charts(pages)
                 except Exception as e:
-                    logger.exception(e)
+                    logger.error(e)
 
             dashboard = Dashboard(
                 logical_id=DashboardLogicalID(
@@ -244,13 +245,13 @@ class PowerBIExtractor(BaseExtractor):
                 if dataset_id == "":
                     continue
 
+                virtual_view = self._virtual_views.get(dataset_id)
+                if virtual_view is None:
+                    logger.error(f"Referenced non-existing dataset {dataset_id}")
+                    continue
+
                 upstream.append(
-                    str(
-                        EntityId(
-                            EntityType.VIRTUAL_VIEW,
-                            self._virtual_views[dataset_id].logical_id,
-                        )
-                    )
+                    str(EntityId(EntityType.VIRTUAL_VIEW, virtual_view.logical_id))
                 )
 
             pbi_dashboard = dashboard_map.get(wi_dashboard.id, None)

--- a/metaphor/power_bi/power_bi_client.py
+++ b/metaphor/power_bi/power_bi_client.py
@@ -239,10 +239,10 @@ class PowerBIClient:
             )
         except EntityNotFoundError as e:
             logger.error(
-                f"Unable to find report {report_id} in workspace {group_id}\n"
+                f"Unable to find report {report_id} in workspace {group_id}. "
                 f"Please add the service principal as a viewer to the workspace"
             )
-            raise e
+            raise e from None
 
     def get_refreshes(self, group_id: str, dataset_id: str) -> List[PowerBIRefresh]:
         # https://docs.microsoft.com/en-us/rest/api/power-bi/datasets/get-refresh-history-in-group
@@ -256,10 +256,10 @@ class PowerBIClient:
             )
         except EntityNotFoundError as e:
             logger.error(
-                f"Unable to find dataset {dataset_id} in workspace {group_id}\n"
+                f"Unable to find dataset {dataset_id} in workspace {group_id}. "
                 f"Please add the service principal as a viewer to the workspace"
             )
-            raise e
+            raise e from None
 
     def get_workspace_info(self, workspace_ids: List[str]) -> List[WorkspaceInfo]:
         def create_scan() -> str:
@@ -347,10 +347,10 @@ class PowerBIClient:
             )
         except ApiError as error:
             if error.status_code == 401:
-                raise AuthenticationError(error.error_msg)
+                raise AuthenticationError(error.error_msg) from None
             elif error.status_code == 404:
-                raise EntityNotFoundError(error.error_msg)
+                raise EntityNotFoundError(error.error_msg) from None
             else:
                 raise AssertionError(
                     f"GET {url} failed: {error.status_code}\n{error.error_msg}"
-                )
+                ) from None

--- a/metaphor/power_bi/power_bi_client.py
+++ b/metaphor/power_bi/power_bi_client.py
@@ -204,9 +204,17 @@ class PowerBIClient:
     def get_tiles(self, dashboard_id: str) -> List[PowerBITile]:
         # https://docs.microsoft.com/en-us/rest/api/power-bi/admin/dashboards-get-tiles-as-admin
         url = f"{self.API_ENDPOINT}/admin/dashboards/{dashboard_id}/tiles"
-        return self._call_get(
-            url, List[PowerBITile], transform_response=lambda r: r.json()["value"]
-        )
+
+        try:
+            return self._call_get(
+                url, List[PowerBITile], transform_response=lambda r: r.json()["value"]
+            )
+        except EntityNotFoundError:
+            logger.error(
+                f"Unable to find dashboard {dashboard_id}."
+                f"Please add the service principal as a viewer to the workspace"
+            )
+            return []
 
     def get_datasets(self, group_id: str) -> List[PowerBIDataset]:
         # https://docs.microsoft.com/en-us/rest/api/power-bi/admin/datasets-get-datasets-in-group-as-admin
@@ -237,12 +245,12 @@ class PowerBIClient:
             return self._call_get(
                 url, List[PowerBIPage], transform_response=lambda r: r.json()["value"]
             )
-        except EntityNotFoundError as e:
+        except EntityNotFoundError:
             logger.error(
                 f"Unable to find report {report_id} in workspace {group_id}. "
                 f"Please add the service principal as a viewer to the workspace"
             )
-            raise e from None
+            return []
 
     def get_refreshes(self, group_id: str, dataset_id: str) -> List[PowerBIRefresh]:
         # https://docs.microsoft.com/en-us/rest/api/power-bi/datasets/get-refresh-history-in-group
@@ -254,12 +262,12 @@ class PowerBIClient:
                 List[PowerBIRefresh],
                 transform_response=lambda r: r.json()["value"],
             )
-        except EntityNotFoundError as e:
+        except EntityNotFoundError:
             logger.error(
                 f"Unable to find dataset {dataset_id} in workspace {group_id}. "
                 f"Please add the service principal as a viewer to the workspace"
             )
-            raise e from None
+            return []
 
     def get_workspace_info(self, workspace_ids: List[str]) -> List[WorkspaceInfo]:
         def create_scan() -> str:

--- a/metaphor/power_bi/power_query_parser.py
+++ b/metaphor/power_bi/power_query_parser.py
@@ -221,10 +221,7 @@ class PowerQueryParser:
 
         if "Value.NativeQuery(" in power_query:
             return PowerQueryParser._parse_native_query(power_query, snowflake_account)
-
-        try:
+        else:
             return [PowerQueryParser._parse_power_query(power_query)]
-        except (AssertionError, IndexError) as error:
-            logger.warning(f"Parsing upstream fail, exp: {power_query}, error: {error}")
 
         return []

--- a/metaphor/power_bi/power_query_parser.py
+++ b/metaphor/power_bi/power_query_parser.py
@@ -223,5 +223,3 @@ class PowerQueryParser:
             return PowerQueryParser._parse_native_query(power_query, snowflake_account)
         else:
             return [PowerQueryParser._parse_power_query(power_query)]
-
-        return []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.121"
+version = "0.11.122"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Depending the workspace processing order, the crawler may crash when processing Power BI dashboards/reports that reference a dataset from another workspace with the following error:

```
023-02-27 13:29:39:ERROR:metaphor:'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
Traceback (most recent call last):
  File "/Users/marslan/Metaphor/connectors/metaphor/power_bi/extractor.py", line 92, in extract
    self.map_wi_reports_to_dashboard(workspace, app_map)
  File "/Users/marslan/Metaphor/connectors/metaphor/power_bi/extractor.py", line 191, in map_wi_reports_to_dashboard
    self._virtual_views[wi_report.datasetId].logical_id,
KeyError: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
```

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Process datasets across all workspaces up front to avoid invalid cross-workspace references in datasets & reports. 
- Refactored various exception handling avoid log cluttering and breaks the crawler when unhandled exceptions occur.
- Use `from None` to avoid printing nested exception context when rethrowing exceptions (see [PEP-409](https://peps.python.org/pep-0409/)).

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified against a production instance.
