### PR TITLE
ambiguous column name error for Snowflake [sc-17430]

### DIFF
--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -457,7 +457,7 @@ class SnowflakeExtractor(BaseExtractor):
                 f"""
                 SELECT QUERY_ID, USER_NAME, QUERY_TEXT, START_TIME, TOTAL_ELAPSED_TIME, CREDITS_USED_CLOUD_SERVICES,
                   DATABASE_NAME, SCHEMA_NAME, BYTES_SCANNED, BYTES_WRITTEN, ROWS_PRODUCED
-                FROM SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY
+                FROM SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY q
                 WHERE EXECUTION_STATUS = 'SUCCESS'
                   AND START_TIME > %s AND START_TIME <= %s
                   {exclude_username_clause(self._query_log_excluded_usernames)}

--- a/metaphor/snowflake/utils.py
+++ b/metaphor/snowflake/utils.py
@@ -98,8 +98,12 @@ def async_execute(
 
 
 def exclude_username_clause(excluded_usernames: Set[str]) -> str:
+    """
+    Excludes usernames from query history output
+    use "q" as "SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY" table alias
+    """
     return (
-        f"and USER_NAME NOT IN ({','.join(['%s'] * len(excluded_usernames))})"
+        f"and q.USER_NAME NOT IN ({','.join(['%s'] * len(excluded_usernames))})"
         if len(excluded_usernames) > 0
         else ""
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.135"
+version = "0.11.136"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
### 🤔 Why?

It seems that the ACCESS_HISTORY view also has a column "USER_NAME" now, so when joining it with QUERY_HISTORY view and adding the exclude username clause, it causes ambiguous column error

### 🤓 What?

- add table qualifier to the "USER_NAME" column, the joining query already used `q` as the alias, so we reused that

### 🧪 Tested?

added `excluded_usernames` config and crawler our testing Snowflake instance, previous code will throw error, but the updated code works fine.
