### PR TITLE
[ThoughtSpot] Column' object has no attribute 'expression'

### DIFF
--- a/metaphor/thought_spot/utils.py
+++ b/metaphor/thought_spot/utils.py
@@ -1,6 +1,7 @@
 from typing import Callable, Dict, Iterable, List, Optional, TypeVar
 
 from pydantic import parse_obj_as
+from sqllineage.core.models import Column
 from thoughtspot_rest_api_v1 import TSRestApiV2
 
 from metaphor.common.logger import get_logger, json_dump_to_debug_file
@@ -260,3 +261,11 @@ class ThoughtSpot:
                     return sql_query.get("sql_query")
 
         return None
+
+
+def getColumnTransformation(target_column: Column) -> Optional[str]:
+    if not hasattr(target_column, "expression"):
+        return None
+    if target_column.expression is None or target_column.expression.token is None:
+        return None
+    return str(target_column.expression.token)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.158"
+version = "0.11.159"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

ThoughtSpot crawler cannot handle complex case of column lineage, this PR will catch the error to keep crawler running.

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

- Only get expression if possible, fill `None` otherwise
- Move `get_column_lineage` in try...catch

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

Test against production env.

<!--
  Describe how the change was tested end-to-end.
-->
