### PR TITLE
[Tableau] Output placeholder upstream datasets in MCE

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.152"
+version = "0.11.153"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/tableau/expected.json
+++ b/tests/tableau/expected.json
@@ -69,5 +69,24 @@
         "DATASET~5375BC53A82C65FD48653B9418094BB0"
       ]
     }
+  },
+  {
+    "logicalId": {
+      "name": "db.schema.table",
+      "platform": "BIGQUERY"
+    }
+  },
+  {
+    "logicalId": {
+      "account": "snow",
+      "name": "dev_db.london.cycle",
+      "platform": "SNOWFLAKE"
+    }
+  },
+  {
+    "logicalId": {
+      "name": "acme.berlin_bicycles.cycle_hire",
+      "platform": "REDSHIFT"
+    }
   }
 ]

--- a/tests/tableau/test_extractor.py
+++ b/tests/tableau/test_extractor.py
@@ -121,7 +121,7 @@ def test_extract_workbook_id():
     )
 
 
-def test_parse_dataset_id():
+def test_parse_database_table():
     extractor = TableauExtractor(dummy_config())
 
     assert (


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Currently the connector reference upstream datasets using entity IDs hoping that the datasets have already been created by the corresponding dataset connector (e.g. Snowflake, BigQuery, etc.). However, this can become confusing and very difficult to debug for the users. It'd be better to create placeholder datasets so at least they show up in the lineage. 

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Tested against a production instance and verified the MCEs manually.
