### PR TITLE
Handle missing Unity Catalog lineage API gracefully

### DIFF
--- a/metaphor/unity_catalog/utils.py
+++ b/metaphor/unity_catalog/utils.py
@@ -1,26 +1,47 @@
 from databricks_cli.sdk.api_client import ApiClient
 from pydantic import parse_obj_as
+from requests import HTTPError
 
+from metaphor.common.logger import get_logger
 from metaphor.unity_catalog.models import ColumnLineage, TableLineage
+
+logger = get_logger()
 
 
 def list_table_lineage(client: ApiClient, table_name: str) -> TableLineage:
     _data = {"table_name": table_name}
-    return parse_obj_as(
-        TableLineage,
-        client.perform_query(
-            "GET", "/lineage-tracking/table-lineage", data=_data, version="2.0"
-        ),
-    )
+
+    try:
+        return parse_obj_as(
+            TableLineage,
+            client.perform_query(
+                "GET", "/lineage-tracking/table-lineage", data=_data, version="2.0"
+            ),
+        )
+    except HTTPError as e:
+        # Lineage API returns 503 on GCP as it's not yet available
+        if e.response.status_code == 503:
+            return TableLineage()
+
+        raise e
 
 
 def list_column_lineage(
     client: ApiClient, table_name: str, column_name: str
 ) -> ColumnLineage:
     _data = {"table_name": table_name, "column_name": column_name}
-    return parse_obj_as(
-        ColumnLineage,
-        client.perform_query(
-            "GET", "/lineage-tracking/column-lineage", data=_data, version="2.0"
-        ),
-    )
+
+    # Lineage API returns 503 on GCP as it's not yet available
+    try:
+        return parse_obj_as(
+            ColumnLineage,
+            client.perform_query(
+                "GET", "/lineage-tracking/column-lineage", data=_data, version="2.0"
+            ),
+        )
+    except HTTPError as e:
+        # Lineage API returns 503 on GCP as it's not yet available
+        if e.response.status_code == 503:
+            return ColumnLineage()
+
+        raise e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.126"
+version = "0.11.127"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Unity Catalog's Lineage API is only [available on AWS & Azure](https://www.databricks.com/blog/2022/12/12/announcing-general-availability-data-lineage-unity-catalog.html) for now. It'd return HTTP 503 error when running against a GCP instance.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Add try-catch to handle the missing API gracefully.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified against a production instance running on GCP.
