### PR TITLE
[Snowflake] Make sure upstream datasets contain only unique IDs

### DIFF
--- a/metaphor/snowflake/lineage/extractor.py
+++ b/metaphor/snowflake/lineage/extractor.py
@@ -264,9 +264,11 @@ class SnowflakeLineageExtractor(BaseExtractor):
             )
 
             if target_normalized_name in self._datasets:
-                self._datasets[target_normalized_name].upstream.source_datasets.append(
-                    source_entity_id_str
-                )
+                source_datasets = self._datasets[
+                    target_normalized_name
+                ].upstream.source_datasets
+                if source_entity_id_str not in source_datasets:
+                    source_datasets.append(source_entity_id_str)
             else:
                 self._datasets[target_normalized_name] = Dataset(
                     logical_id=target_logical_id,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.160"
+version = "0.11.161"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -9,6 +9,7 @@ from metaphor.common.utils import (
     filter_empty_strings,
     must_set_exactly_one,
     start_of_day,
+    unique_list,
 )
 
 
@@ -86,3 +87,9 @@ def test_chunk_by_size():
         slice(4, 5),  # ['eee']
         slice(5, 6),  # ['ffff']
     ]
+
+
+def test_unique_list():
+    assert unique_list(["a", "b", "c"]) == ["a", "b", "c"]
+    assert unique_list(["a", "a", "c"]) == ["a", "c"]
+    assert unique_list(["c", "a", "c"]) == ["c", "a"]

--- a/tests/snowflake/lineage/test_extractor.py
+++ b/tests/snowflake/lineage/test_extractor.py
@@ -126,6 +126,8 @@ def test_parse_object_dependencies(test_root_dir):
         ("ACME", "METAPHOR", "FOO", "TABLE", "ACME", "METAPHOR", "BAR", "VIEW"),
         ("ACME", "METAPHOR", "ABC", "TABLE", "ACME", "METAPHOR", "XYZ", "VIEW"),
         ("ACME", "METAPHOR", "F", "TABLE", "ACME", "METAPHOR", "B", "STAGE"),
+        # OBJECT_DEPENDENCIES can contain repeated rows
+        ("ACME", "METAPHOR", "FOO", "TABLE", "ACME", "METAPHOR", "BAR", "VIEW"),
     ]
 
     with patch("metaphor.snowflake.auth.connect"):


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Encountered the following error when ingesting Snowflake Lineage: 

```
MCE parsing error Error: Class MetadataChangeEvent2 validation error:  "sourceDatasets" is not a valid unique array of entity IDs
```

Turns out that Snowflake's [OBJECT_DEPENDENCY view](https://docs.snowflake.com/en/sql-reference/account-usage/object_dependencies) can contain rows with repeated content, leading to the same IDs added to `source_datasets` field multiple times.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Make sure the entity ID is unique before appending it to `source_datasets` in `_parse_object_dependencies`.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified against a production instance