### PR TITLE
BigQuery access denied for jobs get API [sc-17038]

### DIFF
--- a/metaphor/bigquery/README.md
+++ b/metaphor/bigquery/README.md
@@ -6,12 +6,19 @@ This connector extracts technical metadata from a BigQuery project using [Python
 
 We recommend creating a dedicated GCP service account with limited permissions for the connector:
 
-1. Go to [Service Accounts](https://console.cloud.google.com/iam-admin/serviceaccounts) in Google Cloud Console. Make sure the appropriate project is selected from the project dropdown.
-2. Click `Create Service Account` and use the following settings to create a new account:
+1. Go to [Roles](https://console.cloud.google.com/iam-admin/roles) in Google Cloud Console. Make sure the appropriate project is selected from the project dropdown.
+2. Click `Create Role` and use the following settings to create a new custom role for running metadata-fetching jobs and getting job information:
+    - Enter a role title, e.g. `Metaphor Job`.
+    - Enter a description, e.g. `Metadata collection job role for metaphor app`.
+    - Choose role stage `General Availability`.
+    - Click `ADD PERMISSIONS` and add `bigquery.config.get`, `bigquery.jobs.create`, `bigquery.jobs.get`.
+    - Click `CREATE` to create the custom role.
+3. Go to [Service Accounts](https://console.cloud.google.com/iam-admin/serviceaccounts) in Google Cloud Console. Make sure the appropriate project is selected from the project dropdown.
+4. Click `Create Service Account` and use the following settings to create a new account:
     - Enter a service account name, e.g., `metaphor-bigquery`.
     - Enter a description, e.g. `Metadata collection for Metaphor app`
     - Click `CREATE AND CONTINUE`.
-    - Select `BigQuery Metadata Viewer` and `BigQuery Job User` as the roles and click `CONTINUE`.
+    - Select `BigQuery Metadata Viewer`, `Log Viewer` and `Metaphor Job` as the roles and click `CONTINUE`.
     - Click `DONE` to complete the process as there's no need to grant user access to the service account.
 
 Once the service account is created, you need to create a service account key for authentication:

--- a/metaphor/bigquery/README.md
+++ b/metaphor/bigquery/README.md
@@ -7,18 +7,18 @@ This connector extracts technical metadata from a BigQuery project using [Python
 We recommend creating a dedicated GCP service account with limited permissions for the connector:
 
 1. Go to [Roles](https://console.cloud.google.com/iam-admin/roles) in Google Cloud Console. Make sure the appropriate project is selected from the project dropdown.
-2. Click `Create Role` and use the following settings to create a new custom role for running metadata-fetching jobs and getting job information:
+2. Click `Create Role` and use the following settings to create a new custom role for running metadata jobs and fetching logs:
     - Enter a role title, e.g. `Metaphor Job`.
     - Enter a description, e.g. `Metadata collection job role for metaphor app`.
     - Choose role stage `General Availability`.
-    - Click `ADD PERMISSIONS` and add `bigquery.config.get`, `bigquery.jobs.create`, `bigquery.jobs.get`.
+    - Click `ADD PERMISSIONS` and add: `bigquery.config.get`, `bigquery.jobs.create`, `bigquery.jobs.get`, `logging.logEntries.download`, `logging.logEntries.list`, `logging.views.access`, `logging.views.listLogs`.
     - Click `CREATE` to create the custom role.
 3. Go to [Service Accounts](https://console.cloud.google.com/iam-admin/serviceaccounts) in Google Cloud Console. Make sure the appropriate project is selected from the project dropdown.
 4. Click `Create Service Account` and use the following settings to create a new account:
     - Enter a service account name, e.g., `metaphor-bigquery`.
     - Enter a description, e.g. `Metadata collection for Metaphor app`
     - Click `CREATE AND CONTINUE`.
-    - Select `BigQuery Metadata Viewer`, `Log Viewer` and `Metaphor Job` as the roles and click `CONTINUE`.
+    - Select `BigQuery Metadata Viewer` and `Metaphor Job` as the roles and click `CONTINUE`.
     - Click `DONE` to complete the process as there's no need to grant user access to the service account.
 
 Once the service account is created, you need to create a service account key for authentication:

--- a/metaphor/bigquery/README.md
+++ b/metaphor/bigquery/README.md
@@ -11,15 +11,36 @@ We recommend creating a dedicated GCP service account with limited permissions f
     - Enter a role title, e.g. `Metaphor Job`.
     - Enter a description, e.g. `Metadata collection job role for metaphor app`.
     - Choose role stage `General Availability`.
-    - Click `ADD PERMISSIONS` and add: `bigquery.config.get`, `bigquery.jobs.create`, `bigquery.jobs.get`, `logging.logEntries.download`, `logging.logEntries.list`, `logging.views.access`, `logging.views.listLogs`.
+    - Click `ADD PERMISSIONS` and add: `bigquery.config.get`, `bigquery.jobs.create`, `bigquery.jobs.get`.
     - Click `CREATE` to create the custom role.
 3. Go to [Service Accounts](https://console.cloud.google.com/iam-admin/serviceaccounts) in Google Cloud Console. Make sure the appropriate project is selected from the project dropdown.
 4. Click `Create Service Account` and use the following settings to create a new account:
     - Enter a service account name, e.g., `metaphor-bigquery`.
     - Enter a description, e.g. `Metadata collection for Metaphor app`
     - Click `CREATE AND CONTINUE`.
-    - Select `BigQuery Metadata Viewer` and `Metaphor Job` as the roles and click `CONTINUE`.
+    - Select `BigQuery Metadata Viewer`, `Private Logs Viewer` and `Metaphor Job` as the roles and click `CONTINUE`.
     - Click `DONE` to complete the process as there's no need to grant user access to the service account.
+
+> Alternatively, if one prefer to avoid predefined roles and use custom role only, here is the complete list of permissions needed:
+> - bigquery.config.get
+> - bigquery.datasets.get
+> - bigquery.datasets.getIamPolicy
+> - bigquery.jobs.create
+> - bigquery.jobs.get
+> - bigquery.datasets.get
+> - bigquery.datasets.getIamPolicy
+> - bigquery.models.getMetadata
+> - bigquery.models.list
+> - bigquery.routines.get
+> - bigquery.routines.list
+> - bigquery.tables.get
+> - bigquery.tables.getIamPolicy
+> - bigquery.tables.list
+> - logging.logEntries.list
+> - logging.logs.list
+> - logging.privateLogEntries.list
+> - resourcemanager.projects.get
+
 
 Once the service account is created, you need to create a service account key for authentication:
 

--- a/metaphor/bigquery/extractor.py
+++ b/metaphor/bigquery/extractor.py
@@ -294,7 +294,12 @@ class BigQueryExtractor(BaseExtractor):
         if match:
             project = match.group(1)
             job_id = match.group(2)
-            job = client.get_job(job_id, project)
+
+            try:
+                job = client.get_job(job_id, project)
+            except Exception as e:
+                logger.warning(f"Failed to get job information: {e}")
+                return None
 
             if isinstance(job, bigquery.QueryJob):
                 return job.query
@@ -340,7 +345,7 @@ class BigQueryExtractor(BaseExtractor):
             and job_change.query_truncated
             and self._fetch_job_query_if_truncated
         ):
-            query = self._fetch_job_query(client, job_change.job_name)
+            query = self._fetch_job_query(client, job_change.job_name) or query
 
         elapsed_time = (
             (job_change.end_time - job_change.start_time).total_seconds()

--- a/metaphor/bigquery/lineage/README.md
+++ b/metaphor/bigquery/lineage/README.md
@@ -4,16 +4,7 @@ This connector extracts BigQuery lineage information from a Google cloud project
 
 ## Setup
 
-Create a [Service Accounts](https://console.cloud.google.com/iam-admin/serviceaccounts) based on the [Setup](../README.md#Setup) guide for the general BigQuery connector. You'll need to grant additional permissions to the account to view the [audit log](https://cloud.google.com/logging/docs/audit/services). You can add the `Private Logs Viewers` role to your service account or add the following permissions to the custom IAM role your service account bind with:
-
-```text
-logging.logEntries.list
-logging.logs.list
-logging.logServiceIndexes.list
-logging.logServices.list
-logging.privateLogEntries.list
-resourcemanager.projects.get
-```
+Create a [Service Accounts](https://console.cloud.google.com/iam-admin/serviceaccounts) based on the [Setup](../README.md#Setup) guide for the general BigQuery connector.
 
 See [Access Control](https://cloud.google.com/logging/docs/access-control#console_permissions) for more information.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.127"
+version = "0.11.128"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
### 🤔 Why?

PR #474 added capability to query BigQuery job API to get full SQL. But that requires additional permission `jobs.get` which we didn't request from customer. This will result in access deny error.

### 🤓 What?

- update README to add process for creating custom role and added to service account.
- reduced the required permissions to minimum
- add error handling to job detail fetching

### 🧪 Tested?

created new service account following the process and verified the crawler 
