### PR TITLE
Fix dbt manifest validation errors by clearing the docs block

### DIFF
--- a/metaphor/dbt/manifest_parser.py
+++ b/metaphor/dbt/manifest_parser.py
@@ -207,6 +207,12 @@ class ManifestParser:
         )
         logger.info(f"parsing manifest.json {schema_version} ...")
 
+        # It's possible for dbt to generate "docs block" in the manifest that doesn't
+        # conform to the JSON schema. Specifically, the "name" field can be None in
+        # some cases. Since the field is not actually used, it's safe to clear it out to
+        # avoid hitting any validation issues.
+        manifest_json["docs"] = {}
+
         dbt_manifest_class = dbt_version_manifest_class_map.get(schema_version)
         if dbt_manifest_class is None:
             raise ValueError(f"unsupported manifest schema '{schema_version}'")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.132"
+version = "0.11.133"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

dbt connector can throw the following error when processing `manifest.json`:

```
2023-04-26 14:51:43:ERROR:metaphor:Parse manifest json error: 1 validation error for DbtManifest
docs -> XXXXX.None -> name
  none is not an allowed value (type=type_error.none.not_allowed)
2023-04-26 14:51:43:ERROR:metaphor:1 validation error for DbtManifest
docs -> XXXXX.None -> name
  none is not an allowed value (type=type_error.none.not_allowed)
Traceback (most recent call last):
  File "/Users/marslan/Metaphor/connectors/metaphor/common/runner.py", line 54, in run_connector
    entities = connector_func()
  File "/Users/marslan/Metaphor/connectors/metaphor/common/base_extractor.py", line 32, in run_async
    return asyncio.run(self.extract())
  File "/Users/marslan/.pyenv/versions/3.9.6/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/Users/marslan/.pyenv/versions/3.9.6/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
    return future.result()
  File "/Users/marslan/Metaphor/connectors/metaphor/dbt/cloud/extractor.py", line 140, in extract
    return await DbtExtractor(
  File "/Users/marslan/Metaphor/connectors/metaphor/dbt/extractor.py", line 65, in extract
    manifest_parser.parse(manifest_json)
  File "/Users/marslan/Metaphor/connectors/metaphor/dbt/manifest_parser.py", line 218, in parse
    raise e
  File "/Users/marslan/Metaphor/connectors/metaphor/dbt/manifest_parser.py", line 215, in parse
    manifest = dbt_manifest_class.parse_obj(manifest_json)
  File "pydantic/main.py", line 521, in pydantic.main.BaseModel.parse_obj
  File "pydantic/main.py", line 341, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for DbtManifest
```
Turns out that dbt doesn't check that a [docs block](https://docs.getdbt.com/docs/collaborate/documentation#using-docs-blocks) have a name defined and will happily generate a manifest.json file that doesn't pass the official JSON schema, e.g. 

```md
{% docs %}
hello world!
{% enddocs %}
```

will lead to this in `manifest.json`:

```
        "doc.metaphor_subscriptions.None":
        {
            "name": null,
            "resource_type": "doc",
            "package_name": "metaphor_subscriptions",
            "path": "README.md",
            "original_file_path": "docs/README.md",
            "unique_id": "doc.metaphor_subscriptions.None",
            "block_contents": "hello world!"
        }
```

which doesn't conform to the JSON schema as the `name` [must be non-null](https://schemas.getdbt.com/dbt/manifest/v8/index.html#docs_additionalProperties_name).

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Clear out the `docs` field in manifest.json before validation since it's not being used anyway.

[docs block](https://docs.getdbt.com/docs/collaborate/documentation#using-docs-blocks)

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Tested against a production deployment.
