### PR TITLE
Add a per-chunk item count limit to chunk_by_size

### DIFF
--- a/metaphor/common/utils.py
+++ b/metaphor/common/utils.py
@@ -47,16 +47,21 @@ def to_utc_time(time: datetime) -> datetime:
 
 
 def chunk_by_size(
-    list_to_chunk: list, chunk_size: int, size_func: Callable[[Any], int]
+    list_to_chunk: list,
+    items_per_chunk: int,
+    chunk_size: int,
+    size_func: Callable[[Any], int],
 ) -> List[slice]:
-    """Split a list into the minimum number of chunks smaller than chunk_size
+    """Split a list into chunks based on specified limits
 
-    Normally each chunk is packed with as many successive items as
-    possible without exceeding the chunk_size. However, if a single
-    item is larger than chunk_size, it'll be put into its own chunk.
+    Normally each chunk is packed with as many successive items as possible
+    without exceeding items_per_chunk & chunk_size. However, if a single item
+    is larger than chunk_size, it'll be put into its own chunk.
 
     Parameters
     ----------
+    items_per_chunk:
+        Maximum number of items in a chunk
     list_to_chunk : list
         The list to be chunked
     chunk_size : int
@@ -74,6 +79,12 @@ def chunk_by_size(
     slices: List[slice] = []
     slice_size = 0
     for index, item in enumerate(list_to_chunk):
+        # Create a chunk if there's enough items already
+        if index - start >= items_per_chunk:
+            slices.append(slice(start, index))
+            start = index
+            slice_size = 0
+
         item_size = size_func(item)
         slice_size += item_size
         if slice_size > chunk_size:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.157"
+version = "0.11.158"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -41,30 +41,48 @@ def test_filter_empty_strings():
 
 def test_chunk_by_size():
 
-    # Each item has the same size as chunk_size
-    assert chunk_by_size([1, 2, 3], 1, lambda item: 1) == [
-        slice(0, 1),
-        slice(1, 2),
-        slice(2, 3),
+    # Return length of item as size
+    def size_func(item):
+        return len(item)
+
+    # Each item fits into a chunk exactly
+    assert chunk_by_size(["a", "b", "c"], 10, 1, size_func) == [
+        slice(0, 1),  # ['a']
+        slice(1, 2),  # ['b']
+        slice(2, 3),  # ['c']
     ]
 
     # Each item is smaller than chunk_size but adjacent pairs are too large
-    assert chunk_by_size([1, 2, 3], 3, lambda item: 2) == [
-        slice(0, 1),
-        slice(1, 2),
-        slice(2, 3),
+    assert chunk_by_size(["aa", "bb", "cc"], 10, 3, size_func) == [
+        slice(0, 1),  # ['aa']
+        slice(1, 2),  # ['bb']
+        slice(2, 3),  # ['cc']
     ]
 
     # Each item is larger than chunk_size
-    assert chunk_by_size([1, 2, 3], 1, lambda item: 2) == [
-        slice(0, 1),
-        slice(1, 2),
-        slice(2, 3),
+    assert chunk_by_size(["aa", "bb", "cc"], 10, 1, size_func) == [
+        slice(0, 1),  # ['aa']
+        slice(1, 2),  # ['bb']
+        slice(2, 3),  # ['cc']
     ]
 
     # Each pair of items adds up to the chunk size
-    assert chunk_by_size([1, 2, 3, 4, 5], 2, lambda item: 1) == [
-        slice(0, 2),
-        slice(2, 4),
-        slice(4, 5),
+    assert chunk_by_size(["a", "b", "c", "d", "e"], 10, 2, size_func) == [
+        slice(0, 2),  # ['a', 'b']
+        slice(2, 4),  # ['c', 'd']
+        slice(4, 5),  # ['e']
+    ]
+
+    # Can fit all items into a chunk but limited by items_per_chunk
+    assert chunk_by_size(["a", "b", "c", "d", "e"], 3, 10, size_func) == [
+        slice(0, 3),  # ['a', 'b', 'c']
+        slice(3, 5),  # ['d', 'e']
+    ]
+
+    # A complex case that limits the chunk by both size & count
+    assert chunk_by_size(["aa", "b", "c", "d", "eee", "ffff"], 2, 3, size_func) == [
+        slice(0, 2),  # ['aa', 'b']
+        slice(2, 4),  # ['c', 'd']
+        slice(4, 5),  # ['eee']
+        slice(5, 6),  # ['ffff']
     ]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

https://github.com/MetaphorData/connectors/pull/509 changed from count-based chunking to size-based chunking. While it works for most cases, it can lead to various ingestion difficulties (OOM, slow processing) when a file contains a large number of small records.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled. Added a `batch_size_count` config to control the maximum number of records in each MCE file.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Tested against a production instance with a `batch_size_count` of 40.

```
2023-05-27 10:46:24:INFO:metaphor:Ended running with RunStatus.SUCCESS at 2023-05-27 10:46:24.344648, fetched 163 entities, took 13.5s
2023-05-27 10:46:24:INFO:metaphor:Written 1-of-5.json (40 records)
2023-05-27 10:46:24:INFO:metaphor:Written 2-of-5.json (40 records)
2023-05-27 10:46:24:INFO:metaphor:Written 3-of-5.json (40 records)
2023-05-27 10:46:24:INFO:metaphor:Written 4-of-5.json (40 records)
2023-05-27 10:46:24:INFO:metaphor:Written 5-of-5.json (3 records)
2023-05-27 10:46:24:INFO:metaphor:Written 5 MCE files
```
