### PR TITLE
Remove dataSize field [sc-17825]

### DIFF
--- a/metaphor/common/models.py
+++ b/metaphor/common/models.py
@@ -3,7 +3,6 @@ from typing import Optional, Union
 
 from pydantic.dataclasses import dataclass
 
-from metaphor.common.constants import BYTES_PER_MEGABYTES
 from metaphor.common.entity_id import normalize_full_dataset_name, to_dataset_entity_id
 from metaphor.models.metadata_change_event import (
     DataPlatform,
@@ -39,9 +38,6 @@ def to_dataset_statistics(
     last_updated: Optional[datetime] = None,
 ) -> DatasetStatistics:
     return DatasetStatistics(
-        data_size=float(size_bytes / BYTES_PER_MEGABYTES)
-        if size_bytes is not None
-        else None,
         data_size_bytes=float(size_bytes) if size_bytes is not None else None,
         record_count=float(rows) if rows is not None else None,
         last_updated=last_updated,

--- a/metaphor/redshift/extractor.py
+++ b/metaphor/redshift/extractor.py
@@ -89,7 +89,6 @@ class RedshiftExtractor(PostgreSQLExtractor):
                 result["tbl_rows"], result["size"] * BYTES_PER_MEGABYTES
             )
             dataset.statistics.record_count = statistics.record_count
-            dataset.statistics.data_size = statistics.data_size
             dataset.statistics.data_size_bytes = statistics.data_size_bytes
 
     async def _fetch_query_logs(self, conn) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.144"
+version = "0.11.145"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/bigquery/expected.json
+++ b/tests/bigquery/expected.json
@@ -28,7 +28,6 @@
       }
     },
     "statistics": {
-      "dataSize": 5.0,
       "dataSizeBytes": 5242880.0,
       "recordCount": 100.0,
       "lastUpdated": "2000-01-02T00:00:00+00:00"
@@ -85,7 +84,6 @@
       }
     },
     "statistics": {
-      "dataSize": 0.5,
       "dataSizeBytes": 524288.0,
       "recordCount": 1000.0,
       "lastUpdated": "2000-01-02T00:00:00+00:00"


### PR DESCRIPTION
### 🤔 Why?

We have deprecated `dataSize` field in favor of `dataSizeBytes` field and UI has already migrated.

### 🤓 What?

- Stop crawlers from writing to `dataSize` field 

### 🧪 Tested?

unit tests. Tested locally against Snowflake and BigQuery
