### PR TITLE
Add support to specify Snowflake private key data directly in the config

### DIFF
--- a/metaphor/snowflake/README.md
+++ b/metaphor/snowflake/README.md
@@ -85,6 +85,16 @@ output:
 
 The `private_key.passphrase` is only needed if using encrypted version of the private key. Otherwise, it can be omitted from the config.
 
+You can also specify the content of the private key file directly in the config like this:
+
+```yaml
+private_key:
+  key_data: |
+    -----BEGIN ENCRYPTED PRIVATE KEY-----
+    ...
+    -----END ENCRYPTED PRIVATE KEY-----
+```
+
 See [Output Config](../common/docs/output.md) for more information on `output`.
 
 ### Optional Configurations

--- a/metaphor/snowflake/auth.py
+++ b/metaphor/snowflake/auth.py
@@ -24,10 +24,19 @@ METAPHOR_DATA_SNOWFLAKE_CONNECTOR = "MetaphorData_SnowflakeConnector"
 class SnowflakeKeyPairAuthConfig:
     """Config for key pair authentication"""
 
-    key_file: str
+    # path to the PEM key file
+    key_file: Optional[str] = None
+
+    # raw content of the PEM key file
+    key_data: Optional[str] = None
 
     # provide decryption passphrase if private key is encrypted
     passphrase: Optional[str] = None
+
+    @root_validator
+    def have_key_file_or_key_content(cls, values):
+        must_set_exactly_one(values, ["key_file", "key_data"])
+        return values
 
 
 @dataclass
@@ -69,10 +78,17 @@ def connect(config: SnowflakeAuthConfig) -> snowflake.connector.SnowflakeConnect
             else None
         )
 
-        with open(config.private_key.key_file, "rb") as f:
-            p_key = serialization.load_pem_private_key(
-                f.read(), password=passphrase, backend=default_backend()
-            )
+        # Read the private key data from a key file or source directly from the config
+        key_data = None
+        if config.private_key.key_file:
+            with open(config.private_key.key_file, "rb") as f:
+                key_data = f.read()
+        elif config.private_key.key_data:
+            key_data = bytes(config.private_key.key_data, "utf-8")
+
+        p_key = serialization.load_pem_private_key(
+            key_data, password=passphrase, backend=default_backend()
+        )
 
         pkb = p_key.private_bytes(
             encoding=serialization.Encoding.DER,

--- a/metaphor/snowflake/auth.py
+++ b/metaphor/snowflake/auth.py
@@ -85,6 +85,8 @@ def connect(config: SnowflakeAuthConfig) -> snowflake.connector.SnowflakeConnect
                 key_data = f.read()
         elif config.private_key.key_data:
             key_data = bytes(config.private_key.key_data, "utf-8")
+        else:
+            raise ValueError("No private key file or data specified")
 
         p_key = serialization.load_pem_private_key(
             key_data, password=passphrase, backend=default_backend()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.148"
+version = "0.11.149"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Sometimes it's more convenient to specify the content of the private key directly in the config file, instead of pointing it to an external file.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Tested end-to-end against a production instance.
