### PR TITLE
Replace metaphor-sqllineage with sqllineage

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1820,23 +1820,6 @@ optional = false
 python-versions = ">=3.7,<4.0"
 
 [[package]]
-name = "metaphor-sqllineage"
-version = "2.0.10"
-description = "SQL Lineage Analysis Tool powered by Python"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-networkx = ">=2.4"
-sqlparse = ">=0.3.1"
-
-[package.extras]
-ci = ["bandit (==1.7.1)", "black", "flake8", "flake8-blind-except", "flake8-builtins", "flake8-import-order", "flake8-logging-format", "mypy (==0.971)", "pytest", "pytest-cov", "tox", "twine", "wheel"]
-cli = ["flask", "flask-cors", "werkzeug"]
-docs = ["Sphinx (>=3.2.0)", "sphinx-rtd-theme (>=0.5.0)"]
-
-[[package]]
 name = "msal"
 version = "1.21.0"
 description = "The Microsoft Authentication Library (MSAL) for Python library enables your app to access the Microsoft Cloud by supporting authentication of users with Microsoft Azure Active Directory accounts (AAD) and Microsoft Accounts (MSA) using industry standard OAuth2 and OpenID Connect."
@@ -2722,12 +2705,33 @@ timezone = ["python-dateutil"]
 url = ["furl (>=0.4.1)"]
 
 [[package]]
+name = "sqllineage"
+version = "1.3.8"
+description = "SQL Lineage Analysis Tool powered by Python"
+category = "main"
+optional = true
+python-versions = ">=3.6"
+
+[package.dependencies]
+networkx = ">=2.4"
+sqlparse = ">=0.4.4"
+
+[package.extras]
+ci = ["bandit", "black", "flake8", "flake8-blind-except", "flake8-builtins", "flake8-import-order", "flake8-logging-format", "mypy", "pytest", "pytest-cov", "tox", "twine", "wheel"]
+docs = ["Sphinx (>=3.2.0)", "sphinx-rtd-theme (>=0.5.0)"]
+
+[[package]]
 name = "sqlparse"
-version = "0.4.3"
+version = "0.4.4"
 description = "A non-validating SQL parser."
 category = "main"
 optional = false
 python-versions = ">=3.5"
+
+[package.extras]
+dev = ["build", "flake8"]
+doc = ["sphinx"]
+test = ["pytest", "pytest-cov"]
 
 [[package]]
 name = "stevedore"
@@ -2991,7 +2995,7 @@ docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker
 testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [extras]
-all = ["asyncpg", "databricks-cli", "GitPython", "google-cloud-bigquery", "google-cloud-logging", "lkml", "looker-sdk", "metaphor-sqllineage", "msal", "pymssql", "pymysql", "snowflake-connector-python", "SQLAlchemy", "sql-metadata", "tableauserverclient", "thoughtspot-rest-api-sdk"]
+all = ["asyncpg", "databricks-cli", "GitPython", "google-cloud-bigquery", "google-cloud-logging", "lkml", "looker-sdk", "msal", "pymssql", "pymysql", "snowflake-connector-python", "SQLAlchemy", "sql-metadata", "sqllineage", "tableauserverclient", "thoughtspot-rest-api-sdk"]
 bigquery = ["google-cloud-bigquery", "google-cloud-logging", "sql-metadata"]
 dbt = []
 looker = ["GitPython", "lkml", "looker-sdk", "sql-metadata"]
@@ -3000,17 +3004,17 @@ mssql = ["pymssql"]
 mysql = ["pymysql", "SQLAlchemy"]
 postgresql = ["asyncpg"]
 power-bi = ["msal", "sql-metadata"]
-redshift = ["asyncpg", "metaphor-sqllineage"]
+redshift = ["asyncpg", "sqllineage"]
 snowflake = ["snowflake-connector-python", "sql-metadata"]
 synapse = ["pymssql"]
-tableau = ["tableauserverclient", "metaphor-sqllineage"]
+tableau = ["tableauserverclient", "sqllineage"]
 throughtspot = ["thoughtspot-rest-api-sdk"]
 unity-catalog = ["databricks-cli"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<3.11"  # See https://github.com/googleapis/python-bigquery/issues/856
-content-hash = "5adf4f5511d19f95789963156783993276b6ef7f84951eed9ab91c44d40a22df"
+content-hash = "4f9e4adfd1ee012e31084667aa8b28f1489950293cb456c04649542cc3ebafee"
 
 [metadata.files]
 aiohttp = [
@@ -4081,10 +4085,6 @@ metaphor-models = [
     {file = "metaphor_models-0.17.6-py3-none-any.whl", hash = "sha256:58a6d342162d0813cf0b412de1bccdef5bf24fd4da70567b6e62169792652be6"},
     {file = "metaphor_models-0.17.6.tar.gz", hash = "sha256:b951e898d9acac6be1a6998244bfd2a79f4f128b7dd8790fc80924a11fd600a4"},
 ]
-metaphor-sqllineage = [
-    {file = "metaphor-sqllineage-2.0.10.tar.gz", hash = "sha256:7d80a1c964cb965ed2096aaf99c17fa78cc39129efe700670a2aafdf33d7bdc6"},
-    {file = "metaphor_sqllineage-2.0.10-py3-none-any.whl", hash = "sha256:89d0ba5233526343519420833109f8e24636d921a4a3345977fb526ceba016d7"},
-]
 msal = [
     {file = "msal-1.21.0-py2.py3-none-any.whl", hash = "sha256:e8444617c1eccdff7bb73f5d4f94036002accea4a2c05f8f39c9efb5bd2b0c6a"},
     {file = "msal-1.21.0.tar.gz", hash = "sha256:96b5c867830fd116e5f7d0ec8ef1b238b4cda4d1aea86d8fecf518260e136fbf"},
@@ -4904,9 +4904,13 @@ sqlalchemy-utils = [
     {file = "SQLAlchemy-Utils-0.40.0.tar.gz", hash = "sha256:af803089a7929803faeb6173b90f29d1a67ad02f1d1e732f40b054a8eb3c7370"},
     {file = "SQLAlchemy_Utils-0.40.0-py3-none-any.whl", hash = "sha256:4c7098d4857d5cad1248bf7cd940727aecb75b596a5574b86a93b37079929520"},
 ]
+sqllineage = [
+    {file = "sqllineage-1.3.8-py3-none-any.whl", hash = "sha256:dd1966606e13e95ecd26c9fae7e4451932e9af9253be704aedd6aa7285b2fe41"},
+    {file = "sqllineage-1.3.8.tar.gz", hash = "sha256:c577d7473ef319440189560bec48e71e9f3cafafc10de1872618baacfb8ed9db"},
+]
 sqlparse = [
-    {file = "sqlparse-0.4.3-py3-none-any.whl", hash = "sha256:0323c0ec29cd52bceabc1b4d9d579e311f3e4961b98d174201d5622a23b85e34"},
-    {file = "sqlparse-0.4.3.tar.gz", hash = "sha256:69ca804846bb114d2ec380e4360a8a340db83f0ccf3afceeb1404df028f57268"},
+    {file = "sqlparse-0.4.4-py3-none-any.whl", hash = "sha256:5430a4fe2ac7d0f93e66f1efc6e1338a41884b7ddf2a350cedd20ccc4d9d28f3"},
+    {file = "sqlparse-0.4.4.tar.gz", hash = "sha256:d446183e84b8349fa3061f0fe7f06ca94ba65b426946ffebe6e3e8295332420c"},
 ]
 stevedore = [
     {file = "stevedore-3.5.2-py3-none-any.whl", hash = "sha256:fa2630e3d0ad3e22d4914aff2501445815b9a4467a6edc49387c667a38faf5bf"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.131"
+version = "0.11.132"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ google-cloud-logging = { version = "^3.5.0", optional = true }
 lkml = { version = "^1.3.1", optional = true }
 looker-sdk = { version = "^22.20.0", optional = true }
 metaphor-models = "0.17.6"
-metaphor-sqllineage = { version = "^2.0.10", optional = true }
 msal = { version = "^1.20.0", optional = true }
 pydantic = "~=1.9.0"
 pymssql = { version = "^2.2.7", optional = true }
@@ -41,6 +40,7 @@ smart-open = "^6.3.0"
 snowflake-connector-python = { version = "~=2.8.0", optional = true }
 SQLAlchemy = { version = "^1.4.46", optional = true}
 sql-metadata = { version = "^2.6.0", optional = true }
+sqllineage = { version = "^1.3.8", optional = true }
 tableauserverclient = { version = "^0.23.4", optional = true }
 thoughtspot-rest-api-sdk = { version = "^1.11.0", optional = true }
 
@@ -53,7 +53,6 @@ all = [
   "google-cloud-logging",
   "lkml",
   "looker-sdk",
-  "metaphor-sqllineage",
   "msal",
   "pymssql",
   "pymysql",
@@ -61,6 +60,7 @@ all = [
   "snowflake-connector-python",
   "SQLAlchemy",
   "sql-metadata",
+  "sqllineage",
   "tableauserverclient",
   "thoughtspot-rest-api-sdk",
 ]
@@ -72,10 +72,10 @@ mssql = ["pymssql"]
 mysql = ["pymysql", "SQLAlchemy"]
 postgresql = ["asyncpg"]
 power_bi = ["msal", "sql-metadata"]
-redshift = ["asyncpg", "metaphor-sqllineage"]
+redshift = ["asyncpg", "sqllineage"]
 snowflake = ["snowflake-connector-python", "sql-metadata"]
 synapse = ["pymssql"]
-tableau = ["tableauserverclient", "metaphor-sqllineage"]
+tableau = ["tableauserverclient", "sqllineage"]
 throughtspot = ["thoughtspot-rest-api-sdk"]
 unity_catalog = ["databricks-cli"]
 


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

sqllinage released an update that fixes the [monkey patch broken by sqlparse 0.4.4](https://github.com/reata/sqllineage/pull/360). Since newer versions of sqlllinage has [dropped the dependency on flask](https://github.com/reata/sqllineage/pull/305), it's safe to switch back to using it. Also avoided 1.4.x, which [replace sqlparse with sqlfluff](https://github.com/reata/sqllineage/issues/302), for now until further testing.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified against a production instance.
