### PR TITLE
SourceEntityId is incorrect

### DIFF
--- a/metaphor/fivetran/extractor.py
+++ b/metaphor/fivetran/extractor.py
@@ -1,6 +1,5 @@
 import json
 from dataclasses import asdict, dataclass
-from functools import lru_cache
 from typing import Collection, Dict, List, Optional, Type
 
 from requests.auth import HTTPBasicAuth
@@ -234,7 +233,7 @@ class FivetranExtractor(BaseExtractor):
         )
 
         source_logical_id = DatasetLogicalID(
-            name=dataset_normalized_name(table=source_dataset_name),
+            name=source_dataset_name,
             platform=source_platform,
             account=source_account,
         )
@@ -275,8 +274,8 @@ class FivetranExtractor(BaseExtractor):
             creator_email,
         )
 
-        source_db = self.get_database_name_from_connector(connector)
         if connector.service in SOURCE_PLATFORM_MAPPING:
+            source_db = self.get_database_name_from_connector(connector)
             source_logical_id = self._get_source_logical_id(
                 source_db, schema, table, connector
             )
@@ -307,8 +306,6 @@ class FivetranExtractor(BaseExtractor):
         )
 
         self._datasets[destination_dataset_name] = dataset
-
-        return dataset
 
     def get_snowflake_account_from_config(self, config: dict) -> Optional[str]:
         host = config.get("host")
@@ -439,10 +436,9 @@ class FivetranExtractor(BaseExtractor):
         return get_request(url=url, headers=headers, auth=self._auth, **kwargs)
 
 
-@lru_cache()
 def populate_fivetran_connector_detail(
     connector: ConnectorPayload,
-    connector_type_name: str,
+    connector_type_name: Optional[str],
     serialized_schema_metadata: str,
     creator_email: Optional[str],
 ) -> FiveTranConnector:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.141"
+version = "0.11.142"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/fivetran/data/v1__metadata__connectors__connector_2__columns.json
+++ b/tests/fivetran/data/v1__metadata__connectors__connector_2__columns.json
@@ -21,6 +21,16 @@
         "type_in_destination": "DECIMAL(38, 6)",
         "is_primary_key": false,
         "is_foreign_key": false
+      },
+      {
+        "id": "MzI4NDE5MTg1",
+        "parent_id": "OTI2OTU2OR",
+        "name_in_source": "col1",
+        "name_in_destination": "col1",
+        "type_in_source": "BigDecimal",
+        "type_in_destination": "DECIMAL(38, 6)",
+        "is_primary_key": false,
+        "is_foreign_key": false
       }
     ]
   }

--- a/tests/fivetran/data/v1__metadata__connectors__connector_2__tables.json
+++ b/tests/fivetran/data/v1__metadata__connectors__connector_2__tables.json
@@ -7,6 +7,12 @@
         "parent_id": "c25vd2ZsYWtlX2RiX3JpZGVfc2hhcmU",
         "name_in_source": "table",
         "name_in_destination": "table"
+      },
+      {
+        "id": "OTI2OTU2OR",
+        "parent_id": "c25vd2ZsYWtlX2RiX3JpZGVfc2hhcmU",
+        "name_in_source": "table2",
+        "name_in_destination": "table2"
       }
     ]
   }

--- a/tests/fivetran/expected.json
+++ b/tests/fivetran/expected.json
@@ -94,15 +94,15 @@
         "createdAt": "2023-04-10T18:02:35.655597+00:00",
         "creatorEmail": "user@foo.com",
         "paused": true,
-        "schemaMetadata": "[{\"name_in_source\": \"schema\", \"name_in_destination\": \"snowflake_db_schema\", \"tables\": [{\"name_in_source\": \"table\", \"name_in_destination\": \"table\", \"columns\": [{\"name_in_source\": \"col1\", \"name_in_destination\": \"col1\", \"type_in_source\": \"BigDecimal\", \"type_in_destination\": \"DECIMAL(38, 6)\", \"is_primary_key\": false, \"is_foreign_key\": false}, {\"name_in_source\": \"col2\", \"name_in_destination\": \"col2\", \"type_in_source\": \"BigDecimal\", \"type_in_destination\": \"DECIMAL(38, 6)\", \"is_primary_key\": false, \"is_foreign_key\": false}]}]}]",
+        "schemaMetadata": "[{\"name_in_source\": \"schema\", \"name_in_destination\": \"snowflake_db_schema\", \"tables\": [{\"name_in_source\": \"table\", \"name_in_destination\": \"table\", \"columns\": [{\"name_in_source\": \"col1\", \"name_in_destination\": \"col1\", \"type_in_source\": \"BigDecimal\", \"type_in_destination\": \"DECIMAL(38, 6)\", \"is_primary_key\": false, \"is_foreign_key\": false}, {\"name_in_source\": \"col2\", \"name_in_destination\": \"col2\", \"type_in_source\": \"BigDecimal\", \"type_in_destination\": \"DECIMAL(38, 6)\", \"is_primary_key\": false, \"is_foreign_key\": false}]}, {\"name_in_source\": \"table2\", \"name_in_destination\": \"table2\", \"columns\": [{\"name_in_source\": \"col1\", \"name_in_destination\": \"col1\", \"type_in_source\": \"BigDecimal\", \"type_in_destination\": \"DECIMAL(38, 6)\", \"is_primary_key\": false, \"is_foreign_key\": false}]}]}]",
+        "sourceEntityId": "DATASET~E71466A1A1CE8D63F92424B3CF3F3F4E",
         "status": {
           "setupState": "connected",
           "syncState": "paused",
           "updateState": "on_schedule"
         },
         "succeededAt": "2023-04-19T08:56:03.467000+00:00",
-        "syncIntervalInMinute": 1440.0,
-        "sourceEntityId": "DATASET~E71466A1A1CE8D63F92424B3CF3F3F4E"
+        "syncIntervalInMinute": 1440.0
       },
       "sourceEntities": [
         "DATASET~E71466A1A1CE8D63F92424B3CF3F3F4E"
@@ -154,18 +154,108 @@
         "createdAt": "2023-04-10T18:02:35.655597+00:00",
         "creatorEmail": "user@foo.com",
         "paused": true,
-        "schemaMetadata": "[{\"name_in_source\": \"schema\", \"name_in_destination\": \"snowflake_db_schema\", \"tables\": [{\"name_in_source\": \"table\", \"name_in_destination\": \"table\", \"columns\": [{\"name_in_source\": \"col1\", \"name_in_destination\": \"col1\", \"type_in_source\": \"BigDecimal\", \"type_in_destination\": \"DECIMAL(38, 6)\", \"is_primary_key\": false, \"is_foreign_key\": false}, {\"name_in_source\": \"col2\", \"name_in_destination\": \"col2\", \"type_in_source\": \"BigDecimal\", \"type_in_destination\": \"DECIMAL(38, 6)\", \"is_primary_key\": false, \"is_foreign_key\": false}]}]}]",
+        "schemaMetadata": "[{\"name_in_source\": \"schema\", \"name_in_destination\": \"snowflake_db_schema\", \"tables\": [{\"name_in_source\": \"table\", \"name_in_destination\": \"table\", \"columns\": [{\"name_in_source\": \"col1\", \"name_in_destination\": \"col1\", \"type_in_source\": \"BigDecimal\", \"type_in_destination\": \"DECIMAL(38, 6)\", \"is_primary_key\": false, \"is_foreign_key\": false}, {\"name_in_source\": \"col2\", \"name_in_destination\": \"col2\", \"type_in_source\": \"BigDecimal\", \"type_in_destination\": \"DECIMAL(38, 6)\", \"is_primary_key\": false, \"is_foreign_key\": false}]}, {\"name_in_source\": \"table2\", \"name_in_destination\": \"table2\", \"columns\": [{\"name_in_source\": \"col1\", \"name_in_destination\": \"col1\", \"type_in_source\": \"BigDecimal\", \"type_in_destination\": \"DECIMAL(38, 6)\", \"is_primary_key\": false, \"is_foreign_key\": false}]}]}]",
+        "sourceEntityId": "DATASET~E71466A1A1CE8D63F92424B3CF3F3F4E",
         "status": {
           "setupState": "connected",
           "syncState": "paused",
           "updateState": "on_schedule"
         },
         "succeededAt": "2023-04-19T08:56:03.467000+00:00",
-        "syncIntervalInMinute": 1440.0,
-        "sourceEntityId": "DATASET~E71466A1A1CE8D63F92424B3CF3F3F4E"
+        "syncIntervalInMinute": 1440.0
       },
       "sourceDatasets": [
         "DATASET~E71466A1A1CE8D63F92424B3CF3F3F4E"
+      ]
+    }
+  },
+  {
+    "entityType": "DATASET",
+    "entityUpstream": {
+      "fieldMappings": [
+        {
+          "destination": "col1",
+          "sources": [
+            {
+              "dataset": {
+                "account": "source_account",
+                "name": "source_db.schema.table2",
+                "platform": "SNOWFLAKE"
+              },
+              "field": "col1",
+              "sourceEntityId": "DATASET~F31B21D3EDB9FF855528E9D6679840C7"
+            }
+          ]
+        }
+      ],
+      "fiveTranConnector": {
+        "config": "{\"database\": \"source_db\", \"password\": \"******\", \"is_private_key_encrypted\": false, \"port\": 443, \"auth\": \"PASSWORD\", \"update_method\": \"TELEPORT\", \"host\": \"source_account.snowflakecomputing.com\", \"user\": \"user\"}",
+        "connectorLogsUrl": "https://fivetran.com/dashboard/connectors/connector_2/logs",
+        "connectorName": "snowflake_db",
+        "connectorTypeId": "snowflake_db",
+        "connectorTypeName": "Snowflake",
+        "connectorUrl": "https://fivetran.com/dashboard/connectors/connector_2",
+        "createdAt": "2023-04-10T18:02:35.655597+00:00",
+        "creatorEmail": "user@foo.com",
+        "paused": true,
+        "schemaMetadata": "[{\"name_in_source\": \"schema\", \"name_in_destination\": \"snowflake_db_schema\", \"tables\": [{\"name_in_source\": \"table\", \"name_in_destination\": \"table\", \"columns\": [{\"name_in_source\": \"col1\", \"name_in_destination\": \"col1\", \"type_in_source\": \"BigDecimal\", \"type_in_destination\": \"DECIMAL(38, 6)\", \"is_primary_key\": false, \"is_foreign_key\": false}, {\"name_in_source\": \"col2\", \"name_in_destination\": \"col2\", \"type_in_source\": \"BigDecimal\", \"type_in_destination\": \"DECIMAL(38, 6)\", \"is_primary_key\": false, \"is_foreign_key\": false}]}, {\"name_in_source\": \"table2\", \"name_in_destination\": \"table2\", \"columns\": [{\"name_in_source\": \"col1\", \"name_in_destination\": \"col1\", \"type_in_source\": \"BigDecimal\", \"type_in_destination\": \"DECIMAL(38, 6)\", \"is_primary_key\": false, \"is_foreign_key\": false}]}]}]",
+        "sourceEntityId": "DATASET~F31B21D3EDB9FF855528E9D6679840C7",
+        "status": {
+          "setupState": "connected",
+          "syncState": "paused",
+          "updateState": "on_schedule"
+        },
+        "succeededAt": "2023-04-19T08:56:03.467000+00:00",
+        "syncIntervalInMinute": 1440.0
+      },
+      "sourceEntities": [
+        "DATASET~F31B21D3EDB9FF855528E9D6679840C7"
+      ]
+    },
+    "logicalId": {
+      "account": "dest_account",
+      "name": "fivetran.snowflake_db_schema.table2",
+      "platform": "SNOWFLAKE"
+    },
+    "upstream": {
+      "fieldMappings": [
+        {
+          "destination": "col1",
+          "sources": [
+            {
+              "dataset": {
+                "account": "source_account",
+                "name": "source_db.schema.table2",
+                "platform": "SNOWFLAKE"
+              },
+              "field": "col1",
+              "sourceEntityId": "DATASET~F31B21D3EDB9FF855528E9D6679840C7"
+            }
+          ]
+        }
+      ],
+      "fiveTranConnector": {
+        "config": "{\"database\": \"source_db\", \"password\": \"******\", \"is_private_key_encrypted\": false, \"port\": 443, \"auth\": \"PASSWORD\", \"update_method\": \"TELEPORT\", \"host\": \"source_account.snowflakecomputing.com\", \"user\": \"user\"}",
+        "connectorLogsUrl": "https://fivetran.com/dashboard/connectors/connector_2/logs",
+        "connectorName": "snowflake_db",
+        "connectorTypeId": "snowflake_db",
+        "connectorTypeName": "Snowflake",
+        "connectorUrl": "https://fivetran.com/dashboard/connectors/connector_2",
+        "createdAt": "2023-04-10T18:02:35.655597+00:00",
+        "creatorEmail": "user@foo.com",
+        "paused": true,
+        "schemaMetadata": "[{\"name_in_source\": \"schema\", \"name_in_destination\": \"snowflake_db_schema\", \"tables\": [{\"name_in_source\": \"table\", \"name_in_destination\": \"table\", \"columns\": [{\"name_in_source\": \"col1\", \"name_in_destination\": \"col1\", \"type_in_source\": \"BigDecimal\", \"type_in_destination\": \"DECIMAL(38, 6)\", \"is_primary_key\": false, \"is_foreign_key\": false}, {\"name_in_source\": \"col2\", \"name_in_destination\": \"col2\", \"type_in_source\": \"BigDecimal\", \"type_in_destination\": \"DECIMAL(38, 6)\", \"is_primary_key\": false, \"is_foreign_key\": false}]}, {\"name_in_source\": \"table2\", \"name_in_destination\": \"table2\", \"columns\": [{\"name_in_source\": \"col1\", \"name_in_destination\": \"col1\", \"type_in_source\": \"BigDecimal\", \"type_in_destination\": \"DECIMAL(38, 6)\", \"is_primary_key\": false, \"is_foreign_key\": false}]}]}]",
+        "sourceEntityId": "DATASET~F31B21D3EDB9FF855528E9D6679840C7",
+        "status": {
+          "setupState": "connected",
+          "syncState": "paused",
+          "updateState": "on_schedule"
+        },
+        "succeededAt": "2023-04-19T08:56:03.467000+00:00",
+        "syncIntervalInMinute": 1440.0
+      },
+      "sourceDatasets": [
+        "DATASET~F31B21D3EDB9FF855528E9D6679840C7"
       ]
     }
   }


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

When a connector has multiple table, sourceEntityId field was incorrect. The reason was we use `@lru_cache` for generate `FiveTranConnector` object for not spending too much time on serializing json objects, which cause different `dataset` share the same `FiveTranConnector`; therefore the `SourceEntityId` will be the last table's ID.

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

- Drop the cache decorator


<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

- Update test data to cover the case

<!--
  Describe how the change was tested end-to-end.
-->
