### PR TITLE
Fix logging for ThoughtSpot API calls

### DIFF
--- a/metaphor/thought_spot/utils.py
+++ b/metaphor/thought_spot/utils.py
@@ -188,6 +188,7 @@ class ThoughtSpot:
         obj = ThoughtSpot._fetch_object_detail(
             client.metadata, ids, GetObjectDetailTypeEnum.CONNECTION
         )
+        json_dump_to_debug_file(obj, "connection.json")
         return parse_obj_as(List[ConnectionMetadata], obj)
 
     @classmethod
@@ -202,6 +203,7 @@ class ThoughtSpot:
         logger.info(f"{mtype} ids: {ids}")
 
         obj = ThoughtSpot._fetch_object_detail(client.metadata, ids, detail_type)
+        json_dump_to_debug_file(obj, f"{str(mtype).lower()}.json")
 
         # Because mypy can't handle dynamic type variables properly, we skip type-checking here.
         return parse_obj_as(List[target_type], obj)  # type: ignore
@@ -244,7 +246,6 @@ class ThoughtSpot:
             if "storables" in response:
                 res.extend(response["storables"])
 
-        json_dump_to_debug_file(res, f"{str(object_type).lower()}.json")
         return res
 
     @staticmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.129"
+version = "0.11.130"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Currently the logs for different types of ThoughtSpot data objects get clobbered into one, making it difficult to debug.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Split the log files based on data object types.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Before:
<img width="697" alt="Screenshot 2023-04-14 at 8 50 39 PM" src="https://user-images.githubusercontent.com/24240669/232181502-c7b3ec95-104e-4d63-92cd-0b5bf438fbd1.png">

After:
<img width="682" alt="Screenshot 2023-04-14 at 8 44 49 PM" src="https://user-images.githubusercontent.com/24240669/232181332-49348be0-4ad3-4c82-8704-f25eb672267b.png">


