### PR TITLE
[dbt] Filter out empty tags

### DIFF
--- a/metaphor/common/utils.py
+++ b/metaphor/common/utils.py
@@ -15,6 +15,10 @@ def unique_list(non_unique_list: list) -> list:
     return list(dict.fromkeys(non_unique_list))
 
 
+def filter_empty_strings(original_list: list) -> list:
+    return list(filter(lambda e: len(e) > 0, original_list))
+
+
 def chunks(list, n):
     """Yield successive n-sized chunks from the list."""
     for i in range(0, len(list), n):

--- a/metaphor/dbt/manifest_parser.py
+++ b/metaphor/dbt/manifest_parser.py
@@ -5,6 +5,7 @@ from pydantic.utils import unique_list
 from metaphor.common.entity_id import EntityId
 from metaphor.common.logger import get_logger
 from metaphor.common.snowflake import normalize_snowflake_account
+from metaphor.common.utils import filter_empty_strings
 from metaphor.dbt.config import DbtRunConfig
 from metaphor.dbt.util import (
     build_metric_docs_url,
@@ -359,7 +360,7 @@ class ManifestParser:
                 self._project_source_url, model.original_file_path
             ),
             docs_url=build_model_docs_url(self._docs_base_url, model.unique_id),
-            tags=model.tags,
+            tags=filter_empty_strings(model.tags) if model.tags is not None else None,
             fields=[],
         )
         dbt_model = virtual_view.dbt_model
@@ -607,7 +608,7 @@ class ManifestParser:
             package_name=metric.package_name,
             description=metric.description or None,
             label=metric.label,
-            tags=metric.tags,
+            tags=filter_empty_strings(metric.tags) if metric.tags is not None else None,
             timestamp=metric.timestamp,
             time_grains=metric.time_grains,
             dimensions=metric.dimensions,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.153"
+version = "0.11.154"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -4,7 +4,11 @@ import pytest
 import pytz
 from freezegun import freeze_time
 
-from metaphor.common.utils import must_set_exactly_one, start_of_day
+from metaphor.common.utils import (
+    filter_empty_strings,
+    must_set_exactly_one,
+    start_of_day,
+)
 
 
 @freeze_time("2020-01-10")
@@ -26,3 +30,9 @@ def test_must_set_exactly_one():
 
     with pytest.raises(ValueError):
         must_set_exactly_one({"foo": 1, "bar": 1}, ["foo", "bar"])
+
+
+def test_filter_empty_strings():
+    assert filter_empty_strings(["", "", ""]) == []
+    assert filter_empty_strings(["foo", "", "bar"]) == ["foo", "bar"]
+    assert filter_empty_strings(["foo", "bar", "baz"]) == ["foo", "bar", "baz"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Seems like it's possible to specify empty tags in older versions of dbt. We should filter these out when creating the MCEs.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Added `filter_empty_strings` util method to filter out empty tags.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified against a production instance.