### PR TITLE
Add a base_url config to support dbt Cloud Single Tenancy

### DIFF
--- a/metaphor/dbt/cloud/README.md
+++ b/metaphor/dbt/cloud/README.md
@@ -25,6 +25,16 @@ You can extract `account_id` & `job_id` from a particular dbt job's URL, which h
 
 See [Output Config](../common/docs/output.md) for more information on `output`.
 
+### Optional Configurations
+
+#### Base URL
+
+If you're using dbt [Single Tenancy](https://docs.getdbt.com/docs/cloud/about-cloud/tenancy#single-tenant), you'll also need to specify a different base URL:
+
+```yaml
+base_url: https://cloud.<tenant>.getdbt.com
+```
+
 ## Testing
 
 Follow the [Installation](../../README.md) instructions to install `metaphor-connectors` in your environment (or virtualenv). Make sure to include either `all` or `dbt` extra.

--- a/metaphor/dbt/cloud/config.py
+++ b/metaphor/dbt/cloud/config.py
@@ -23,3 +23,6 @@ class DbtCloudConfig(BaseConfig):
 
     # map meta field to tags
     meta_tags: List[MetaTag] = dataclass_field(default_factory=lambda: [])
+
+    # Base URL for dbt instance
+    base_url: str = "https://cloud.getdbt.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.149"
+version = "0.11.150"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/dbt/cloud/config.yml
+++ b/tests/dbt/cloud/config.yml
@@ -2,4 +2,5 @@
 account_id: 1234
 job_id: 5678
 service_token: token
+base_url: https://cloud.metaphor.getdbt.com
 output: {}

--- a/tests/dbt/cloud/test_config.py
+++ b/tests/dbt/cloud/test_config.py
@@ -9,5 +9,6 @@ def test_yaml_config(test_root_dir):
         account_id=1234,
         job_id=5678,
         service_token="token",
+        base_url="https://cloud.metaphor.getdbt.com",
         output=OutputConfig(),
     )

--- a/tests/dbt/cloud/test_extractor.py
+++ b/tests/dbt/cloud/test_extractor.py
@@ -34,16 +34,23 @@ async def test_extractor(test_root_dir):
             output=OutputConfig(),
             account_id=1111,
             job_id=2222,
+            base_url="https://cloud.metaphor.getdbt.com",
             service_token="service_token",
         )
         extractor = DbtCloudExtractor(config)
         await extractor.extract()
 
+        mock_client_class.assert_called_once_with(
+            base_url="https://cloud.metaphor.getdbt.com",
+            account_id=1111,
+            service_token="service_token",
+        )
+
         mock_dbt_extractor_class.assert_called_once_with(
             DbtRunConfig(
                 manifest="tempfile",
                 account="snowflake_account",
-                docs_base_url="https://cloud.getdbt.com/accounts/1111/jobs/2222/docs",
+                docs_base_url="https://cloud.metaphor.getdbt.com/accounts/1111/jobs/2222/docs",
                 output=OutputConfig(),
             )
         )


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

The Admin API & Docs URLs are different for [dbt Single Tenant](https://docs.getdbt.com/docs/cloud/about-cloud/tenancy#single-tenant).

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Tested against a production instance.
