### PR TITLE
Make Power BI connector more robust against unexpected API returns

### DIFF
--- a/metaphor/power_bi/extractor.py
+++ b/metaphor/power_bi/extractor.py
@@ -40,7 +40,6 @@ from metaphor.power_bi.power_bi_client import (
     PowerBIClient,
     PowerBIPage,
     PowerBIRefresh,
-    PowerBIRefreshStatus,
     PowerBITile,
     WorkspaceInfo,
 )
@@ -334,9 +333,7 @@ class PowerBIExtractor(BaseExtractor):
             # Assume refreshes are already sorted in reversed chronological order
             # Empty endTime means still in progress
             refresh = next(
-                r
-                for r in refreshes
-                if r.status == PowerBIRefreshStatus.COMPLETED and r.endTime != ""
+                r for r in refreshes if r.status == "Completed" and r.endTime != ""
             )
         except StopIteration:
             return None

--- a/metaphor/power_bi/power_bi_client.py
+++ b/metaphor/power_bi/power_bi_client.py
@@ -1,5 +1,4 @@
 import tempfile
-from enum import Enum
 from time import sleep
 from typing import Any, Callable, List, Optional, Type, TypeVar
 
@@ -75,16 +74,9 @@ class PowerBITile(BaseModel):
     embedUrl: Optional[str]
 
 
-class PowerBIRefreshStatus(Enum):
-    UNKNOWN = "Unknown"
-    COMPLETED = "Completed"
-    FAILED = "Failed"
-    DISABLED = "Disabled"
-
-
 class PowerBIRefresh(BaseModel):
-    status: PowerBIRefreshStatus
-    endTime: str
+    status: str = ""
+    endTime: str = ""
 
 
 class PowerBITableColumn(BaseModel):
@@ -250,7 +242,13 @@ class PowerBIClient:
                 f"Unable to find report {report_id} in workspace {group_id}. "
                 f"Please add the service principal as a viewer to the workspace"
             )
-            return []
+        except Exception as e:
+            # Fail gracefully for any other errors
+            logger.error(
+                f"Failed to get pages from report {report_id} in workspace {group_id}: {e}"
+            )
+
+        return []
 
     def get_refreshes(self, group_id: str, dataset_id: str) -> List[PowerBIRefresh]:
         # https://docs.microsoft.com/en-us/rest/api/power-bi/datasets/get-refresh-history-in-group
@@ -267,7 +265,13 @@ class PowerBIClient:
                 f"Unable to find dataset {dataset_id} in workspace {group_id}. "
                 f"Please add the service principal as a viewer to the workspace"
             )
-            return []
+        except Exception as e:
+            # Fail gracefully for any other errors
+            logger.error(
+                f"Failed to get pages from dataset {dataset_id} in workspace {group_id}: {e}"
+            )
+
+        return []
 
     def get_workspace_info(self, workspace_ids: List[str]) -> List[WorkspaceInfo]:
         def create_scan() -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.122"
+version = "0.11.123"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/power_bi/test_extractor.py
+++ b/tests/power_bi/test_extractor.py
@@ -13,7 +13,6 @@ from metaphor.power_bi.power_bi_client import (
     PowerBIDataset,
     PowerBIPage,
     PowerBIRefresh,
-    PowerBIRefreshStatus,
     PowerBIReport,
     PowerBITable,
     PowerBITableColumn,
@@ -149,9 +148,9 @@ async def test_extractor(test_root_dir):
     refreshes = {
         workspace1_id: {
             dataset1_id: [
-                PowerBIRefresh(status=PowerBIRefreshStatus.FAILED, endTime=""),
+                PowerBIRefresh(status="Failed", endTime=""),
                 PowerBIRefresh(
-                    status=PowerBIRefreshStatus.COMPLETED,
+                    status="Completed",
                     endTime="2022-01-01T01:02:03.456Z",
                 ),
             ]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

The [Datasets - Get Refresh History](https://learn.microsoft.com/en-us/rest/api/power-bi/datasets/get-refresh-history) can return empty strings or missing value for the [`status`](https://learn.microsoft.com/en-us/rest/api/power-bi/datasets/get-refresh-history#:~:text=of%20the%20refresh-,status,-string)  and [`endTime`](https://learn.microsoft.com/en-us/rest/api/power-bi/datasets/get-refresh-history#:~:text=Description-,endTime,-string) fields, which can lead to model validation error like the following,

```
validation errors for ParsingModel[List[metaphor.power_bi.power_bi_client.PowerBIRefresh]]
__root__ -> 18 -> endTime
  field required (type=value_error.missing)
__root__ -> 19 -> status
  value is not a valid enumeration member; permitted: 'Unknown', 'Completed', 'Failed', 'Disabled' (type=type_error.enum; enum_values=[<PowerBIRefreshStatus.UNKNOWN: 'Unknown'>, <PowerBIRefreshStatus.COMPLETED: 'Completed'>, <PowerBIRefreshStatus.FAILED: 'Failed'>, <PowerBIRefreshStatus.DISABLED: 'Disabled'>])
__root__ -> 19 -> endTime
  field required (type=value_error.missing)
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/metaphor/common/runner.py", line 54, in run_connector
    entities = connector_func()
  File "/usr/local/lib/python3.8/site-packages/metaphor/common/base_extractor.py", line 32, in run_async
    return asyncio.run(self.extract())
  File "/usr/local/lib/python3.8/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/local/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/usr/local/lib/python3.8/site-packages/metaphor/power_bi/extractor.py", line 91, in extract
    self.map_wi_datasets_to_virtual_views(workspace)
  File "/usr/local/lib/python3.8/site-packages/metaphor/power_bi/extractor.py", line 153, in map_wi_datasets_to_virtual_views
    refreshes = self._client.get_refreshes(workspace.id, wds.id)
  File "/usr/local/lib/python3.8/site-packages/metaphor/power_bi/power_bi_client.py", line 260, in get_refreshes
    return self._call_get(
  File "/usr/local/lib/python3.8/site-packages/metaphor/power_bi/power_bi_client.py", line 350, in _call_get
    return get_request(
  File "/usr/local/lib/python3.8/site-packages/metaphor/common/api_request.py", line 44, in get_request
    return parse_obj_as(type_, transform_response(result))
  File "pydantic/tools.py", line 38, in pydantic.tools.parse_obj_as
  File "pydantic/main.py", line 341, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 3 validation errors for ParsingModel[List[metaphor.power_bi.power_bi_client.PowerBIRefresh]]
__root__ -> 18 -> endTime
  field required (type=value_error.missing)
__root__ -> 19 -> status
  value is not a valid enumeration member; permitted: 'Unknown', 'Completed', 'Failed', 'Disabled' (type=type_error.enum; enum_values=[<PowerBIRefreshStatus.UNKNOWN: 'Unknown'>, <PowerBIRefreshStatus.COMPLETED: 'Completed'>, <PowerBIRefreshStatus.FAILED: 'Failed'>, <PowerBIRefreshStatus.DISABLED: 'Disabled'>])
__root__ -> 19 -> endTime
  field required (type=value_error.missing)
```

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Change `status` field from enum to string with a default value. Also provide a default value for `endTime`.
- Catch all exceptions thrown in `get_pages` & `get_refrehes` to avoid similar errors from bring down the whole connector

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Manually tested against a production instance
