### PR TITLE
Add error handling for Power BI access token retrieval

### DIFF
--- a/metaphor/power_bi/README.md
+++ b/metaphor/power_bi/README.md
@@ -35,7 +35,7 @@ tenant_id: <tenant_id>  # The Power BI tenant ID
 
 client_id: <client_id>  # The Azure Application client id
 
-secret: <secret>  # The client secret
+secret: <secret>  # The client secret value (not secret ID)
 
 output:
   file:

--- a/metaphor/power_bi/power_bi_client.py
+++ b/metaphor/power_bi/power_bi_client.py
@@ -134,6 +134,11 @@ class WorkspaceInfo(BaseModel):
     dashboards: List[WorkspaceInfoDashboard] = []
 
 
+class AccessTokenError(Exception):
+    def __init__(self, message: str) -> None:
+        super().__init__(f"Failed to acquire access token: {message}")
+
+
 class AuthenticationError(Exception):
     def __init__(self, body) -> None:
         super().__init__(
@@ -177,7 +182,11 @@ class PowerBIClient:
             )
             token = app.acquire_token_for_client(scopes=self.SCOPES)
 
-        return f"Bearer {token['access_token']}"
+        access_token = token.get("access_token")
+        if access_token is None:
+            raise AccessTokenError(token.get("error_description", "unknown error"))
+
+        return f"Bearer {access_token}"
 
     def get_groups(self) -> List[PowerBIWorkspace]:
         # https://docs.microsoft.com/en-us/rest/api/power-bi/admin/groups-get-groups-as-admin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.128"
+version = "0.11.129"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

When the client secret is invalid of missing, the Power BI extractor will throw the following cryptic exception:
```
Traceback (most recent call last):
  File "/Users/marslan/Metaphor/connectors/metaphor/common/runner.py", line 54, in run_connector
    entities = connector_func()
  File "/Users/marslan/Metaphor/connectors/metaphor/common/base_extractor.py", line 32, in run_async
    return asyncio.run(self.extract())
  File "/Users/marslan/.pyenv/versions/3.9.6/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/Users/marslan/.pyenv/versions/3.9.6/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
    return future.result()
  File "/Users/marslan/Metaphor/connectors/metaphor/power_bi/extractor.py", line 71, in extract
    self._client = PowerBIClient(self._config)
  File "/Users/marslan/Metaphor/connectors/metaphor/power_bi/power_bi_client.py", line 164, in __init__
    self._headers = {"Authorization": self.retrieve_access_token(config)}
  File "/Users/marslan/Metaphor/connectors/metaphor/power_bi/power_bi_client.py", line 180, in retrieve_access_token
    return f"Bearer {token['access_token']}"
KeyError: 'access_token'
```

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Add proper error handling and throw `AccessTokenError` with additional debug information. Also updated the doc with information on client secret key vs value.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Tested against a production instance:

```
Failed to acquire access token: AADSTS7000215: Invalid client secret provided. Ensure the secret being sent in the request is the client secret value, not the client secret ID, for a secret added to app 'XXXXX'.
Trace ID: XXXXXX
```
