### PR TITLE
Use size-based chunking when spliting MCE files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.156"
+version = "0.11.157"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/common/test_file_sink.py
+++ b/tests/common/test_file_sink.py
@@ -30,7 +30,8 @@ def test_file_sink_no_split(test_root_dir):
         MetadataChangeEvent(person=Person(logical_id=PersonLogicalID("foo2@bar.com"))),
     ]
 
-    sink = FileSink(FileSinkConfig(directory=directory, batch_size=2))
+    # Set batch_size_bytes so large that all messages can fit in the same file
+    sink = FileSink(FileSinkConfig(directory=directory, batch_size_bytes=1000000))
     assert sink.sink(messages) is True
     assert messages == events_from_json(f"{directory}/946684800/1-of-1.json")
 
@@ -47,11 +48,14 @@ def test_file_sink_split(test_root_dir):
         MetadataChangeEvent(person=Person(logical_id=PersonLogicalID("foo5@bar.com"))),
     ]
 
-    sink = FileSink(FileSinkConfig(directory=directory, batch_size=2))
+    # Set batch_size_bytes so small that only one message can be fit in each file
+    sink = FileSink(FileSinkConfig(directory=directory, batch_size_bytes=10))
     assert sink.sink(messages) is True
-    assert messages[0:2] == events_from_json(f"{directory}/946684800/1-of-3.json")
-    assert messages[2:4] == events_from_json(f"{directory}/946684800/2-of-3.json")
-    assert messages[4:] == events_from_json(f"{directory}/946684800/3-of-3.json")
+    assert messages[0:1] == events_from_json(f"{directory}/946684800/1-of-5.json")
+    assert messages[1:2] == events_from_json(f"{directory}/946684800/2-of-5.json")
+    assert messages[2:3] == events_from_json(f"{directory}/946684800/3-of-5.json")
+    assert messages[3:4] == events_from_json(f"{directory}/946684800/4-of-5.json")
+    assert messages[4:5] == events_from_json(f"{directory}/946684800/5-of-5.json")
 
 
 @freeze_time("2000-01-01")

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -5,6 +5,7 @@ import pytz
 from freezegun import freeze_time
 
 from metaphor.common.utils import (
+    chunk_by_size,
     filter_empty_strings,
     must_set_exactly_one,
     start_of_day,
@@ -36,3 +37,34 @@ def test_filter_empty_strings():
     assert filter_empty_strings(["", "", ""]) == []
     assert filter_empty_strings(["foo", "", "bar"]) == ["foo", "bar"]
     assert filter_empty_strings(["foo", "bar", "baz"]) == ["foo", "bar", "baz"]
+
+
+def test_chunk_by_size():
+
+    # Each item has the same size as chunk_size
+    assert chunk_by_size([1, 2, 3], 1, lambda item: 1) == [
+        slice(0, 1),
+        slice(1, 2),
+        slice(2, 3),
+    ]
+
+    # Each item is smaller than chunk_size but adjacent pairs are too large
+    assert chunk_by_size([1, 2, 3], 3, lambda item: 2) == [
+        slice(0, 1),
+        slice(1, 2),
+        slice(2, 3),
+    ]
+
+    # Each item is larger than chunk_size
+    assert chunk_by_size([1, 2, 3], 1, lambda item: 2) == [
+        slice(0, 1),
+        slice(1, 2),
+        slice(2, 3),
+    ]
+
+    # Each pair of items adds up to the chunk size
+    assert chunk_by_size([1, 2, 3, 4, 5], 2, lambda item: 1) == [
+        slice(0, 2),
+        slice(2, 4),
+        slice(4, 5),
+    ]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

The current size-based chunking can lead to large files (100's of MB) for large individual items. These large files are slow to process and can also lead to OOM issues.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Add a `batch_size_bytes` config to replace `batch_size`
- Add a generic `chunk_by_size` util method
- Update `FileSink` to chunk output by the size JSON-serialized string

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Tested against a production instance:

<img width="742" alt="Screenshot 2023-05-26 at 12 08 04 PM" src="https://github.com/MetaphorData/connectors/assets/24240669/6905f467-d00c-47e0-8c9a-e13729ab2f46">


