### PR TITLE
Fivetran crawler should create "placeholder nodes" for systems that are natively supported.

### DIFF
--- a/metaphor/fivetran/extractor.py
+++ b/metaphor/fivetran/extractor.py
@@ -121,6 +121,7 @@ class FivetranExtractor(BaseExtractor):
         self._auth = HTTPBasicAuth(username=config.api_key, password=config.api_secret)
         self._destinations: Dict[str, DestinationPayload] = {}
         self._datasets: Dict[str, Dataset] = {}
+        self._source_datasets: Dict[str, Dataset] = {}
         self._source_metadata: Dict[str, SourceMetadataPayload] = {}
         self._users: Dict[str, str] = {}
         self._base_url = "https://api.fivetran.com/v1"
@@ -144,7 +145,7 @@ class FivetranExtractor(BaseExtractor):
 
             self.map_to_datasets(connector, connector_schema_metadata)
 
-        return self._datasets.values()
+        return [*self._datasets.values(), *self._source_datasets.values()]
 
     def process_metadata(
         self,
@@ -279,8 +280,13 @@ class FivetranExtractor(BaseExtractor):
             source_logical_id = self._get_source_logical_id(
                 source_db, schema, table, connector
             )
+
             source_entity_id = str(
                 to_dataset_entity_id_from_logical_id(source_logical_id)
+            )
+
+            self._source_datasets[source_entity_id] = Dataset(
+                logical_id=source_logical_id
             )
 
             dataset.upstream.source_datasets = [source_entity_id]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.159"
+version = "0.11.160"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/fivetran/expected.json
+++ b/tests/fivetran/expected.json
@@ -262,5 +262,19 @@
         "DATASET~F31B21D3EDB9FF855528E9D6679840C7"
       ]
     }
+  },
+  {
+    "logicalId": {
+      "account": "source_account",
+      "name": "source_db.schema.table",
+      "platform": "SNOWFLAKE"
+    }
+  },
+  {
+    "logicalId": {
+      "account": "source_account",
+      "name": "source_db.schema.table2",
+      "platform": "SNOWFLAKE"
+    }
   }
 ]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

To complete the lineage for known platform when we don't have the corresponding crawler, for example, SQL server.

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

- Add dummy dataset for source.

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

Update tests

<!--
  Describe how the change was tested end-to-end.
-->
