### PR TITLE
BigQuery truncate long SQL in audit log [sc-16983]

### DIFF
--- a/metaphor/bigquery/README.md
+++ b/metaphor/bigquery/README.md
@@ -126,6 +126,9 @@ query_log:
 
   # (Optional) The number of query logs to fetch from BigQuery in one batch. Max 1000, default to 1000.
   fetch_size: <number_of_logs>
+
+  # (Optional) Fetch the full query SQL from job API if it's truncated in the audit metadata log, default True.
+  fetch_job_query_if_truncated: <boolean>
 ```
 
 ### Notes

--- a/metaphor/bigquery/config.py
+++ b/metaphor/bigquery/config.py
@@ -52,6 +52,9 @@ class BigQueryQueryLogConfig:
     # The number of query logs to fetch from BigQuery in one batch
     fetch_size: int = DEFAULT_QUERY_LOG_FETCH_SIZE
 
+    # Fetch the full query SQL from job API if it's truncated in the audit metadata log
+    fetch_job_query_if_truncated: bool = True
+
 
 @dataclass
 class BigQueryRunConfig(BaseConfig):

--- a/metaphor/bigquery/extractor.py
+++ b/metaphor/bigquery/extractor.py
@@ -332,7 +332,7 @@ class BigQueryExtractor(BaseExtractor):
 
         query: Optional[str] = job_change.query
         # if query SQL is truncated, fetch full SQL from job API
-        if job_change.job_type == "QUERY" and not job_change.query:
+        if job_change.job_type == "QUERY" and job_change.query_truncated:
             query = self._fetch_job_query(client, job_change.job_name)
 
         elapsed_time = (

--- a/metaphor/bigquery/logEvent.py
+++ b/metaphor/bigquery/logEvent.py
@@ -28,6 +28,7 @@ class JobChangeEvent:
     user_email: str
 
     query: Optional[str]
+    query_truncated: Optional[bool]
     statementType: Optional[str]
     source_tables: List[BigQueryResource]
     destination_table: Optional[BigQueryResource]
@@ -62,6 +63,7 @@ class JobChangeEvent:
         job_type = job["jobConfig"]["type"]
 
         query, query_statement_type = None, None
+        query_truncated = None
         destination_table = None
         default_dataset = None
 
@@ -80,10 +82,7 @@ class JobChangeEvent:
             query_job = job["jobConfig"]["queryConfig"]
 
             query = query_job["query"]
-
-            # if query is truncated, reset query and will call job API separately
-            if query_job.get("queryTruncated", False):
-                query = None
+            query_truncated = query_job.get("queryTruncated", None)
 
             # Not all query jobs will have a destination table, e.g. calling a stored procedure
             if "destinationTable" in query_job:
@@ -139,6 +138,7 @@ class JobChangeEvent:
             timestamp=timestamp,
             user_email=user_email,
             query=query,
+            query_truncated=query_truncated,
             statementType=query_statement_type,
             source_tables=source_tables,
             destination_table=destination_table,

--- a/metaphor/bigquery/logEvent.py
+++ b/metaphor/bigquery/logEvent.py
@@ -21,6 +21,7 @@ class JobChangeEvent:
     """
 
     job_name: str
+    job_type: str
     timestamp: datetime
     start_time: Optional[datetime]  # Job execution start time.
     end_time: Optional[datetime]  # Job completion time.
@@ -80,11 +81,16 @@ class JobChangeEvent:
 
             query = query_job["query"]
 
+            # if query is truncated, reset query and will call job API separately
+            if query_job.get("queryTruncated", False):
+                query = None
+
             # Not all query jobs will have a destination table, e.g. calling a stored procedure
             if "destinationTable" in query_job:
                 destination_table = BigQueryResource.from_str(
                     query_job["destinationTable"]
                 ).remove_extras()
+
             query_statement_type = query_job.get("statementType")
 
             query_stats = job["jobStats"].get("queryStats", {})
@@ -129,6 +135,7 @@ class JobChangeEvent:
 
         return cls(
             job_name=job_name,
+            job_type=job_type,
             timestamp=timestamp,
             user_email=user_email,
             query=query,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.124"
+version = "0.11.125"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/bigquery/lineage/data/sample_log.json
+++ b/tests/bigquery/lineage/data/sample_log.json
@@ -98,6 +98,7 @@
               "type": "QUERY",
               "queryConfig": {
                 "query": "INSERT INTO `metaphor-data.test.yi_test3` \nSELECT * from `metaphor-data.test.yi_tests1` \nUNION ALL \nSELECT * from `metaphor-data.test.yi_tests2`",
+                "queryTruncated": true,
                 "destinationTable": "projects/metaphor-data/datasets/test/tables/yi_tests",
                 "createDisposition": "CREATE_IF_NEEDED",
                 "writeDisposition": "WRITE_TRUNCATE",

--- a/tests/bigquery/lineage/test_parser.py
+++ b/tests/bigquery/lineage/test_parser.py
@@ -15,6 +15,7 @@ def test_parse_log(test_root_dir):
     assert results == [
         JobChangeEvent(
             job_name="projects/metaphor-data/jobs/bquxjob_616d0f38_17e9c8d8782",
+            job_type="COPY",
             timestamp=datetime(2022, 1, 27, 17, 20, 29, 105490, pytz.UTC),
             start_time=datetime(2022, 1, 27, 17, 20, 28, 366000, pytz.UTC),
             end_time=datetime(2022, 1, 27, 17, 20, 29, 93000, pytz.UTC),
@@ -36,6 +37,7 @@ def test_parse_log(test_root_dir):
         ),
         JobChangeEvent(
             job_name="projects/metaphor-data/jobs/7526798f-8072-446d-bdf1-ac1acb4d8591",
+            job_type="QUERY",
             timestamp=datetime(2022, 1, 27, 17, 17, 12, 636773, pytz.UTC),
             start_time=datetime(2022, 1, 27, 17, 17, 11, 823000, pytz.UTC),
             end_time=datetime(2022, 1, 27, 17, 17, 12, 630000, pytz.UTC),

--- a/tests/bigquery/lineage/test_parser.py
+++ b/tests/bigquery/lineage/test_parser.py
@@ -21,6 +21,7 @@ def test_parse_log(test_root_dir):
             end_time=datetime(2022, 1, 27, 17, 20, 29, 93000, pytz.UTC),
             user_email="yi@metaphor.io",
             query=None,
+            query_truncated=None,
             statementType=None,
             source_tables=[
                 BigQueryResource(
@@ -43,6 +44,7 @@ def test_parse_log(test_root_dir):
             end_time=datetime(2022, 1, 27, 17, 17, 12, 630000, pytz.UTC),
             user_email="bigquery-crawler@metaphor-data.iam.gserviceaccount.com",
             query="INSERT INTO `metaphor-data.test.yi_test3` \nSELECT * from `metaphor-data.test.yi_tests1` \nUNION ALL \nSELECT * from `metaphor-data.test.yi_tests2`",
+            query_truncated=True,
             statementType="SELECT",
             source_tables=[
                 BigQueryResource(


### PR DESCRIPTION

### 🤔 Why?

BigQuery audit metadata log has a size limit 100KB
https://cloud.google.com/bigquery/docs/reference/auditlogs#limitation
Longer SQL will be truncated, thus we need to call `jobs.get` to get the full job spec.

### 🤓 What?

- Check `queryTruncated` flag and call `jobs` API to get full query SQL

### 🧪 Tested?

tested locally against BigQuery instance
