### PR TITLE
Upgrade the ThoughtSpot API version to 9.0+

### DIFF
--- a/metaphor/thought_spot/extractor.py
+++ b/metaphor/thought_spot/extractor.py
@@ -3,7 +3,6 @@ from itertools import chain
 from typing import Collection, Dict, List, Tuple
 
 from pydantic import parse_raw_as
-from restapisdk.models.search_object_header_type_enum import SearchObjectHeaderTypeEnum
 from sqllineage.exceptions import SQLLineageException
 from sqllineage.runner import LineageRunner
 
@@ -40,12 +39,12 @@ from metaphor.models.metadata_change_event import (
 )
 from metaphor.thought_spot.config import ThoughtSpotRunConfig
 from metaphor.thought_spot.models import (
-    AnswerMetadata,
-    ConnectionMetadata,
+    AnswerMetadataDetail,
+    ConnectionMetadataDetail,
     DataSourceTypeEnum,
     Header,
-    LiveBoardMetadata,
-    SourceMetadata,
+    LiveBoardMetadataDetail,
+    LogicalTableMetadataDetail,
     TableMappingInfo,
     Tag,
     TMLObject,
@@ -88,6 +87,7 @@ class ThoughtSpotExtractor(BaseExtractor):
         logger.info("Fetching metadata from ThoughtSpot")
 
         self._client = ThoughtSpot.create_client(self._config)
+
         self.fetch_virtual_views()
         self.fetch_dashboards()
 
@@ -96,11 +96,9 @@ class ThoughtSpotExtractor(BaseExtractor):
     def fetch_virtual_views(self):
         connections = from_list(ThoughtSpot.fetch_connections(self._client))
 
-        data_objects = ThoughtSpot.fetch_objects(
-            self._client, SearchObjectHeaderTypeEnum.DATAOBJECT_ALL
-        )
+        data_objects = ThoughtSpot.fetch_tables(self._client)
 
-        def is_source_valid(table: SourceMetadata):
+        def is_source_valid(table: LogicalTableMetadataDetail):
             """
             Table should source from a connection
             """
@@ -117,7 +115,9 @@ class ThoughtSpotExtractor(BaseExtractor):
         self.populate_lineage(connections, tables)
         self.populate_formula()
 
-    def populate_logical_column_mapping(self, tables: Dict[str, SourceMetadata]):
+    def populate_logical_column_mapping(
+        self, tables: Dict[str, LogicalTableMetadataDetail]
+    ):
         for table in tables.values():
             table_id = table.header.id
             view_id = VirtualViewLogicalID(
@@ -131,8 +131,8 @@ class ThoughtSpotExtractor(BaseExtractor):
 
     def populate_virtual_views(
         self,
-        connections: Dict[str, ConnectionMetadata],
-        tables: Dict[str, SourceMetadata],
+        connections: Dict[str, ConnectionMetadataDetail],
+        tables: Dict[str, LogicalTableMetadataDetail],
     ):
         for table in tables.values():
             table_id = table.header.id
@@ -248,8 +248,8 @@ class ThoughtSpotExtractor(BaseExtractor):
 
     def populate_lineage(
         self,
-        connections: Dict[str, ConnectionMetadata],
-        tables: Dict[str, SourceMetadata],
+        connections: Dict[str, ConnectionMetadataDetail],
+        tables: Dict[str, LogicalTableMetadataDetail],
     ):
         """
         Populate lineage between tables/worksheets/views
@@ -308,7 +308,7 @@ class ThoughtSpotExtractor(BaseExtractor):
 
     @staticmethod
     def get_source_entity_id_from_connection(
-        connections: Dict[str, ConnectionMetadata],
+        connections: Dict[str, ConnectionMetadataDetail],
         normalized_name: str,
         source_id: str,
     ) -> str:
@@ -323,7 +323,7 @@ class ThoughtSpotExtractor(BaseExtractor):
 
     @staticmethod
     def find_entity_id_from_connection(
-        connections: Dict[str, ConnectionMetadata],
+        connections: Dict[str, ConnectionMetadataDetail],
         mapping: TableMappingInfo,
         source_id: str,
     ) -> str:
@@ -370,17 +370,13 @@ class ThoughtSpotExtractor(BaseExtractor):
         return source_ids
 
     def fetch_dashboards(self):
-        answers = ThoughtSpot.fetch_objects(
-            self._client, SearchObjectHeaderTypeEnum.ANSWER
-        )
+        answers = ThoughtSpot.fetch_answers(self._client)
         self.populate_answers(answers)
 
-        boards = ThoughtSpot.fetch_objects(
-            self._client, SearchObjectHeaderTypeEnum.LIVEBOARD
-        )
-        self.populate_liveboards(boards)
+        liveboards = ThoughtSpot.fetch_liveboards(self._client)
+        self.populate_liveboards(liveboards)
 
-    def populate_answers(self, answers: List[AnswerMetadata]):
+    def populate_answers(self, answers: List[AnswerMetadataDetail]):
         for answer in answers:
             answer_id = answer.header.id
 
@@ -424,7 +420,7 @@ class ThoughtSpotExtractor(BaseExtractor):
 
             self._dashboards[answer_id] = dashboard
 
-    def populate_liveboards(self, liveboards: List[LiveBoardMetadata]):
+    def populate_liveboards(self, liveboards: List[LiveBoardMetadataDetail]):
         for board in liveboards:
             board_id = board.header.id
 

--- a/metaphor/thought_spot/models.py
+++ b/metaphor/thought_spot/models.py
@@ -2,7 +2,7 @@
 This module models the ThoughtSpot SDK complex return objects.
 """
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 from pydantic import BaseModel
 
@@ -173,7 +173,6 @@ class LogicalTableMetadataDetail(Metadata):
 
 class LogicalTableMetadata(BaseModel):
     metadata_detail: LogicalTableMetadataDetail
-    dependent_objects: Any
 
 
 class AnswerMetadataDetail(Metadata):
@@ -225,7 +224,18 @@ class TMLView(TMLBase):
     view_columns: List[TMLColumn]
 
 
+class TMLTable(BaseModel):
+    name: str
+    id: Optional[str]
+    fqn: Optional[str]
+
+
+class TMLAnswer(TMLBase):
+    tables: List[TMLTable]
+
+
 class TMLObject(BaseModel):
     guid: str
     worksheet: Optional[TMLWorksheet]
     view: Optional[TMLView]
+    answer: Optional[TMLAnswer]

--- a/metaphor/thought_spot/models.py
+++ b/metaphor/thought_spot/models.py
@@ -2,7 +2,7 @@
 This module models the ThoughtSpot SDK complex return objects.
 """
 from enum import Enum
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel
 
@@ -173,6 +173,7 @@ class LogicalTableMetadataDetail(Metadata):
 
 class LogicalTableMetadata(BaseModel):
     metadata_detail: LogicalTableMetadataDetail
+    dependent_objects: Any
 
 
 class AnswerMetadataDetail(Metadata):

--- a/metaphor/thought_spot/models.py
+++ b/metaphor/thought_spot/models.py
@@ -152,14 +152,18 @@ class LogicalTable(Metadata):
     logicalTableContent: LogicalTableContent
 
 
-class ConnectionMetadata(Metadata):
+class ConnectionMetadataDetail(Metadata):
     header: Header
     type: ConnectionType
     dataSourceContent: DataSourceContent
     logicalTableList: List[LogicalTable]
 
 
-class SourceMetadata(Metadata):
+class ConnectionMetadata(BaseModel):
+    metadata_detail: ConnectionMetadataDetail
+
+
+class LogicalTableMetadataDetail(Metadata):
     type: str
     columns: List[ColumnMetadata]
     dataSourceId: str
@@ -167,15 +171,27 @@ class SourceMetadata(Metadata):
     logicalTableContent: LogicalTableContent
 
 
-class AnswerMetadata(Metadata):
+class LogicalTableMetadata(BaseModel):
+    metadata_detail: LogicalTableMetadataDetail
+
+
+class AnswerMetadataDetail(Metadata):
     type: str
     reportContent: ReportContent
 
 
-class LiveBoardMetadata(Metadata):
+class AnswerMetadata(BaseModel):
+    metadata_detail: AnswerMetadataDetail
+
+
+class LiveBoardMetadataDetail(Metadata):
     header: LiveBoardHeader
     type: str
     reportContent: ReportContent
+
+
+class LiveBoardMetadata(BaseModel):
+    metadata_detail: LiveBoardMetadataDetail
 
 
 class TMLResult(BaseModel):

--- a/metaphor/thought_spot/utils.py
+++ b/metaphor/thought_spot/utils.py
@@ -19,7 +19,6 @@ from metaphor.thought_spot.models import (
     LiveBoardMetadata,
     LiveBoardMetadataDetail,
     LogicalTableMetadata,
-    LogicalTableMetadataDetail,
     SourceType,
     TMLResult,
 )
@@ -129,24 +128,20 @@ class ThoughtSpot:
         return connection_details
 
     @classmethod
-    def fetch_tables(cls, client: TSRestApiV2) -> List[LogicalTableMetadataDetail]:
+    def fetch_tables(cls, client: TSRestApiV2) -> List[LogicalTableMetadata]:
         response = client.metadata_search(
             {
                 "metadata": [{"type": "LOGICAL_TABLE"}],
                 "include_details": True,
+                "include_dependent_objects": True,
                 "record_size": 100,
             }
         )
         json_dump_to_debug_file(response, "metadata_search__logical_table.json")
 
-        table_details = [
-            table.metadata_detail
-            for table in parse_obj_as(List[LogicalTableMetadata], response)
-        ]
+        tables = parse_obj_as(List[LogicalTableMetadata], response)
 
-        logger.info(f"TABLE ids: {[c.header.id for c in table_details]}")
-
-        return table_details
+        return tables
 
     @classmethod
     def fetch_answers(cls, client: TSRestApiV2) -> List[AnswerMetadataDetail]:

--- a/poetry.lock
+++ b/poetry.lock
@@ -763,26 +763,6 @@ urllib3 = ">=1.25.4,<1.27"
 crt = ["awscrt (==0.16.9)"]
 
 [[package]]
-name = "cachecontrol"
-version = "0.12.11"
-description = "httplib2 caching for requests"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-files = [
-    {file = "CacheControl-0.12.11-py2.py3-none-any.whl", hash = "sha256:2c75d6a8938cb1933c75c50184549ad42728a27e9f6b92fd677c3151aa72555b"},
-    {file = "CacheControl-0.12.11.tar.gz", hash = "sha256:a5b9fcc986b184db101aa280b42ecdcdfc524892596f606858e0b7a8b4d9e144"},
-]
-
-[package.dependencies]
-msgpack = ">=0.5.2"
-requests = "*"
-
-[package.extras]
-filecache = ["lockfile (>=0.9)"]
-redis = ["redis (>=2.10.5)"]
-
-[[package]]
 name = "cached-property"
 version = "1.5.2"
 description = "A decorator for caching properties in classes."
@@ -1355,19 +1335,6 @@ files = [
 [package.dependencies]
 dnspython = ">=1.15.0"
 idna = ">=2.0.0"
-
-[[package]]
-name = "enum34"
-version = "1.1.10"
-description = "Python 3.4 Enum backported to 3.3, 3.2, 3.1, 2.7, 2.6, 2.5, and 2.4"
-category = "main"
-optional = true
-python-versions = "*"
-files = [
-    {file = "enum34-1.1.10-py2-none-any.whl", hash = "sha256:a98a201d6de3f2ab3db284e70a33b0f896fbf35f8086594e8c9e74b909058d53"},
-    {file = "enum34-1.1.10-py3-none-any.whl", hash = "sha256:c3858660960c984d6ab0ebad691265180da2b43f07e061c0f8dca9ef3cffd328"},
-    {file = "enum34-1.1.10.tar.gz", hash = "sha256:cce6a7477ed816bd2542d03d53db9f0db935dd013b70f336a95c73979289f248"},
-]
 
 [[package]]
 name = "exceptiongroup"
@@ -2454,26 +2421,6 @@ files = [
 ]
 
 [[package]]
-name = "jsonpickle"
-version = "1.5.2"
-description = "Python library for serializing any arbitrary object graph into JSON"
-category = "main"
-optional = true
-python-versions = ">=2.7"
-files = [
-    {file = "jsonpickle-1.5.2-py2.py3-none-any.whl", hash = "sha256:7ace67f85a5cfd148e0d2b7defb63d97e856dd5151c092cc6c48dcc91f39f471"},
-    {file = "jsonpickle-1.5.2.tar.gz", hash = "sha256:9e899bcf94bb1ce6e17beccf880d096fd6221681faede55aa7a8349556822359"},
-]
-
-[package.dependencies]
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
-
-[package.extras]
-docs = ["jaraco.packaging (>=3.2)", "rst.linker (>=1.9)", "sphinx"]
-testing = ["coverage (<5)", "ecdsa", "enum34", "feedparser", "jsonlib", "numpy", "pandas", "pymongo", "pytest (>=3.5,!=3.7.3)", "pytest-black-multipy", "pytest-checkdocs (>=1.2.3)", "pytest-cov", "pytest-flake8", "sklearn", "sqlalchemy"]
-testing-libs = ["demjson", "simplejson", "ujson", "yajl"]
-
-[[package]]
 name = "jsonschema"
 version = "4.17.3"
 description = "An implementation of JSON Schema validation for Python"
@@ -2904,79 +2851,6 @@ requests = ">=2.0.0,<3"
 broker = ["pymsalruntime (>=0.13.2,<0.14)"]
 
 [[package]]
-name = "msgpack"
-version = "1.0.5"
-description = "MessagePack serializer"
-category = "main"
-optional = true
-python-versions = "*"
-files = [
-    {file = "msgpack-1.0.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:525228efd79bb831cf6830a732e2e80bc1b05436b086d4264814b4b2955b2fa9"},
-    {file = "msgpack-1.0.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4f8d8b3bf1ff2672567d6b5c725a1b347fe838b912772aa8ae2bf70338d5a198"},
-    {file = "msgpack-1.0.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cdc793c50be3f01106245a61b739328f7dccc2c648b501e237f0699fe1395b81"},
-    {file = "msgpack-1.0.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5cb47c21a8a65b165ce29f2bec852790cbc04936f502966768e4aae9fa763cb7"},
-    {file = "msgpack-1.0.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e42b9594cc3bf4d838d67d6ed62b9e59e201862a25e9a157019e171fbe672dd3"},
-    {file = "msgpack-1.0.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:55b56a24893105dc52c1253649b60f475f36b3aa0fc66115bffafb624d7cb30b"},
-    {file = "msgpack-1.0.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:1967f6129fc50a43bfe0951c35acbb729be89a55d849fab7686004da85103f1c"},
-    {file = "msgpack-1.0.5-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:20a97bf595a232c3ee6d57ddaadd5453d174a52594bf9c21d10407e2a2d9b3bd"},
-    {file = "msgpack-1.0.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:d25dd59bbbbb996eacf7be6b4ad082ed7eacc4e8f3d2df1ba43822da9bfa122a"},
-    {file = "msgpack-1.0.5-cp310-cp310-win32.whl", hash = "sha256:382b2c77589331f2cb80b67cc058c00f225e19827dbc818d700f61513ab47bea"},
-    {file = "msgpack-1.0.5-cp310-cp310-win_amd64.whl", hash = "sha256:4867aa2df9e2a5fa5f76d7d5565d25ec76e84c106b55509e78c1ede0f152659a"},
-    {file = "msgpack-1.0.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9f5ae84c5c8a857ec44dc180a8b0cc08238e021f57abdf51a8182e915e6299f0"},
-    {file = "msgpack-1.0.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9e6ca5d5699bcd89ae605c150aee83b5321f2115695e741b99618f4856c50898"},
-    {file = "msgpack-1.0.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5494ea30d517a3576749cad32fa27f7585c65f5f38309c88c6d137877fa28a5a"},
-    {file = "msgpack-1.0.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1ab2f3331cb1b54165976a9d976cb251a83183631c88076613c6c780f0d6e45a"},
-    {file = "msgpack-1.0.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28592e20bbb1620848256ebc105fc420436af59515793ed27d5c77a217477705"},
-    {file = "msgpack-1.0.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fe5c63197c55bce6385d9aee16c4d0641684628f63ace85f73571e65ad1c1e8d"},
-    {file = "msgpack-1.0.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ed40e926fa2f297e8a653c954b732f125ef97bdd4c889f243182299de27e2aa9"},
-    {file = "msgpack-1.0.5-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:b2de4c1c0538dcb7010902a2b97f4e00fc4ddf2c8cda9749af0e594d3b7fa3d7"},
-    {file = "msgpack-1.0.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:bf22a83f973b50f9d38e55c6aade04c41ddda19b00c4ebc558930d78eecc64ed"},
-    {file = "msgpack-1.0.5-cp311-cp311-win32.whl", hash = "sha256:c396e2cc213d12ce017b686e0f53497f94f8ba2b24799c25d913d46c08ec422c"},
-    {file = "msgpack-1.0.5-cp311-cp311-win_amd64.whl", hash = "sha256:6c4c68d87497f66f96d50142a2b73b97972130d93677ce930718f68828b382e2"},
-    {file = "msgpack-1.0.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:a2b031c2e9b9af485d5e3c4520f4220d74f4d222a5b8dc8c1a3ab9448ca79c57"},
-    {file = "msgpack-1.0.5-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f837b93669ce4336e24d08286c38761132bc7ab29782727f8557e1eb21b2080"},
-    {file = "msgpack-1.0.5-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b1d46dfe3832660f53b13b925d4e0fa1432b00f5f7210eb3ad3bb9a13c6204a6"},
-    {file = "msgpack-1.0.5-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:366c9a7b9057e1547f4ad51d8facad8b406bab69c7d72c0eb6f529cf76d4b85f"},
-    {file = "msgpack-1.0.5-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:4c075728a1095efd0634a7dccb06204919a2f67d1893b6aa8e00497258bf926c"},
-    {file = "msgpack-1.0.5-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:f933bbda5a3ee63b8834179096923b094b76f0c7a73c1cfe8f07ad608c58844b"},
-    {file = "msgpack-1.0.5-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:36961b0568c36027c76e2ae3ca1132e35123dcec0706c4b7992683cc26c1320c"},
-    {file = "msgpack-1.0.5-cp36-cp36m-win32.whl", hash = "sha256:b5ef2f015b95f912c2fcab19c36814963b5463f1fb9049846994b007962743e9"},
-    {file = "msgpack-1.0.5-cp36-cp36m-win_amd64.whl", hash = "sha256:288e32b47e67f7b171f86b030e527e302c91bd3f40fd9033483f2cacc37f327a"},
-    {file = "msgpack-1.0.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:137850656634abddfb88236008339fdaba3178f4751b28f270d2ebe77a563b6c"},
-    {file = "msgpack-1.0.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c05a4a96585525916b109bb85f8cb6511db1c6f5b9d9cbcbc940dc6b4be944b"},
-    {file = "msgpack-1.0.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56a62ec00b636583e5cb6ad313bbed36bb7ead5fa3a3e38938503142c72cba4f"},
-    {file = "msgpack-1.0.5-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ef8108f8dedf204bb7b42994abf93882da1159728a2d4c5e82012edd92c9da9f"},
-    {file = "msgpack-1.0.5-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:1835c84d65f46900920b3708f5ba829fb19b1096c1800ad60bae8418652a951d"},
-    {file = "msgpack-1.0.5-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:e57916ef1bd0fee4f21c4600e9d1da352d8816b52a599c46460e93a6e9f17086"},
-    {file = "msgpack-1.0.5-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:17358523b85973e5f242ad74aa4712b7ee560715562554aa2134d96e7aa4cbbf"},
-    {file = "msgpack-1.0.5-cp37-cp37m-win32.whl", hash = "sha256:cb5aaa8c17760909ec6cb15e744c3ebc2ca8918e727216e79607b7bbce9c8f77"},
-    {file = "msgpack-1.0.5-cp37-cp37m-win_amd64.whl", hash = "sha256:ab31e908d8424d55601ad7075e471b7d0140d4d3dd3272daf39c5c19d936bd82"},
-    {file = "msgpack-1.0.5-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:b72d0698f86e8d9ddf9442bdedec15b71df3598199ba33322d9711a19f08145c"},
-    {file = "msgpack-1.0.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:379026812e49258016dd84ad79ac8446922234d498058ae1d415f04b522d5b2d"},
-    {file = "msgpack-1.0.5-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:332360ff25469c346a1c5e47cbe2a725517919892eda5cfaffe6046656f0b7bb"},
-    {file = "msgpack-1.0.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:476a8fe8fae289fdf273d6d2a6cb6e35b5a58541693e8f9f019bfe990a51e4ba"},
-    {file = "msgpack-1.0.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a9985b214f33311df47e274eb788a5893a761d025e2b92c723ba4c63936b69b1"},
-    {file = "msgpack-1.0.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:48296af57cdb1d885843afd73c4656be5c76c0c6328db3440c9601a98f303d87"},
-    {file = "msgpack-1.0.5-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:addab7e2e1fcc04bd08e4eb631c2a90960c340e40dfc4a5e24d2ff0d5a3b3edb"},
-    {file = "msgpack-1.0.5-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:916723458c25dfb77ff07f4c66aed34e47503b2eb3188b3adbec8d8aa6e00f48"},
-    {file = "msgpack-1.0.5-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:821c7e677cc6acf0fd3f7ac664c98803827ae6de594a9f99563e48c5a2f27eb0"},
-    {file = "msgpack-1.0.5-cp38-cp38-win32.whl", hash = "sha256:1c0f7c47f0087ffda62961d425e4407961a7ffd2aa004c81b9c07d9269512f6e"},
-    {file = "msgpack-1.0.5-cp38-cp38-win_amd64.whl", hash = "sha256:bae7de2026cbfe3782c8b78b0db9cbfc5455e079f1937cb0ab8d133496ac55e1"},
-    {file = "msgpack-1.0.5-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:20c784e66b613c7f16f632e7b5e8a1651aa5702463d61394671ba07b2fc9e025"},
-    {file = "msgpack-1.0.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:266fa4202c0eb94d26822d9bfd7af25d1e2c088927fe8de9033d929dd5ba24c5"},
-    {file = "msgpack-1.0.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:18334484eafc2b1aa47a6d42427da7fa8f2ab3d60b674120bce7a895a0a85bdd"},
-    {file = "msgpack-1.0.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:57e1f3528bd95cc44684beda696f74d3aaa8a5e58c816214b9046512240ef437"},
-    {file = "msgpack-1.0.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:586d0d636f9a628ddc6a17bfd45aa5b5efaf1606d2b60fa5d87b8986326e933f"},
-    {file = "msgpack-1.0.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a740fa0e4087a734455f0fc3abf5e746004c9da72fbd541e9b113013c8dc3282"},
-    {file = "msgpack-1.0.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:3055b0455e45810820db1f29d900bf39466df96ddca11dfa6d074fa47054376d"},
-    {file = "msgpack-1.0.5-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:a61215eac016f391129a013c9e46f3ab308db5f5ec9f25811e811f96962599a8"},
-    {file = "msgpack-1.0.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:362d9655cd369b08fda06b6657a303eb7172d5279997abe094512e919cf74b11"},
-    {file = "msgpack-1.0.5-cp39-cp39-win32.whl", hash = "sha256:ac9dd47af78cae935901a9a500104e2dea2e253207c924cc95de149606dc43cc"},
-    {file = "msgpack-1.0.5-cp39-cp39-win_amd64.whl", hash = "sha256:06f5174b5f8ed0ed919da0e62cbd4ffde676a374aba4020034da05fab67b9164"},
-    {file = "msgpack-1.0.5.tar.gz", hash = "sha256:c075544284eadc5cddc70f4757331d99dcbc16b2bbd4849d15f8aae4cf36d31c"},
-]
-
-[[package]]
 name = "multidict"
 version = "6.0.4"
 description = "multidict implementation"
@@ -3218,6 +3092,21 @@ files = [
 
 [package.dependencies]
 asn1crypto = ">=1.5.1"
+
+[[package]]
+name = "oyaml"
+version = "1.0"
+description = "Ordered YAML: drop-in replacement for PyYAML which preserves dict ordering"
+category = "main"
+optional = true
+python-versions = "*"
+files = [
+    {file = "oyaml-1.0-py2.py3-none-any.whl", hash = "sha256:3a378747b7fb2425533d1ce41962d6921cda075d46bb480a158d45242d156323"},
+    {file = "oyaml-1.0.tar.gz", hash = "sha256:ed8fc096811f4763e1907dce29c35895d6d5936c4d0400fe843a91133d4744ed"},
+]
+
+[package.dependencies]
+pyyaml = "*"
 
 [[package]]
 name = "packaging"
@@ -4720,22 +4609,21 @@ files = [
 ]
 
 [[package]]
-name = "thoughtspot-rest-api-sdk"
-version = "1.11.0"
-description = "Python client library for RESTAPI SDK"
+name = "thoughtspot-rest-api-v1"
+version = "1.4.1"
+description = "Library implementing the ThoughtSpot V1 REST API"
 category = "main"
 optional = true
-python-versions = "*"
+python-versions = ">=3.6"
 files = [
-    {file = "thoughtspot-rest-api-sdk-1.11.0.tar.gz", hash = "sha256:43b88ad4109eb8c7614bc1d8fbf44dffe46e7a7a8dcb6fc7fe149aac21fdaefc"},
+    {file = "thoughtspot_rest_api_v1-1.4.1-py3-none-any.whl", hash = "sha256:145b6c16f3d017b19a86aa4eba63bd8cc54cce2d7aba50ae86498e1e0eb5d63c"},
+    {file = "thoughtspot_rest_api_v1-1.4.1.tar.gz", hash = "sha256:1b8833db67429cba02dce86eb6f91ed147e7d0ffd8d3e3bd376f24bf46161fc6"},
 ]
 
 [package.dependencies]
-cachecontrol = ">=0.12.6,<0.13.0"
-enum34 = ">=1.1.10,<2.0"
-jsonpickle = ">=1.4.1,<2.0"
-python-dateutil = ">=2.8.1,<2.9.0"
-requests = ">=2.24,<3.0"
+oyaml = "*"
+PyYAML = "*"
+requests = "*"
 
 [[package]]
 name = "toml"
@@ -5163,7 +5051,7 @@ docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker
 testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [extras]
-all = ["GitPython", "SQLAlchemy", "asyncpg", "databricks-cli", "google-cloud-bigquery", "google-cloud-logging", "lkml", "looker-sdk", "msal", "pymssql", "pymysql", "snowflake-connector-python", "sql-metadata", "sqllineage", "tableauserverclient", "thoughtspot-rest-api-sdk"]
+all = ["GitPython", "SQLAlchemy", "asyncpg", "databricks-cli", "google-cloud-bigquery", "google-cloud-logging", "lkml", "looker-sdk", "msal", "pymssql", "pymysql", "snowflake-connector-python", "sql-metadata", "sqllineage", "tableauserverclient", "thoughtspot_rest_api_v1"]
 bigquery = ["google-cloud-bigquery", "google-cloud-logging", "sql-metadata"]
 dbt = []
 looker = ["GitPython", "lkml", "looker-sdk", "sql-metadata"]
@@ -5176,10 +5064,10 @@ redshift = ["asyncpg", "sqllineage"]
 snowflake = ["snowflake-connector-python", "sql-metadata"]
 synapse = ["pymssql"]
 tableau = ["sqllineage", "tableauserverclient"]
-throughtspot = ["thoughtspot-rest-api-sdk"]
+throughtspot = ["thoughtspot_rest_api_v1"]
 unity-catalog = ["databricks-cli"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7.2,<3.11"  # See https://github.com/googleapis/python-bigquery/issues/856
-content-hash = "8ec70c697df2159246b26fd628d03fe9529e833abf6b7d68c8b092477ed727a2"
+content-hash = "238c9b7cf6f4af58b0607950a2a218349a2dc8c9d289e6e369a195cafb25a939"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ SQLAlchemy = { version = "^1.4.46", optional = true}
 sql-metadata = { version = "^2.8.0", optional = true }
 sqllineage = { version = "^1.3.8", optional = true }
 tableauserverclient = { version = "^0.23.4", optional = true }
-thoughtspot-rest-api-sdk = { version = "^1.11.0", optional = true }
+thoughtspot_rest_api_v1 = { version = "1.4.1", optional = true }
 
 [tool.poetry.extras]
 all = [
@@ -62,7 +62,7 @@ all = [
   "sql-metadata",
   "sqllineage",
   "tableauserverclient",
-  "thoughtspot-rest-api-sdk",
+  "thoughtspot-rest-api-v1",
 ]
 bigquery = ["google-cloud-bigquery", "google-cloud-logging", "sql-metadata"]
 dbt = []
@@ -76,7 +76,7 @@ redshift = ["asyncpg", "sqllineage"]
 snowflake = ["snowflake-connector-python", "sql-metadata"]
 synapse = ["pymssql"]
 tableau = ["tableauserverclient", "sqllineage"]
-throughtspot = ["thoughtspot-rest-api-sdk"]
+throughtspot = ["thoughtspot-rest-api-v1"]
 unity_catalog = ["databricks-cli"]
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.143"
+version = "0.11.144"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/thought_spot/data/answers.json
+++ b/tests/thought_spot/data/answers.json
@@ -10,22 +10,7 @@
                 {
                   "vizContent": {
                     "chartType": "LINE",
-                    "columns": [
-                      {
-                        "referencedTableHeaders": [
-                          {
-                            "id": "data1",
-                            "name": "__unused__"
-                          }
-                        ],
-                        "referencedColumnHeaders": [
-                          {
-                            "id": "table1.col1",
-                            "name": "__unused__"
-                          }
-                        ]
-                      }
-                    ],
+                    "columns": [],
                     "vizType": "CHART"
                   },
                   "relatedLinks": [],

--- a/tests/thought_spot/data/answers.json
+++ b/tests/thought_spot/data/answers.json
@@ -1,63 +1,65 @@
 [
   {
-    "reportContent": {
-      "sheets": [
-        {
-          "sheetType": "QUESTION",
-          "sheetContent": {
-            "visualizations": [
-              {
-                "vizContent": {
-                  "chartType": "LINE",
-                  "columns": [
-                    {
-                      "referencedTableHeaders": [
-                        {
-                          "id": "data1",
-                          "name": "__unused__"
-                        }
-                      ],
-                      "referencedColumnHeaders": [
-                        {
-                          "id": "table1.col1",
-                          "name": "__unused__"
-                        }
-                      ]
-                    }
-                  ],
-                  "vizType": "CHART"
-                },
-                "relatedLinks": [],
-                "header": {
-                  "id": "viz1",
-                  "name": "__unused__"
+    "metadata_detail": {
+      "reportContent": {
+        "sheets": [
+          {
+            "sheetType": "QUESTION",
+            "sheetContent": {
+              "visualizations": [
+                {
+                  "vizContent": {
+                    "chartType": "LINE",
+                    "columns": [
+                      {
+                        "referencedTableHeaders": [
+                          {
+                            "id": "data1",
+                            "name": "__unused__"
+                          }
+                        ],
+                        "referencedColumnHeaders": [
+                          {
+                            "id": "table1.col1",
+                            "name": "__unused__"
+                          }
+                        ]
+                      }
+                    ],
+                    "vizType": "CHART"
+                  },
+                  "relatedLinks": [],
+                  "header": {
+                    "id": "viz1",
+                    "name": "__unused__"
+                  }
                 }
-              }
-            ]
-          },
-          "header": {
-            "id": "answer1",
-            "name": "Answer 1",
-            "description": "This is answer1"
+              ]
+            },
+            "header": {
+              "id": "answer1",
+              "name": "Answer 1",
+              "description": "This is answer1"
+            }
           }
-        }
-      ]
-    },
-    "type": "QUESTION",
-    "header": {
-      "id": "answer1",
-      "name": "Answer 1",
-      "description": "This is answer1",
-      "tags": [
-        {
-          "name": "tag2",
-          "isDeleted": false,
-          "isHidden": false,
-          "isDeprecated": false
-        }
-      ]
-    },
-    "complete": true,
-    "incompleteDetail": []
+        ]
+      },
+      "type": "QUESTION",
+      "header": {
+        "id": "answer1",
+        "name": "Answer 1",
+        "description": "This is answer1",
+        "tags": [
+          {
+            "name": "tag2",
+            "isDeleted": false,
+            "isHidden": false,
+            "isDeprecated": false
+          }
+        ]
+      },
+      "complete": true,
+      "incompleteDetail": []
+    }
   }
 ]

--- a/tests/thought_spot/data/connections.json
+++ b/tests/thought_spot/data/connections.json
@@ -1,56 +1,58 @@
 [
   {
-    "header": {
-      "id": "conn1",
-      "name": "Connection 1",
-      "description": "connection 1 description",
-      "tags": []
-    },
-    "type": "RDBMS_GCP_BIGQUERY",
-    "logicalTableList": [
-      {
-        "columns": [
-          {
-            "header": {
-              "id": "table1.col1",
-              "name": "col1"
-            },
-            "dataType": "VARCHAR",
-            "type": "ATTRIBUTE",
-            "sources": []
-          }
-        ],
-        "logicalTableContent": {
-          "joinType": "INNER",
-          "worksheetType": "VIEW",
-          "tableMappingInfo": {
-            "databaseName": "project",
-            "schemaName": "schema",
-            "tableName": "table",
-            "tableType": "TABLE"
-          }
-        },
-        "type": "ONE_TO_ONE_LOGICAL",
-        "dataSourceId": "conn1",
-        "dataSourceTypeEnum": "RDBMS_GCP_BIGQUERY",
-        "header": {
-          "id": "table1",
-          "name": "Table 1",
-          "description": "This is table1",
-          "tags": [
+    "metadata_detail": {
+      "header": {
+        "id": "conn1",
+        "name": "Connection 1",
+        "description": "connection 1 description",
+        "tags": []
+      },
+      "type": "RDBMS_GCP_BIGQUERY",
+      "logicalTableList": [
+        {
+          "columns": [
             {
-              "name": "table",
-              "isDeleted": false,
-              "isHidden": false,
-              "isDeprecated": false
+              "header": {
+                "id": "table1.col1",
+                "name": "col1"
+              },
+              "dataType": "VARCHAR",
+              "type": "ATTRIBUTE",
+              "sources": []
             }
-          ]
+          ],
+          "logicalTableContent": {
+            "joinType": "INNER",
+            "worksheetType": "VIEW",
+            "tableMappingInfo": {
+              "databaseName": "project",
+              "schemaName": "schema",
+              "tableName": "table",
+              "tableType": "TABLE"
+            }
+          },
+          "type": "ONE_TO_ONE_LOGICAL",
+          "dataSourceId": "conn1",
+          "dataSourceTypeEnum": "RDBMS_GCP_BIGQUERY",
+          "header": {
+            "id": "table1",
+            "name": "Table 1",
+            "description": "This is table1",
+            "tags": [
+              {
+                "name": "table",
+                "isDeleted": false,
+                "isHidden": false,
+                "isDeprecated": false
+              }
+            ]
+          }
         }
-      }
-    ],
-    "dataSourceContent": {
-      "configuration": {
-        "project_id": "project"
+      ],
+      "dataSourceContent": {
+        "configuration": {
+          "project_id": "project"
+        }
       }
     }
   }

--- a/tests/thought_spot/data/data_objects.json
+++ b/tests/thought_spot/data/data_objects.json
@@ -1,144 +1,152 @@
 [
   {
-    "columns": [],
-    "logicalTableContent": {
-      "joinType": "INNER",
-      "worksheetType": "CONTAINER"
-    },
-    "type": "WORKSHEET",
-    "dataSourceId": "conn1",
-    "dataSourceTypeEnum": "DEFAULT",
-    "header": {
-      "id": "worksheet1",
-      "name": "Worksheet 1",
-      "description": "This is worksheet1",
-      "tags": [
-        {
-          "name": "tag1",
-          "isDeleted": false,
-          "isHidden": false,
-          "isDeprecated": false
-        }
-      ]
-    }
-  },
-  {
-    "columns": [
-      {
-        "columnMappingInfo": {
-          "columnName": "col1"
-        },
-        "header": {
-          "id": "table1.col1",
-          "name": "col1"
-        },
-        "dataType": "VARCHAR",
-        "type": "ATTRIBUTE",
-        "sources": []
-      }
-    ],
-    "logicalTableContent": {
-      "joinType": "INNER",
-      "physicalTableName": "table1",
-      "worksheetType": "VIEW",
-      "tableMappingInfo": {
-        "databaseName": "project",
-        "schemaName": "schema",
-        "tableName": "table",
-        "tableType": "TABLE"
-      }
-    },
-    "type": "ONE_TO_ONE_LOGICAL",
-    "dataSourceId": "conn1",
-    "dataSourceTypeEnum": "RDBMS_GCP_BIGQUERY",
-    "header": {
-      "id": "table1",
-      "name": "Table 1",
-      "description": "This is table1",
-      "tags": [
-        {
-          "name": "table",
-          "isDeleted": false,
-          "isHidden": false,
-          "isDeprecated": false
-        }
-      ]
-    }
-  },
-  {
-    "columns": [
-      {
-        "header": {
-          "id": "view.col1",
-          "name": "col1"
-        },
-        "dataType": "VARCHAR",
-        "type": "ATTRIBUTE",
-        "sources": [
-          {
-            "tableId": "table1",
-            "columnId": "table1.col1"
-          }
-        ]
+    "metadata_detail": {
+      "columns": [],
+      "logicalTableContent": {
+        "joinType": "INNER",
+        "worksheetType": "CONTAINER"
       },
-      {
-        "optionalType": "FORMULA",
-        "header": {
-          "id": "view.col2",
-          "name": "col2"
-        },
-        "dataType": "VARCHAR",
-        "type": "MEASURE",
-        "sources": [
+      "type": "WORKSHEET",
+      "dataSourceId": "conn1",
+      "dataSourceTypeEnum": "DEFAULT",
+      "header": {
+        "id": "worksheet1",
+        "name": "Worksheet 1",
+        "description": "This is worksheet1",
+        "tags": [
           {
-            "tableId": "table1",
-            "columnId": "table1.col1"
+            "name": "tag1",
+            "isDeleted": false,
+            "isHidden": false,
+            "isDeprecated": false
           }
         ]
       }
-    ],
-    "logicalTableContent": {
-      "joinType": "INNER",
-      "worksheetType": "VIEW"
-    },
-    "type": "AGGR_WORKSHEET",
-    "dataSourceId": "conn1",
-    "dataSourceTypeEnum": "DEFAULT",
-    "header": {
-      "id": "view1",
-      "name": "View 1",
-      "description": "This is view1",
-      "tags": []
     }
   },
   {
-    "columns": [
-      {
-        "header": {
-          "id": "sql_col1_id",
-          "name": "sql_col1"
-        },
-        "dataType": "VARCHAR",
-        "type": "ATTRIBUTE",
-        "columnMappingInfo": {
-          "columnName": "sql_col1"
-        },
-        "sources": []
+    "metadata_detail": {
+      "columns": [
+        {
+          "columnMappingInfo": {
+            "columnName": "col1"
+          },
+          "header": {
+            "id": "table1.col1",
+            "name": "col1"
+          },
+          "dataType": "VARCHAR",
+          "type": "ATTRIBUTE",
+          "sources": []
+        }
+      ],
+      "logicalTableContent": {
+        "joinType": "INNER",
+        "physicalTableName": "table1",
+        "worksheetType": "VIEW",
+        "tableMappingInfo": {
+          "databaseName": "project",
+          "schemaName": "schema",
+          "tableName": "table",
+          "tableType": "TABLE"
+        }
+      },
+      "type": "ONE_TO_ONE_LOGICAL",
+      "dataSourceId": "conn1",
+      "dataSourceTypeEnum": "RDBMS_GCP_BIGQUERY",
+      "header": {
+        "id": "table1",
+        "name": "Table 1",
+        "description": "This is table1",
+        "tags": [
+          {
+            "name": "table",
+            "isDeleted": false,
+            "isHidden": false,
+            "isDeprecated": false
+          }
+        ]
       }
-    ],
-    "logicalTableContent": {
-      "sqlQuery": "select c as sql_col1 from project.schema.table",
-      "joinType": "INNER",
-      "worksheetType": "VIEW"
-    },
-    "type": "SQL_VIEW",
-    "dataSourceId": "conn1",
-    "dataSourceTypeEnum": "RDBMS_SNOWFLAKE",
-    "header": {
-      "id": "sql_view_1",
-      "name": "JOIN SQL view",
-      "tags": [],
-      "type": "SQL_VIEW"
+    }
+  },
+  {
+    "metadata_detail": {
+      "columns": [
+        {
+          "header": {
+            "id": "view.col1",
+            "name": "col1"
+          },
+          "dataType": "VARCHAR",
+          "type": "ATTRIBUTE",
+          "sources": [
+            {
+              "tableId": "table1",
+              "columnId": "table1.col1"
+            }
+          ]
+        },
+        {
+          "optionalType": "FORMULA",
+          "header": {
+            "id": "view.col2",
+            "name": "col2"
+          },
+          "dataType": "VARCHAR",
+          "type": "MEASURE",
+          "sources": [
+            {
+              "tableId": "table1",
+              "columnId": "table1.col1"
+            }
+          ]
+        }
+      ],
+      "logicalTableContent": {
+        "joinType": "INNER",
+        "worksheetType": "VIEW"
+      },
+      "type": "AGGR_WORKSHEET",
+      "dataSourceId": "conn1",
+      "dataSourceTypeEnum": "DEFAULT",
+      "header": {
+        "id": "view1",
+        "name": "View 1",
+        "description": "This is view1",
+        "tags": []
+      }
+    }
+  },
+  {
+    "metadata_detail": {
+      "columns": [
+        {
+          "header": {
+            "id": "sql_col1_id",
+            "name": "sql_col1"
+          },
+          "dataType": "VARCHAR",
+          "type": "ATTRIBUTE",
+          "columnMappingInfo": {
+            "columnName": "sql_col1"
+          },
+          "sources": []
+        }
+      ],
+      "logicalTableContent": {
+        "sqlQuery": "select c as sql_col1 from project.schema.table",
+        "joinType": "INNER",
+        "worksheetType": "VIEW"
+      },
+      "type": "SQL_VIEW",
+      "dataSourceId": "conn1",
+      "dataSourceTypeEnum": "RDBMS_SNOWFLAKE",
+      "header": {
+        "id": "sql_view_1",
+        "name": "JOIN SQL view",
+        "tags": [],
+        "type": "SQL_VIEW"
+      }
     }
   }
 ]

--- a/tests/thought_spot/data/data_objects.json
+++ b/tests/thought_spot/data/data_objects.json
@@ -25,6 +25,25 @@
     }
   },
   {
+    "dependent_objects": {
+      "table1": {
+        "QUESTION_ANSWER_BOOK": [
+          {
+            "id": "answer1"
+          }
+        ],
+        "PINBOARD_ANSWER_BOOK": [
+          {
+            "id": "board1"
+          }
+        ],
+        "LOGICAL_TABLE": [
+          {
+            "id": "view1"
+          }
+        ]
+      }
+    },
     "metadata_detail": {
       "columns": [
         {

--- a/tests/thought_spot/data/data_objects.json
+++ b/tests/thought_spot/data/data_objects.json
@@ -25,25 +25,6 @@
     }
   },
   {
-    "dependent_objects": {
-      "table1": {
-        "QUESTION_ANSWER_BOOK": [
-          {
-            "id": "answer1"
-          }
-        ],
-        "PINBOARD_ANSWER_BOOK": [
-          {
-            "id": "board1"
-          }
-        ],
-        "LOGICAL_TABLE": [
-          {
-            "id": "view1"
-          }
-        ]
-      }
-    },
     "metadata_detail": {
       "columns": [
         {

--- a/tests/thought_spot/data/liveboards.json
+++ b/tests/thought_spot/data/liveboards.json
@@ -1,110 +1,112 @@
 [
   {
-    "reportContent": {
-      "sheets": [
-        {
-          "sheetType": "LIVEBOARD",
-          "sheetContent": {
-            "visualizations": [
-              {
-                "vizContent": {
-                  "refAnswerSheetIndex": 0,
-                  "refVizId": "answer1",
-                  "vizType": "LIVEBOARD_VIZ"
-                },
-                "relatedLinks": [],
-                "header": {
-                  "id": "viz2",
-                  "name": "Viz 2",
-                  "description": "This is viz2"
+    "metadata_detail": {
+      "reportContent": {
+        "sheets": [
+          {
+            "sheetType": "LIVEBOARD",
+            "sheetContent": {
+              "visualizations": [
+                {
+                  "vizContent": {
+                    "refAnswerSheetIndex": 0,
+                    "refVizId": "answer1",
+                    "vizType": "LIVEBOARD_VIZ"
+                  },
+                  "relatedLinks": [],
+                  "header": {
+                    "id": "viz2",
+                    "name": "Viz 2",
+                    "description": "This is viz2"
+                  }
                 }
-              }
-            ]
-          },
-          "header": {
-            "id": "sheet1",
-            "name": "Sheet 2",
-            "description": "This is sheet2"
+              ]
+            },
+            "header": {
+              "id": "sheet1",
+              "name": "Sheet 2",
+              "description": "This is sheet2"
+            }
           }
-        }
-      ]
-    },
-    "type": "LIVEBOARD",
-    "header": {
-      "id": "board1",
-      "name": "Board 1",
-      "description": "This is board1",
-      "resolvedObjects": {
-        "answer1": {
-          "reportContent": {
-            "sheets": [
-              {
-                "sheetType": "QUESTION",
-                "sheetContent": {
-                  "visualizations": [
-                    {
-                      "vizContent": {
-                        "chartType": "LINE",
-                        "columns": [
-                          {
-                            "referencedTableHeaders": [
-                              {
-                                "id": "data1",
-                                "name": "__unused__"
-                              }
-                            ],
-                            "referencedColumnHeaders": [
-                              {
-                                "id": "table1.col1",
-                                "name": "__unused__"
-                              }
-                            ]
-                          }
-                        ],
-                        "vizType": "CHART"
-                      },
-                      "relatedLinks": [],
-                      "header": {
-                        "id": "viz1",
-                        "name": "__unused__"
-                      }
-                    }
-                  ]
-                },
-                "header": {
-                  "id": "answer1",
-                  "name": "Answer 1",
-                  "description": "This is answer1"
-                }
-              }
-            ]
-          },
-          "type": "QUESTION",
-          "header": {
-            "id": "answer1",
-            "name": "Answer 1",
-            "description": "This is answer1",
-            "tags": [
-              {
-                "name": "tag2",
-                "isDeleted": false,
-                "isHidden": false,
-                "isDeprecated": false
-              }
-            ]
-          },
-          "complete": true,
-          "incompleteDetail": []
-        }
+        ]
       },
-      "tags": [
-        {
-          "name": "tag3",
-          "isDeleted": false,
-          "isHidden": false,
-          "isDeprecated": false
-        }
-      ]
+      "type": "LIVEBOARD",
+      "header": {
+        "id": "board1",
+        "name": "Board 1",
+        "description": "This is board1",
+        "resolvedObjects": {
+          "answer1": {
+            "reportContent": {
+              "sheets": [
+                {
+                  "sheetType": "QUESTION",
+                  "sheetContent": {
+                    "visualizations": [
+                      {
+                        "vizContent": {
+                          "chartType": "LINE",
+                          "columns": [
+                            {
+                              "referencedTableHeaders": [
+                                {
+                                  "id": "data1",
+                                  "name": "__unused__"
+                                }
+                              ],
+                              "referencedColumnHeaders": [
+                                {
+                                  "id": "table1.col1",
+                                  "name": "__unused__"
+                                }
+                              ]
+                            }
+                          ],
+                          "vizType": "CHART"
+                        },
+                        "relatedLinks": [],
+                        "header": {
+                          "id": "viz1",
+                          "name": "__unused__"
+                        }
+                      }
+                    ]
+                  },
+                  "header": {
+                    "id": "answer1",
+                    "name": "Answer 1",
+                    "description": "This is answer1"
+                  }
+                }
+              ]
+            },
+            "type": "QUESTION",
+            "header": {
+              "id": "answer1",
+              "name": "Answer 1",
+              "description": "This is answer1",
+              "tags": [
+                {
+                  "name": "tag2",
+                  "isDeleted": false,
+                  "isHidden": false,
+                  "isDeprecated": false
+                }
+              ]
+            },
+            "complete": true,
+            "incompleteDetail": []
+          }
+        },
+        "tags": [
+          {
+            "name": "tag3",
+            "isDeleted": false,
+            "isHidden": false,
+            "isDeprecated": false
+          }
+        ]
+      }
     }
   }
 ]

--- a/tests/thought_spot/data/liveboards.json
+++ b/tests/thought_spot/data/liveboards.json
@@ -50,7 +50,7 @@
                             {
                               "referencedTableHeaders": [
                                 {
-                                  "id": "data1",
+                                  "id": "table1",
                                   "name": "__unused__"
                                 }
                               ],

--- a/tests/thought_spot/data/tml_answer.json
+++ b/tests/thought_spot/data/tml_answer.json
@@ -1,0 +1,9 @@
+[
+  {
+    "info": {
+      "id": "answer1",
+      "name": "Answer 1"
+    },
+    "edoc": "{\"guid\":\"answer1\",\"answer\":{\"name\":\"Answer 1\",\"tables\":[{\"name\":\"table 1\",\"id\":\"table 1\", \"fqn\": \"table1\"}]}}"
+  }
+]

--- a/tests/thought_spot/expected.json
+++ b/tests/thought_spot/expected.json
@@ -166,23 +166,12 @@
     },
     "upstream": {
       "sourceVirtualViews": [
-        "VIRTUAL_VIEW~AAF339C7F485C19EF29EF177B3C7B65A"
+        "VIRTUAL_VIEW~F13FAE9D17C5631FD2E1025CE8BC7F5C"
       ]
     },
     "entityUpstream": {
-      "fieldMappings": [
-        {
-          "destination": "Answer 1",
-          "sources": [
-            {
-              "field": "col1",
-              "sourceEntityId": "VIRTUAL_VIEW~F13FAE9D17C5631FD2E1025CE8BC7F5C"
-            }
-          ]
-        }
-      ],
       "sourceEntities": [
-        "VIRTUAL_VIEW~AAF339C7F485C19EF29EF177B3C7B65A"
+        "VIRTUAL_VIEW~F13FAE9D17C5631FD2E1025CE8BC7F5C"
       ]
     }
   },
@@ -215,7 +204,7 @@
     },
     "upstream": {
       "sourceVirtualViews": [
-        "VIRTUAL_VIEW~AAF339C7F485C19EF29EF177B3C7B65A"
+        "VIRTUAL_VIEW~F13FAE9D17C5631FD2E1025CE8BC7F5C"
       ]
     },
     "entityUpstream": {
@@ -231,7 +220,7 @@
         }
       ],
       "sourceEntities": [
-        "VIRTUAL_VIEW~AAF339C7F485C19EF29EF177B3C7B65A"
+        "VIRTUAL_VIEW~F13FAE9D17C5631FD2E1025CE8BC7F5C"
       ]
     }
   }

--- a/tests/thought_spot/test_extractor.py
+++ b/tests/thought_spot/test_extractor.py
@@ -47,6 +47,9 @@ async def test_extractor(test_root_dir):
                 load_json(f"{test_root_dir}/thought_spot/data/answers.json"),
             ),
             MockResponse(
+                load_json(f"{test_root_dir}/thought_spot/data/tml_answer.json")
+            ),
+            MockResponse(
                 load_json(f"{test_root_dir}/thought_spot/data/liveboards.json"),
             ),
         ]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

The beta version of ThoughtSpot v2 (version 8.x) is braking current crawler. Fortunately, the metadata models didn't change a lot, we can still using current model for the most cases.

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

- Use new ThoughtSpot SDK
- Refactor utils related to getting Metadata, it's simpler in 9.0+
- Refactor tests, mocking underlaying requests object
- Rewrite answer lineage part, note that we could get the chart -> virtual view column mapping from the data now.

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

Update tests.

Diff before and after MCE, only dropping fieldMapping

<!--
  Describe how the change was tested end-to-end.
-->
