### PR TITLE
Normalize PrivateLink Snowflake account names for dbt & FiveTran

### DIFF
--- a/metaphor/common/snowflake.py
+++ b/metaphor/common/snowflake.py
@@ -1,0 +1,14 @@
+PRIVATE_LINK_SUFFIX = ".privatelink"
+
+
+def normalize_snowflake_account(account: str) -> str:
+    """
+    Normalize different variations of Snowflake account.
+    See https://docs.snowflake.com/en/user-guide/admin-account-identifier
+    """
+
+    # Strip PrivateLink suffix
+    if account.endswith(PRIVATE_LINK_SUFFIX):
+        return account[: -len(PRIVATE_LINK_SUFFIX)]
+
+    return account

--- a/metaphor/dbt/catalog_parser_v1.py
+++ b/metaphor/dbt/catalog_parser_v1.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Dict
 
 from metaphor.common.logger import get_logger
+from metaphor.common.snowflake import normalize_snowflake_account
 from metaphor.dbt.config import DbtRunConfig
 from metaphor.dbt.generated.dbt_catalog_v1 import CatalogTable, DbtCatalog
 from metaphor.dbt.util import (
@@ -36,10 +37,13 @@ class CatalogParserV1:
         virtual_views: Dict[str, VirtualView],
     ):
         self._platform = platform
-        self._account = config.account
         self._docs_base_url = config.docs_base_url
         self._datasets = datasets
         self._virtual_views = virtual_views
+
+        self._account = config.account
+        if self._account and platform == DataPlatform.SNOWFLAKE:
+            self._account = normalize_snowflake_account(self._account)
 
     def parse(self, catalog_file: str) -> None:
         try:

--- a/metaphor/dbt/manifest_parser.py
+++ b/metaphor/dbt/manifest_parser.py
@@ -4,6 +4,7 @@ from pydantic.utils import unique_list
 
 from metaphor.common.entity_id import EntityId
 from metaphor.common.logger import get_logger
+from metaphor.common.snowflake import normalize_snowflake_account
 from metaphor.dbt.config import DbtRunConfig
 from metaphor.dbt.util import (
     build_metric_docs_url,
@@ -204,7 +205,6 @@ class ManifestParser:
         metrics: Dict[str, Metric],
     ):
         self._platform = platform
-        self._account = config.account
         self._docs_base_url = config.docs_base_url
         self._project_source_url = config.project_source_url
         self._meta_ownerships = config.meta_ownerships
@@ -212,6 +212,10 @@ class ManifestParser:
         self._datasets = datasets
         self._virtual_views = virtual_views
         self._metrics = metrics
+
+        self._account = config.account
+        if self._account and platform == DataPlatform.SNOWFLAKE:
+            self._account = normalize_snowflake_account(self._account)
 
     def parse(self, manifest_json: Dict) -> None:
         manifest_metadata = manifest_json.get("metadata", {})

--- a/metaphor/fivetran/extractor.py
+++ b/metaphor/fivetran/extractor.py
@@ -12,6 +12,7 @@ from metaphor.common.entity_id import (
 )
 from metaphor.common.event_util import ENTITY_TYPES
 from metaphor.common.logger import get_logger
+from metaphor.common.snowflake import normalize_snowflake_account
 from metaphor.fivetran.config import FivetranRunConfig
 from metaphor.fivetran.models import (
     ConnectorPayload,
@@ -313,7 +314,8 @@ class FivetranExtractor(BaseExtractor):
             return None
 
         # remove snowflakecomputing.com parts
-        return ".".join(host.split(".")[:-2])
+        account = ".".join(host.split(".")[:-2])
+        return normalize_snowflake_account(account)
 
     def get_database_name_from_destination(
         self, destination: DestinationPayload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.150"
+version = "0.11.151"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/common/test_snowflake.py
+++ b/tests/common/test_snowflake.py
@@ -1,0 +1,7 @@
+from metaphor.common.snowflake import normalize_snowflake_account
+
+
+def test_normalize_snowflake_account():
+    assert normalize_snowflake_account("org-acc") == "org-acc"
+    assert normalize_snowflake_account("org.us-west-1") == "org.us-west-1"
+    assert normalize_snowflake_account("foo.privatelink") == "foo"


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Some systems (e.g. dbt & Fivetran) support [Snowflake PrivateLink](https://docs.snowflake.com/en/user-guide/admin-security-privatelink) and use the PrivateLink version of the account name (i.e. `<normal_account_name>.privatelink`). This can cause issues when matching datasets across systems.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Added `normalize_snowflake_account` function that is currently limited to stripping the `.privatelink` suffix from the account name. Will address any other variations listed in https://docs.snowflake.com/en/user-guide/admin-account-identifier#label-account-name in future PRs.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Tested against a production instance and manually verified the MCEs.