### PR TITLE
Fivetran validation error

### DIFF
--- a/metaphor/fivetran/extractor.py
+++ b/metaphor/fivetran/extractor.py
@@ -434,8 +434,6 @@ class FivetranExtractor(BaseExtractor):
         result: List[DataT] = []
         next_cursor = None
 
-        import pydantic
-
         while True:
             query = {"cursor": next_cursor, "limit": "1000"}
 
@@ -447,9 +445,6 @@ class FivetranExtractor(BaseExtractor):
                     params=query,
                 )
             except ApiError as error:
-                logger.error(error)
-                return result
-            except pydantic.ValidationError as error:
                 logger.error(error)
                 return result
 

--- a/metaphor/fivetran/extractor.py
+++ b/metaphor/fivetran/extractor.py
@@ -102,7 +102,9 @@ class TableMetadata:
 
 @dataclass
 class SchemaMetadata:
-    name_in_source: str
+    # name_in_source could be null
+    name_in_source: Optional[str]
+
     name_in_destination: str
     tables: List[TableMetadata]
 
@@ -432,6 +434,8 @@ class FivetranExtractor(BaseExtractor):
         result: List[DataT] = []
         next_cursor = None
 
+        import pydantic
+
         while True:
             query = {"cursor": next_cursor, "limit": "1000"}
 
@@ -443,6 +447,9 @@ class FivetranExtractor(BaseExtractor):
                     params=query,
                 )
             except ApiError as error:
+                logger.error(error)
+                return result
+            except pydantic.ValidationError as error:
                 logger.error(error)
                 return result
 

--- a/metaphor/fivetran/models.py
+++ b/metaphor/fivetran/models.py
@@ -24,7 +24,7 @@ class GenericResponse(GenericModel, Generic[DataT]):
 
 class MetadataSchemaPayload(BaseModel):
     id: str
-    name_in_source: str
+    name_in_source: Optional[str]
     name_in_destination: str
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.11.161"
+version = "0.11.162"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

First, turned out the "name_in_source" was optional. Second, the validation part was too strict if the model didn't match the api response, the whole crawler stop.

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

- Make the field optional, verified the output json dump file, name_in_source in `SchemaMetadata` could be null
- add `try...except` around `parse_obj_as` to add more context to log.
- Add a random string to debug file to avoid duplicated name, repeated call with different query or body.


<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

Test against production environment.

<!--
  Describe how the change was tested end-to-end.
-->
