### PR TITLE
upgrade pydantic to 1.10

### DIFF
--- a/metaphor/airflow_plugin/lineage/backend.py
+++ b/metaphor/airflow_plugin/lineage/backend.py
@@ -2,29 +2,28 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Collection, Dict, List, Optional
 
 from airflow.configuration import conf
-
-from metaphor.common.api_sink import ApiSink, ApiSinkConfig
-from metaphor.common.event_util import EventUtil
-from metaphor.common.file_sink import FileSink, FileSinkConfig
-from metaphor.common.sink import Sink
-from metaphor.common.storage import S3StorageConfig
+from airflow.lineage.backend import LineageBackend
+from pydantic.dataclasses import dataclass
 
 if TYPE_CHECKING:
     from airflow import DAG
     from airflow.models.baseoperator import BaseOperator
 
-from airflow.lineage.backend import LineageBackend
-from pydantic.dataclasses import dataclass
-
 from metaphor.airflow_plugin.lineage.entity import MetaphorDataset
+from metaphor.common.api_sink import ApiSink, ApiSinkConfig
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.common.entity_id import EntityId
+from metaphor.common.event_util import EventUtil
+from metaphor.common.file_sink import FileSink, FileSinkConfig
+from metaphor.common.sink import Sink
+from metaphor.common.storage import S3StorageConfig
 from metaphor.models.metadata_change_event import Dataset, DatasetUpstream, EntityType
 
 INGESTION_API_MODE = "ingestion-api"
 S3_MODE = "s3"
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class MetaphorBackendConfig:
     mode: str
     ingestion_url: Optional[str] = None

--- a/metaphor/airflow_plugin/lineage/backend.py
+++ b/metaphor/airflow_plugin/lineage/backend.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 from metaphor.airflow_plugin.lineage.entity import MetaphorDataset
 from metaphor.common.api_sink import ApiSink, ApiSinkConfig
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.entity_id import EntityId
 from metaphor.common.event_util import EventUtil
 from metaphor.common.file_sink import FileSink, FileSinkConfig
@@ -23,7 +23,7 @@ INGESTION_API_MODE = "ingestion-api"
 S3_MODE = "s3"
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class MetaphorBackendConfig:
     mode: str
     ingestion_url: Optional[str] = None

--- a/metaphor/bigquery/config.py
+++ b/metaphor/bigquery/config.py
@@ -5,7 +5,7 @@ from pydantic import root_validator
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.filter import DatasetFilter
 from metaphor.common.tag_matcher import TagMatcher
 from metaphor.common.utils import must_set_exactly_one
@@ -15,7 +15,7 @@ from metaphor.common.utils import must_set_exactly_one
 DEFAULT_QUERY_LOG_FETCH_SIZE = 1000
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class BigQueryCredentials:
     """Credentials used to connect to BigQuery"""
 
@@ -39,7 +39,7 @@ class BigQueryCredentials:
     token_uri: str = "https://oauth2.googleapis.com/token"
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class BigQueryQueryLogConfig:
     # Number of days back of query logs to fetch, if 0, don't fetch query logs
     lookback_days: int = 1
@@ -57,7 +57,7 @@ class BigQueryQueryLogConfig:
     fetch_job_query_if_truncated: bool = True
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class BigQueryRunConfig(BaseConfig):
     # List of project IDs to extract metadata from
     project_ids: List[str]

--- a/metaphor/bigquery/config.py
+++ b/metaphor/bigquery/config.py
@@ -5,6 +5,7 @@ from pydantic import root_validator
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.common.filter import DatasetFilter
 from metaphor.common.tag_matcher import TagMatcher
 from metaphor.common.utils import must_set_exactly_one
@@ -14,7 +15,7 @@ from metaphor.common.utils import must_set_exactly_one
 DEFAULT_QUERY_LOG_FETCH_SIZE = 1000
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class BigQueryCredentials:
     """Credentials used to connect to BigQuery"""
 
@@ -38,7 +39,7 @@ class BigQueryCredentials:
     token_uri: str = "https://oauth2.googleapis.com/token"
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class BigQueryQueryLogConfig:
     # Number of days back of query logs to fetch, if 0, don't fetch query logs
     lookback_days: int = 1
@@ -56,7 +57,7 @@ class BigQueryQueryLogConfig:
     fetch_job_query_if_truncated: bool = True
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class BigQueryRunConfig(BaseConfig):
     # List of project IDs to extract metadata from
     project_ids: List[str]

--- a/metaphor/bigquery/lineage/config.py
+++ b/metaphor/bigquery/lineage/config.py
@@ -1,9 +1,10 @@
 from pydantic.dataclasses import dataclass
 
 from metaphor.bigquery.config import BigQueryRunConfig
+from metaphor.common.dataclass import DataclassConfig
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class BigQueryLineageRunConfig(BigQueryRunConfig):
     # Whether to enable parsing view query to find upstream of the view, default True
     enable_view_lineage: bool = True

--- a/metaphor/bigquery/lineage/config.py
+++ b/metaphor/bigquery/lineage/config.py
@@ -1,10 +1,10 @@
 from pydantic.dataclasses import dataclass
 
 from metaphor.bigquery.config import BigQueryRunConfig
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class BigQueryLineageRunConfig(BigQueryRunConfig):
     # Whether to enable parsing view query to find upstream of the view, default True
     enable_view_lineage: bool = True

--- a/metaphor/bigquery/logEvent.py
+++ b/metaphor/bigquery/logEvent.py
@@ -1,12 +1,11 @@
 import logging
+from dataclasses import dataclass
 from datetime import datetime
 from typing import List, Optional
 
 from google.cloud._helpers import _rfc3339_nanos_to_datetime
-from pydantic.dataclasses import dataclass
 
 from metaphor.bigquery.utils import BigQueryResource, LogEntry
-from metaphor.common.dataclass import DataclassConfig
 from metaphor.common.logger import get_logger
 from metaphor.common.utils import unique_list
 
@@ -14,7 +13,7 @@ logger = get_logger()
 logger.setLevel(logging.INFO)
 
 
-@dataclass(config=DataclassConfig)
+@dataclass
 class JobChangeEvent:
     """
     Container class for BigQueryAuditMetadata.JobChange, where the 'after' job status is 'DONE'

--- a/metaphor/bigquery/logEvent.py
+++ b/metaphor/bigquery/logEvent.py
@@ -1,11 +1,12 @@
 import logging
-from dataclasses import dataclass
 from datetime import datetime
 from typing import List, Optional
 
 from google.cloud._helpers import _rfc3339_nanos_to_datetime
+from pydantic.dataclasses import dataclass
 
 from metaphor.bigquery.utils import BigQueryResource, LogEntry
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.common.logger import get_logger
 from metaphor.common.utils import unique_list
 
@@ -13,7 +14,7 @@ logger = get_logger()
 logger.setLevel(logging.INFO)
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class JobChangeEvent:
     """
     Container class for BigQueryAuditMetadata.JobChange, where the 'after' job status is 'DONE'

--- a/metaphor/bigquery/profile/config.py
+++ b/metaphor/bigquery/profile/config.py
@@ -4,11 +4,11 @@ from pydantic.dataclasses import dataclass
 
 from metaphor.bigquery.config import BigQueryRunConfig
 from metaphor.common.column_statistics import ColumnStatistics
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.sampling import SamplingConfig
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class BigQueryProfileRunConfig(BigQueryRunConfig):
     # Compute specific types of statistics for each column
     column_statistics: ColumnStatistics = field(

--- a/metaphor/bigquery/profile/config.py
+++ b/metaphor/bigquery/profile/config.py
@@ -4,10 +4,11 @@ from pydantic.dataclasses import dataclass
 
 from metaphor.bigquery.config import BigQueryRunConfig
 from metaphor.common.column_statistics import ColumnStatistics
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.common.sampling import SamplingConfig
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class BigQueryProfileRunConfig(BigQueryRunConfig):
     # Compute specific types of statistics for each column
     column_statistics: ColumnStatistics = field(

--- a/metaphor/bigquery/utils.py
+++ b/metaphor/bigquery/utils.py
@@ -1,5 +1,6 @@
 import json
 import re
+from dataclasses import dataclass
 from typing import Any
 
 try:
@@ -10,11 +11,9 @@ except ImportError:
     print("Please install metaphor[bigquery] extra\n")
     raise
 
-from pydantic.dataclasses import dataclass
 from smart_open import open
 
 from metaphor.bigquery.config import BigQueryRunConfig
-from metaphor.common.dataclass import DataclassConfig
 
 # ProtobufEntry is a namedtuple and attribute assigned dynamically with different type, mypy fail here
 # See: https://googleapis.dev/python/logging/latest/client.html#google.cloud.logging_v2.client.Client.list_entries
@@ -67,7 +66,7 @@ SNAPSHOT_TABLE_REGEX = re.compile(r"^(.+)@(\d{13})$")
 INVALID_TABLE_NAME_CHAR = ["$", "@"]
 
 
-@dataclass(config=DataclassConfig)
+@dataclass
 class BigQueryResource:
     project_id: str
     dataset_id: str

--- a/metaphor/bigquery/utils.py
+++ b/metaphor/bigquery/utils.py
@@ -1,11 +1,6 @@
 import json
 import re
-from dataclasses import dataclass
 from typing import Any
-
-from smart_open import open
-
-from metaphor.bigquery.config import BigQueryRunConfig
 
 try:
     import google.cloud.bigquery as bigquery
@@ -15,6 +10,11 @@ except ImportError:
     print("Please install metaphor[bigquery] extra\n")
     raise
 
+from pydantic.dataclasses import dataclass
+from smart_open import open
+
+from metaphor.bigquery.config import BigQueryRunConfig
+from metaphor.common.dataclass import DataclassConfig
 
 # ProtobufEntry is a namedtuple and attribute assigned dynamically with different type, mypy fail here
 # See: https://googleapis.dev/python/logging/latest/client.html#google.cloud.logging_v2.client.Client.list_entries
@@ -67,7 +67,7 @@ SNAPSHOT_TABLE_REGEX = re.compile(r"^(.+)@(\d{13})$")
 INVALID_TABLE_NAME_CHAR = ["$", "@"]
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class BigQueryResource:
     project_id: str
     dataset_id: str

--- a/metaphor/common/api_sink.py
+++ b/metaphor/common/api_sink.py
@@ -5,13 +5,14 @@ from typing import List
 from pydantic.dataclasses import dataclass
 from requests import HTTPError, post
 
+from .dataclass import DataclassConfig
 from .sink import Sink
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class ApiSinkConfig:
     url: str
     api_key: str

--- a/metaphor/common/api_sink.py
+++ b/metaphor/common/api_sink.py
@@ -5,14 +5,14 @@ from typing import List
 from pydantic.dataclasses import dataclass
 from requests import HTTPError, post
 
-from .dataclass import DataclassConfig
+from .dataclass import ConnectorConfig
 from .sink import Sink
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class ApiSinkConfig:
     url: str
     api_key: str

--- a/metaphor/common/base_config.py
+++ b/metaphor/common/base_config.py
@@ -6,6 +6,7 @@ from pydantic.dataclasses import dataclass
 from smart_open import open
 
 from metaphor.common.api_sink import ApiSinkConfig
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.common.file_sink import FileSinkConfig
 from metaphor.common.variable import variable_substitution
 
@@ -13,7 +14,7 @@ from metaphor.common.variable import variable_substitution
 T = TypeVar("T", bound="BaseConfig")
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class OutputConfig:
     """Config for where to output the data"""
 
@@ -21,7 +22,7 @@ class OutputConfig:
     file: Optional[FileSinkConfig] = None
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class BaseConfig:
     """Base class for runtime parameters
 

--- a/metaphor/common/base_config.py
+++ b/metaphor/common/base_config.py
@@ -6,7 +6,7 @@ from pydantic.dataclasses import dataclass
 from smart_open import open
 
 from metaphor.common.api_sink import ApiSinkConfig
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.file_sink import FileSinkConfig
 from metaphor.common.variable import variable_substitution
 
@@ -14,7 +14,7 @@ from metaphor.common.variable import variable_substitution
 T = TypeVar("T", bound="BaseConfig")
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class OutputConfig:
     """Config for where to output the data"""
 
@@ -22,7 +22,7 @@ class OutputConfig:
     file: Optional[FileSinkConfig] = None
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class BaseConfig:
     """Base class for runtime parameters
 

--- a/metaphor/common/column_statistics.py
+++ b/metaphor/common/column_statistics.py
@@ -1,7 +1,9 @@
 from pydantic.dataclasses import dataclass
 
+from metaphor.common.dataclass import DataclassConfig
 
-@dataclass
+
+@dataclass(config=DataclassConfig)
 class ColumnStatistics:
     # Compute null and non-null counts
     null_count: bool = True

--- a/metaphor/common/column_statistics.py
+++ b/metaphor/common/column_statistics.py
@@ -1,9 +1,9 @@
 from pydantic.dataclasses import dataclass
 
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class ColumnStatistics:
     # Compute null and non-null counts
     null_count: bool = True

--- a/metaphor/common/dataclass.py
+++ b/metaphor/common/dataclass.py
@@ -1,0 +1,10 @@
+from pydantic import Extra
+
+
+class DataclassConfig:
+    """
+    Config for pydantic dataclass and BaseModel
+    """
+
+    validate_all = True
+    extra = Extra.forbid

--- a/metaphor/common/dataclass.py
+++ b/metaphor/common/dataclass.py
@@ -1,9 +1,9 @@
 from pydantic import Extra
 
 
-class DataclassConfig:
+class ConnectorConfig:
     """
-    Config for pydantic dataclass and BaseModel
+    Pydantic dataclass Config for metaphor connector configurations
     """
 
     validate_all = True

--- a/metaphor/common/entity_id.py
+++ b/metaphor/common/entity_id.py
@@ -3,6 +3,7 @@ from typing import Optional, Union
 from canonicaljson import encode_canonical_json
 from pydantic.dataclasses import dataclass
 
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.common.event_util import EventUtil
 from metaphor.common.utils import md5_digest
 from metaphor.models.metadata_change_event import (
@@ -18,7 +19,7 @@ from metaphor.models.metadata_change_event import (
 )
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class EntityId:
     type: EntityType
     logicalId: Union[

--- a/metaphor/common/entity_id.py
+++ b/metaphor/common/entity_id.py
@@ -3,7 +3,7 @@ from typing import Optional, Union
 from canonicaljson import encode_canonical_json
 from pydantic.dataclasses import dataclass
 
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.event_util import EventUtil
 from metaphor.common.utils import md5_digest
 from metaphor.models.metadata_change_event import (
@@ -19,7 +19,7 @@ from metaphor.models.metadata_change_event import (
 )
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class EntityId:
     type: EntityType
     logicalId: Union[

--- a/metaphor/common/file_sink.py
+++ b/metaphor/common/file_sink.py
@@ -9,6 +9,7 @@ from zipfile import ZIP_DEFLATED, ZipFile
 
 from pydantic.dataclasses import dataclass
 
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.common.event_util import EventUtil
 from metaphor.common.logger import LOG_FILE, debug_files, get_logger
 from metaphor.common.sink import Sink
@@ -24,7 +25,7 @@ from metaphor.models.crawler_run_metadata import CrawlerRunMetadata
 logger = get_logger()
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class FileSinkConfig:
     # Location of the sink directory, where the MCE file and logs will be output to.
     # Can be local file directory, s3://bucket/ or s3://bucket/path/

--- a/metaphor/common/file_sink.py
+++ b/metaphor/common/file_sink.py
@@ -9,7 +9,7 @@ from zipfile import ZIP_DEFLATED, ZipFile
 
 from pydantic.dataclasses import dataclass
 
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.event_util import EventUtil
 from metaphor.common.logger import LOG_FILE, debug_files, get_logger
 from metaphor.common.sink import Sink
@@ -25,7 +25,7 @@ from metaphor.models.crawler_run_metadata import CrawlerRunMetadata
 logger = get_logger()
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class FileSinkConfig:
     # Location of the sink directory, where the MCE file and logs will be output to.
     # Can be local file directory, s3://bucket/ or s3://bucket/path/

--- a/metaphor/common/filter.py
+++ b/metaphor/common/filter.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional, Set
 
 from pydantic.dataclasses import dataclass
 
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 
 TableFilter = Set[str]
 SchemaFilter = Dict[str, Optional[TableFilter]]
@@ -12,7 +12,7 @@ DatabaseFilter = Dict[str, Optional[SchemaFilter]]
 DUMMY_DATABASE_NAME = "dummy"
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class TwoLevelDatasetFilter:
     # A list of schemas/tables to include
     includes: Optional[SchemaFilter] = None
@@ -21,7 +21,7 @@ class TwoLevelDatasetFilter:
     excludes: Optional[SchemaFilter] = None
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class DatasetFilter:
     # A list of databases/schemas/tables to include
     includes: Optional[DatabaseFilter] = None

--- a/metaphor/common/filter.py
+++ b/metaphor/common/filter.py
@@ -3,6 +3,8 @@ from typing import Dict, Optional, Set
 
 from pydantic.dataclasses import dataclass
 
+from metaphor.common.dataclass import DataclassConfig
+
 TableFilter = Set[str]
 SchemaFilter = Dict[str, Optional[TableFilter]]
 DatabaseFilter = Dict[str, Optional[SchemaFilter]]
@@ -10,7 +12,7 @@ DatabaseFilter = Dict[str, Optional[SchemaFilter]]
 DUMMY_DATABASE_NAME = "dummy"
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class TwoLevelDatasetFilter:
     # A list of schemas/tables to include
     includes: Optional[SchemaFilter] = None
@@ -19,7 +21,7 @@ class TwoLevelDatasetFilter:
     excludes: Optional[SchemaFilter] = None
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class DatasetFilter:
     # A list of databases/schemas/tables to include
     includes: Optional[DatabaseFilter] = None

--- a/metaphor/common/git.py
+++ b/metaphor/common/git.py
@@ -7,10 +7,11 @@ from git import Repo
 from pydantic import root_validator
 from pydantic.dataclasses import dataclass
 
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.common.utils import must_set_exactly_one
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class GitRepoConfig:
     # Git repository URL, ending with ".git"
     git_url: str

--- a/metaphor/common/git.py
+++ b/metaphor/common/git.py
@@ -7,11 +7,11 @@ from git import Repo
 from pydantic import root_validator
 from pydantic.dataclasses import dataclass
 
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.utils import must_set_exactly_one
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class GitRepoConfig:
     # Git repository URL, ending with ".git"
     git_url: str

--- a/metaphor/common/models.py
+++ b/metaphor/common/models.py
@@ -3,6 +3,7 @@ from typing import Optional, Union
 
 from pydantic.dataclasses import dataclass
 
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.common.entity_id import normalize_full_dataset_name, to_dataset_entity_id
 from metaphor.models.metadata_change_event import (
     DataPlatform,
@@ -11,7 +12,7 @@ from metaphor.models.metadata_change_event import (
 )
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class DeserializableDatasetLogicalID:
     name: str
     platform: str

--- a/metaphor/common/models.py
+++ b/metaphor/common/models.py
@@ -3,7 +3,7 @@ from typing import Optional, Union
 
 from pydantic.dataclasses import dataclass
 
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.entity_id import normalize_full_dataset_name, to_dataset_entity_id
 from metaphor.models.metadata_change_event import (
     DataPlatform,
@@ -12,7 +12,7 @@ from metaphor.models.metadata_change_event import (
 )
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class DeserializableDatasetLogicalID:
     name: str
     platform: str

--- a/metaphor/common/sampling.py
+++ b/metaphor/common/sampling.py
@@ -1,10 +1,10 @@
 from pydantic import validator
 from pydantic.dataclasses import dataclass
 
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class SamplingConfig:
     """Config for profile connector"""
 

--- a/metaphor/common/sampling.py
+++ b/metaphor/common/sampling.py
@@ -1,8 +1,10 @@
 from pydantic import validator
 from pydantic.dataclasses import dataclass
 
+from metaphor.common.dataclass import DataclassConfig
 
-@dataclass
+
+@dataclass(config=DataclassConfig)
 class SamplingConfig:
     """Config for profile connector"""
 

--- a/metaphor/common/storage.py
+++ b/metaphor/common/storage.py
@@ -8,6 +8,7 @@ from aws_assume_role_lib import assume_role
 from pydantic.dataclasses import dataclass
 from smart_open import open
 
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.common.logger import get_logger
 
 logger = get_logger()
@@ -69,7 +70,7 @@ class LocalStorage(BaseStorage):
             os.remove(path)
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class S3StorageConfig:
     aws_access_key_id: Optional[str] = None
     aws_secret_access_key: Optional[str] = None

--- a/metaphor/common/storage.py
+++ b/metaphor/common/storage.py
@@ -8,7 +8,7 @@ from aws_assume_role_lib import assume_role
 from pydantic.dataclasses import dataclass
 from smart_open import open
 
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.logger import get_logger
 
 logger = get_logger()
@@ -70,7 +70,7 @@ class LocalStorage(BaseStorage):
             os.remove(path)
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class S3StorageConfig:
     aws_access_key_id: Optional[str] = None
     aws_secret_access_key: Optional[str] = None

--- a/metaphor/common/tag_matcher.py
+++ b/metaphor/common/tag_matcher.py
@@ -3,11 +3,12 @@ from typing import List
 
 from pydantic.dataclasses import dataclass
 
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.common.utils import unique_list
 from metaphor.models.metadata_change_event import Dataset, TagAssignment
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class TagMatcher:
     # The glob pattern to use when matching against the asset name
     pattern: str

--- a/metaphor/common/tag_matcher.py
+++ b/metaphor/common/tag_matcher.py
@@ -3,12 +3,12 @@ from typing import List
 
 from pydantic.dataclasses import dataclass
 
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.utils import unique_list
 from metaphor.models.metadata_change_event import Dataset, TagAssignment
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class TagMatcher:
     # The glob pattern to use when matching against the asset name
     pattern: str

--- a/metaphor/custom/data_quality/config.py
+++ b/metaphor/custom/data_quality/config.py
@@ -4,17 +4,18 @@ from typing import List, Optional
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_extractor import BaseConfig
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.common.models import DeserializableDatasetLogicalID
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class DataQualityMonitorTarget:
     dataset: Optional[str]
 
     column: Optional[str]
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class DataQualityMonitor:
     title: str
 
@@ -37,7 +38,7 @@ class DataQualityMonitor:
     value: Optional[float] = None
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class DataQuality:
     monitors: List[DataQualityMonitor]
 
@@ -47,13 +48,13 @@ class DataQuality:
     url: Optional[str] = None
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class DatasetDataQuality:
     id: DeserializableDatasetLogicalID
 
     data_quality: DataQuality
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class CustomDataQualityConfig(BaseConfig):
     datasets: List[DatasetDataQuality]

--- a/metaphor/custom/data_quality/config.py
+++ b/metaphor/custom/data_quality/config.py
@@ -4,18 +4,18 @@ from typing import List, Optional
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_extractor import BaseConfig
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.models import DeserializableDatasetLogicalID
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class DataQualityMonitorTarget:
     dataset: Optional[str]
 
     column: Optional[str]
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class DataQualityMonitor:
     title: str
 
@@ -38,7 +38,7 @@ class DataQualityMonitor:
     value: Optional[float] = None
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class DataQuality:
     monitors: List[DataQualityMonitor]
 
@@ -48,13 +48,13 @@ class DataQuality:
     url: Optional[str] = None
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class DatasetDataQuality:
     id: DeserializableDatasetLogicalID
 
     data_quality: DataQuality
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class CustomDataQualityConfig(BaseConfig):
     datasets: List[DatasetDataQuality]

--- a/metaphor/custom/governance/config.py
+++ b/metaphor/custom/governance/config.py
@@ -4,10 +4,11 @@ from typing import List
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_extractor import BaseConfig
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.common.models import DeserializableDatasetLogicalID
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class Ownership:
     # Type of ownership to assign
     type: str
@@ -16,7 +17,7 @@ class Ownership:
     email: str
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class ColumnTags:
     # Name of the column
     column: str
@@ -25,7 +26,7 @@ class ColumnTags:
     tags: List[str]
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class Description:
     # The description to assign
     description: str
@@ -34,7 +35,7 @@ class Description:
     email: str
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class DatasetGovernance:
     id: DeserializableDatasetLogicalID
 
@@ -47,6 +48,6 @@ class DatasetGovernance:
     descriptions: List[Description] = dataclass_field(default_factory=lambda: [])
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class CustomGovernanceConfig(BaseConfig):
     datasets: List[DatasetGovernance]

--- a/metaphor/custom/governance/config.py
+++ b/metaphor/custom/governance/config.py
@@ -4,11 +4,11 @@ from typing import List
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_extractor import BaseConfig
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.models import DeserializableDatasetLogicalID
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class Ownership:
     # Type of ownership to assign
     type: str
@@ -17,7 +17,7 @@ class Ownership:
     email: str
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class ColumnTags:
     # Name of the column
     column: str
@@ -26,7 +26,7 @@ class ColumnTags:
     tags: List[str]
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class Description:
     # The description to assign
     description: str
@@ -35,7 +35,7 @@ class Description:
     email: str
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class DatasetGovernance:
     id: DeserializableDatasetLogicalID
 
@@ -48,6 +48,6 @@ class DatasetGovernance:
     descriptions: List[Description] = dataclass_field(default_factory=lambda: [])
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class CustomGovernanceConfig(BaseConfig):
     datasets: List[DatasetGovernance]

--- a/metaphor/custom/lineage/config.py
+++ b/metaphor/custom/lineage/config.py
@@ -3,16 +3,16 @@ from typing import List
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_extractor import BaseConfig
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.models import DeserializableDatasetLogicalID
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class Lineage:
     dataset: DeserializableDatasetLogicalID
     upstreams: List[DeserializableDatasetLogicalID]
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class CustomLineageConfig(BaseConfig):
     lineages: List[Lineage]

--- a/metaphor/custom/lineage/config.py
+++ b/metaphor/custom/lineage/config.py
@@ -3,15 +3,16 @@ from typing import List
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_extractor import BaseConfig
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.common.models import DeserializableDatasetLogicalID
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class Lineage:
     dataset: DeserializableDatasetLogicalID
     upstreams: List[DeserializableDatasetLogicalID]
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class CustomLineageConfig(BaseConfig):
     lineages: List[Lineage]

--- a/metaphor/custom/metadata/config.py
+++ b/metaphor/custom/metadata/config.py
@@ -4,16 +4,17 @@ from typing import Any, Dict, List
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_extractor import BaseConfig
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.common.models import DeserializableDatasetLogicalID
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class DatasetMetadata:
     id: DeserializableDatasetLogicalID
 
     metadata: Dict[str, Any] = dataclass_field(default_factory=lambda: {})
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class CustomMetadataConfig(BaseConfig):
     datasets: List[DatasetMetadata]

--- a/metaphor/custom/metadata/config.py
+++ b/metaphor/custom/metadata/config.py
@@ -4,17 +4,17 @@ from typing import Any, Dict, List
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_extractor import BaseConfig
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.models import DeserializableDatasetLogicalID
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class DatasetMetadata:
     id: DeserializableDatasetLogicalID
 
     metadata: Dict[str, Any] = dataclass_field(default_factory=lambda: {})
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class CustomMetadataConfig(BaseConfig):
     datasets: List[DatasetMetadata]

--- a/metaphor/dbt/cloud/config.py
+++ b/metaphor/dbt/cloud/config.py
@@ -4,10 +4,11 @@ from typing import List
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.dbt.config import MetaOwnership, MetaTag
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class DbtCloudConfig(BaseConfig):
     # dbt cloud account ID
     account_id: int

--- a/metaphor/dbt/cloud/config.py
+++ b/metaphor/dbt/cloud/config.py
@@ -4,11 +4,11 @@ from typing import List
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.dbt.config import MetaOwnership, MetaTag
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class DbtCloudConfig(BaseConfig):
     # dbt cloud account ID
     account_id: int

--- a/metaphor/dbt/config.py
+++ b/metaphor/dbt/config.py
@@ -4,9 +4,10 @@ from typing import List, Optional
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
+from metaphor.common.dataclass import DataclassConfig
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class MetaOwnership:
     # Key to match in the "meta" field
     meta_key: str
@@ -18,7 +19,7 @@ class MetaOwnership:
     email_domain: Optional[str] = None
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class MetaTag:
     # Key to match in the "meta" field
     meta_key: str
@@ -30,7 +31,7 @@ class MetaTag:
     meta_value_matcher: str = "True"
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class DbtRunConfig(BaseConfig):
     manifest: str
     catalog: Optional[str] = None

--- a/metaphor/dbt/config.py
+++ b/metaphor/dbt/config.py
@@ -4,10 +4,10 @@ from typing import List, Optional
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class MetaOwnership:
     # Key to match in the "meta" field
     meta_key: str
@@ -19,7 +19,7 @@ class MetaOwnership:
     email_domain: Optional[str] = None
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class MetaTag:
     # Key to match in the "meta" field
     meta_key: str
@@ -31,7 +31,7 @@ class MetaTag:
     meta_value_matcher: str = "True"
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class DbtRunConfig(BaseConfig):
     manifest: str
     catalog: Optional[str] = None

--- a/metaphor/fivetran/config.py
+++ b/metaphor/fivetran/config.py
@@ -3,11 +3,11 @@ from dataclasses import field as dataclass_field
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.filter import DatasetFilter
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class FivetranRunConfig(BaseConfig):
     api_key: str
     api_secret: str

--- a/metaphor/fivetran/config.py
+++ b/metaphor/fivetran/config.py
@@ -3,10 +3,11 @@ from dataclasses import field as dataclass_field
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.common.filter import DatasetFilter
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class FivetranRunConfig(BaseConfig):
     api_key: str
     api_secret: str

--- a/metaphor/glue/config.py
+++ b/metaphor/glue/config.py
@@ -4,10 +4,11 @@ from typing import Optional
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.common.filter import DatasetFilter
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class AwsCredentials:
     """AWS Credentials"""
 
@@ -24,7 +25,7 @@ class AwsCredentials:
     assume_role_arn: Optional[str] = None
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class GlueRunConfig(BaseConfig):
     aws: AwsCredentials
 

--- a/metaphor/glue/config.py
+++ b/metaphor/glue/config.py
@@ -4,11 +4,11 @@ from typing import Optional
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.filter import DatasetFilter
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class AwsCredentials:
     """AWS Credentials"""
 
@@ -25,7 +25,7 @@ class AwsCredentials:
     assume_role_arn: Optional[str] = None
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class GlueRunConfig(BaseConfig):
     aws: AwsCredentials
 

--- a/metaphor/looker/config.py
+++ b/metaphor/looker/config.py
@@ -4,13 +4,13 @@ from pydantic import root_validator
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.git import GitRepoConfig
 from metaphor.common.utils import must_set_exactly_one
 from metaphor.models.metadata_change_event import DataPlatform
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class LookerConnectionConfig:
     # Database for the connection
     database: str
@@ -26,7 +26,7 @@ class LookerConnectionConfig:
     platform: DataPlatform = DataPlatform.SNOWFLAKE
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class LookerRunConfig(BaseConfig):
     base_url: str
     client_id: str

--- a/metaphor/looker/config.py
+++ b/metaphor/looker/config.py
@@ -4,12 +4,13 @@ from pydantic import root_validator
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.common.git import GitRepoConfig
 from metaphor.common.utils import must_set_exactly_one
 from metaphor.models.metadata_change_event import DataPlatform
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class LookerConnectionConfig:
     # Database for the connection
     database: str
@@ -25,7 +26,7 @@ class LookerConnectionConfig:
     platform: DataPlatform = DataPlatform.SNOWFLAKE
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class LookerRunConfig(BaseConfig):
     base_url: str
     client_id: str

--- a/metaphor/metabase/config.py
+++ b/metaphor/metabase/config.py
@@ -1,9 +1,10 @@
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
+from metaphor.common.dataclass import DataclassConfig
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class MetabaseRunConfig(BaseConfig):
     server_url: str
     username: str

--- a/metaphor/metabase/config.py
+++ b/metaphor/metabase/config.py
@@ -1,10 +1,10 @@
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class MetabaseRunConfig(BaseConfig):
     server_url: str
     username: str

--- a/metaphor/mssql/config.py
+++ b/metaphor/mssql/config.py
@@ -3,10 +3,11 @@ from dataclasses import field
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.common.filter import DatasetFilter
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class MssqlConfig(BaseConfig):
     # The database username
     username: str

--- a/metaphor/mssql/config.py
+++ b/metaphor/mssql/config.py
@@ -3,11 +3,11 @@ from dataclasses import field
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.filter import DatasetFilter
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class MssqlConfig(BaseConfig):
     # The database username
     username: str

--- a/metaphor/mysql/config.py
+++ b/metaphor/mysql/config.py
@@ -3,10 +3,11 @@ from dataclasses import field
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.common.filter import TwoLevelDatasetFilter
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class MySQLRunConfig(BaseConfig):
     host: str
     database: str

--- a/metaphor/mysql/config.py
+++ b/metaphor/mysql/config.py
@@ -3,11 +3,11 @@ from dataclasses import field
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.filter import TwoLevelDatasetFilter
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class MySQLRunConfig(BaseConfig):
     host: str
     database: str

--- a/metaphor/postgresql/config.py
+++ b/metaphor/postgresql/config.py
@@ -3,10 +3,11 @@ from dataclasses import field
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.common.filter import DatasetFilter
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class PostgreSQLRunConfig(BaseConfig):
     host: str
     database: str

--- a/metaphor/postgresql/config.py
+++ b/metaphor/postgresql/config.py
@@ -3,11 +3,11 @@ from dataclasses import field
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.filter import DatasetFilter
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class PostgreSQLRunConfig(BaseConfig):
     host: str
     database: str

--- a/metaphor/postgresql/profile/config.py
+++ b/metaphor/postgresql/profile/config.py
@@ -2,12 +2,12 @@ from dataclasses import field as dataclass_field
 
 from pydantic.dataclasses import dataclass
 
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.sampling import SamplingConfig
 from metaphor.redshift.config import PostgreSQLRunConfig
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class PostgreSQLProfileRunConfig(PostgreSQLRunConfig):
     max_concurrency = 10
 

--- a/metaphor/postgresql/profile/config.py
+++ b/metaphor/postgresql/profile/config.py
@@ -2,11 +2,12 @@ from dataclasses import field as dataclass_field
 
 from pydantic.dataclasses import dataclass
 
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.common.sampling import SamplingConfig
 from metaphor.redshift.config import PostgreSQLRunConfig
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class PostgreSQLProfileRunConfig(PostgreSQLRunConfig):
     max_concurrency = 10
 

--- a/metaphor/postgresql/usage/config.py
+++ b/metaphor/postgresql/usage/config.py
@@ -1,9 +1,9 @@
 from pydantic.dataclasses import dataclass
 
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.redshift.config import PostgreSQLRunConfig
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class PostgreSQLUsageRunConfig(PostgreSQLRunConfig):
     pass

--- a/metaphor/postgresql/usage/config.py
+++ b/metaphor/postgresql/usage/config.py
@@ -1,8 +1,9 @@
 from pydantic.dataclasses import dataclass
 
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.redshift.config import PostgreSQLRunConfig
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class PostgreSQLUsageRunConfig(PostgreSQLRunConfig):
     pass

--- a/metaphor/power_bi/config.py
+++ b/metaphor/power_bi/config.py
@@ -4,9 +4,10 @@ from typing import List, Optional
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
+from metaphor.common.dataclass import DataclassConfig
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class PowerBIRunConfig(BaseConfig):
     # Power BI Directory (tenant) ID
     tenant_id: str

--- a/metaphor/power_bi/config.py
+++ b/metaphor/power_bi/config.py
@@ -4,10 +4,10 @@ from typing import List, Optional
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class PowerBIRunConfig(BaseConfig):
     # Power BI Directory (tenant) ID
     tenant_id: str

--- a/metaphor/redshift/config.py
+++ b/metaphor/redshift/config.py
@@ -3,11 +3,12 @@ from typing import List, Set
 
 from pydantic.dataclasses import dataclass
 
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.common.tag_matcher import TagMatcher
 from metaphor.postgresql.config import PostgreSQLRunConfig
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class RedshiftQueryLogConfig:
     # Number of days back of query logs to fetch, if 0, don't fetch query logs
     lookback_days: int = 1
@@ -16,7 +17,7 @@ class RedshiftQueryLogConfig:
     excluded_usernames: Set[str] = field(default_factory=lambda: set())
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class RedshiftRunConfig(PostgreSQLRunConfig):
     port: int = 5439
 

--- a/metaphor/redshift/config.py
+++ b/metaphor/redshift/config.py
@@ -3,12 +3,12 @@ from typing import List, Set
 
 from pydantic.dataclasses import dataclass
 
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.tag_matcher import TagMatcher
 from metaphor.postgresql.config import PostgreSQLRunConfig
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class RedshiftQueryLogConfig:
     # Number of days back of query logs to fetch, if 0, don't fetch query logs
     lookback_days: int = 1
@@ -17,7 +17,7 @@ class RedshiftQueryLogConfig:
     excluded_usernames: Set[str] = field(default_factory=lambda: set())
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class RedshiftRunConfig(PostgreSQLRunConfig):
     port: int = 5439
 

--- a/metaphor/redshift/lineage/config.py
+++ b/metaphor/redshift/lineage/config.py
@@ -1,10 +1,10 @@
 from pydantic.dataclasses import dataclass
 
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.redshift.config import RedshiftRunConfig
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class RedshiftLineageRunConfig(RedshiftRunConfig):
     # Whether to enable parsing view query to find upstream of the view, default True
     enable_view_lineage: bool = True

--- a/metaphor/redshift/lineage/config.py
+++ b/metaphor/redshift/lineage/config.py
@@ -1,9 +1,10 @@
 from pydantic.dataclasses import dataclass
 
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.redshift.config import RedshiftRunConfig
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class RedshiftLineageRunConfig(RedshiftRunConfig):
     # Whether to enable parsing view query to find upstream of the view, default True
     enable_view_lineage: bool = True

--- a/metaphor/redshift/profile/config.py
+++ b/metaphor/redshift/profile/config.py
@@ -1,9 +1,9 @@
 from pydantic.dataclasses import dataclass
 
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.postgresql.profile.config import PostgreSQLProfileRunConfig
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class RedshiftProfileRunConfig(PostgreSQLProfileRunConfig):
     port: int = 5439

--- a/metaphor/redshift/profile/config.py
+++ b/metaphor/redshift/profile/config.py
@@ -1,8 +1,9 @@
 from pydantic.dataclasses import dataclass
 
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.postgresql.profile.config import PostgreSQLProfileRunConfig
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class RedshiftProfileRunConfig(PostgreSQLProfileRunConfig):
     port: int = 5439

--- a/metaphor/snowflake/auth.py
+++ b/metaphor/snowflake/auth.py
@@ -7,6 +7,7 @@ from pydantic.dataclasses import dataclass
 from smart_open import open
 
 from metaphor.common.base_config import BaseConfig
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.common.utils import must_set_exactly_one
 
 try:
@@ -20,7 +21,7 @@ METAPHOR_DATA = "MetaphorData"
 METAPHOR_DATA_SNOWFLAKE_CONNECTOR = "MetaphorData_SnowflakeConnector"
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class SnowflakeKeyPairAuthConfig:
     """Config for key pair authentication"""
 
@@ -39,7 +40,7 @@ class SnowflakeKeyPairAuthConfig:
         return values
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class SnowflakeAuthConfig(BaseConfig):
     account: str
     user: str

--- a/metaphor/snowflake/auth.py
+++ b/metaphor/snowflake/auth.py
@@ -7,7 +7,7 @@ from pydantic.dataclasses import dataclass
 from smart_open import open
 
 from metaphor.common.base_config import BaseConfig
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.utils import must_set_exactly_one
 
 try:
@@ -21,7 +21,7 @@ METAPHOR_DATA = "MetaphorData"
 METAPHOR_DATA_SNOWFLAKE_CONNECTOR = "MetaphorData_SnowflakeConnector"
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class SnowflakeKeyPairAuthConfig:
     """Config for key pair authentication"""
 
@@ -40,7 +40,7 @@ class SnowflakeKeyPairAuthConfig:
         return values
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class SnowflakeAuthConfig(BaseConfig):
     account: str
     user: str

--- a/metaphor/snowflake/config.py
+++ b/metaphor/snowflake/config.py
@@ -3,6 +3,7 @@ from typing import List, Set
 
 from pydantic.dataclasses import dataclass
 
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.common.filter import DatasetFilter
 from metaphor.common.tag_matcher import TagMatcher
 from metaphor.snowflake.auth import SnowflakeAuthConfig
@@ -12,7 +13,7 @@ from metaphor.snowflake.utils import DEFAULT_THREAD_POOL_SIZE
 DEFAULT_QUERY_LOG_FETCH_SIZE = 100000
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class SnowflakeQueryLogConfig:
     # Number of days back of query logs to fetch, if 0, don't fetch query logs
     lookback_days: int = 1
@@ -24,7 +25,7 @@ class SnowflakeQueryLogConfig:
     fetch_size: int = DEFAULT_QUERY_LOG_FETCH_SIZE
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class SnowflakeRunConfig(SnowflakeAuthConfig):
     # Include or exclude specific databases/schemas/tables
     filter: DatasetFilter = field(default_factory=lambda: DatasetFilter())

--- a/metaphor/snowflake/config.py
+++ b/metaphor/snowflake/config.py
@@ -3,7 +3,7 @@ from typing import List, Set
 
 from pydantic.dataclasses import dataclass
 
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.filter import DatasetFilter
 from metaphor.common.tag_matcher import TagMatcher
 from metaphor.snowflake.auth import SnowflakeAuthConfig
@@ -13,7 +13,7 @@ from metaphor.snowflake.utils import DEFAULT_THREAD_POOL_SIZE
 DEFAULT_QUERY_LOG_FETCH_SIZE = 100000
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class SnowflakeQueryLogConfig:
     # Number of days back of query logs to fetch, if 0, don't fetch query logs
     lookback_days: int = 1
@@ -25,7 +25,7 @@ class SnowflakeQueryLogConfig:
     fetch_size: int = DEFAULT_QUERY_LOG_FETCH_SIZE
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class SnowflakeRunConfig(SnowflakeAuthConfig):
     # Include or exclude specific databases/schemas/tables
     filter: DatasetFilter = field(default_factory=lambda: DatasetFilter())

--- a/metaphor/snowflake/lineage/config.py
+++ b/metaphor/snowflake/lineage/config.py
@@ -1,12 +1,12 @@
 from pydantic.dataclasses import dataclass
 
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.snowflake.config import SnowflakeRunConfig
 
 DEFAULT_BATCH_SIZE = 100000
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class SnowflakeLineageRunConfig(SnowflakeRunConfig):
     # Whether to enable finding view lineage from object dependencies, default True
     enable_view_lineage: bool = True

--- a/metaphor/snowflake/lineage/config.py
+++ b/metaphor/snowflake/lineage/config.py
@@ -1,11 +1,12 @@
 from pydantic.dataclasses import dataclass
 
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.snowflake.config import SnowflakeRunConfig
 
 DEFAULT_BATCH_SIZE = 100000
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class SnowflakeLineageRunConfig(SnowflakeRunConfig):
     # Whether to enable finding view lineage from object dependencies, default True
     enable_view_lineage: bool = True

--- a/metaphor/snowflake/profile/config.py
+++ b/metaphor/snowflake/profile/config.py
@@ -3,12 +3,12 @@ from dataclasses import field
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.column_statistics import ColumnStatistics
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.sampling import SamplingConfig
 from metaphor.snowflake.config import SnowflakeRunConfig
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class SnowflakeProfileRunConfig(SnowflakeRunConfig):
     # Compute specific types of statistics for each column
     column_statistics: ColumnStatistics = field(

--- a/metaphor/snowflake/profile/config.py
+++ b/metaphor/snowflake/profile/config.py
@@ -3,11 +3,12 @@ from dataclasses import field
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.column_statistics import ColumnStatistics
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.common.sampling import SamplingConfig
 from metaphor.snowflake.config import SnowflakeRunConfig
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class SnowflakeProfileRunConfig(SnowflakeRunConfig):
     # Compute specific types of statistics for each column
     column_statistics: ColumnStatistics = field(

--- a/metaphor/synapse/config.py
+++ b/metaphor/synapse/config.py
@@ -2,16 +2,17 @@ from typing import Optional
 
 from pydantic.dataclasses import dataclass
 
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.mssql.config import MssqlConfig
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class SynapseQueryLogConfig:
     # Number of days back of query logs to fetch, if 0, don't fetch query logs
     lookback_days: int = 0
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class SynapseConfig(MssqlConfig):
 
     query_log: Optional[SynapseQueryLogConfig] = SynapseQueryLogConfig()

--- a/metaphor/synapse/config.py
+++ b/metaphor/synapse/config.py
@@ -2,17 +2,17 @@ from typing import Optional
 
 from pydantic.dataclasses import dataclass
 
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.mssql.config import MssqlConfig
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class SynapseQueryLogConfig:
     # Number of days back of query logs to fetch, if 0, don't fetch query logs
     lookback_days: int = 0
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class SynapseConfig(MssqlConfig):
 
     query_log: Optional[SynapseQueryLogConfig] = SynapseQueryLogConfig()

--- a/metaphor/tableau/config.py
+++ b/metaphor/tableau/config.py
@@ -5,10 +5,11 @@ from pydantic import root_validator
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.common.utils import must_set_exactly_one
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class TableauTokenAuthConfig:
     """Config for Personal Access Token authentication"""
 
@@ -16,7 +17,7 @@ class TableauTokenAuthConfig:
     token_value: str
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class TableauPasswordAuthConfig:
     """Config for Username Password authentication"""
 
@@ -24,7 +25,7 @@ class TableauPasswordAuthConfig:
     password: str
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class TableauRunConfig(BaseConfig):
     server_url: str
     site_name: str

--- a/metaphor/tableau/config.py
+++ b/metaphor/tableau/config.py
@@ -5,11 +5,11 @@ from pydantic import root_validator
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.utils import must_set_exactly_one
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class TableauTokenAuthConfig:
     """Config for Personal Access Token authentication"""
 
@@ -17,7 +17,7 @@ class TableauTokenAuthConfig:
     token_value: str
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class TableauPasswordAuthConfig:
     """Config for Username Password authentication"""
 
@@ -25,7 +25,7 @@ class TableauPasswordAuthConfig:
     password: str
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class TableauRunConfig(BaseConfig):
     server_url: str
     site_name: str

--- a/metaphor/thought_spot/config.py
+++ b/metaphor/thought_spot/config.py
@@ -4,10 +4,10 @@ from pydantic import validator
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class ThoughtSpotRunConfig(BaseConfig):
     user: str
 

--- a/metaphor/thought_spot/config.py
+++ b/metaphor/thought_spot/config.py
@@ -4,9 +4,10 @@ from pydantic import validator
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
+from metaphor.common.dataclass import DataclassConfig
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class ThoughtSpotRunConfig(BaseConfig):
     user: str
 

--- a/metaphor/thought_spot/extractor.py
+++ b/metaphor/thought_spot/extractor.py
@@ -1,13 +1,14 @@
-from dataclasses import dataclass
 from itertools import chain
 from typing import Collection, Dict, List, Optional, Tuple
 
 from pydantic import parse_raw_as
+from pydantic.dataclasses import dataclass
 from sqllineage.core.models import Column
 from sqllineage.exceptions import SQLLineageException
 from sqllineage.runner import LineageRunner
 
 from metaphor.common.base_extractor import BaseExtractor
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.common.entity_id import (
     EntityId,
     dataset_normalized_name,
@@ -63,7 +64,7 @@ from metaphor.thought_spot.utils import (
 logger = get_logger()
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class ColumnReference:
     entity_id: str
     field: str

--- a/metaphor/thought_spot/extractor.py
+++ b/metaphor/thought_spot/extractor.py
@@ -8,7 +8,7 @@ from sqllineage.exceptions import SQLLineageException
 from sqllineage.runner import LineageRunner
 
 from metaphor.common.base_extractor import BaseExtractor
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.entity_id import (
     EntityId,
     dataset_normalized_name,
@@ -64,7 +64,7 @@ from metaphor.thought_spot.utils import (
 logger = get_logger()
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class ColumnReference:
     entity_id: str
     field: str

--- a/metaphor/unity_catalog/config.py
+++ b/metaphor/unity_catalog/config.py
@@ -3,10 +3,11 @@ from dataclasses import field
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.common.filter import DatasetFilter
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class UnityCatalogRunConfig(BaseConfig):
     host: str
     token: str

--- a/metaphor/unity_catalog/config.py
+++ b/metaphor/unity_catalog/config.py
@@ -3,11 +3,11 @@ from dataclasses import field
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.filter import DatasetFilter
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class UnityCatalogRunConfig(BaseConfig):
     host: str
     token: str

--- a/poetry.lock
+++ b/poetry.lock
@@ -3389,52 +3389,53 @@ files = [
 
 [[package]]
 name = "pydantic"
-version = "1.9.2"
+version = "1.10.9"
 description = "Data validation and settings management using python type hints"
 category = "main"
 optional = false
-python-versions = ">=3.6.1"
+python-versions = ">=3.7"
 files = [
-    {file = "pydantic-1.9.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9c9e04a6cdb7a363d7cb3ccf0efea51e0abb48e180c0d31dca8d247967d85c6e"},
-    {file = "pydantic-1.9.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fafe841be1103f340a24977f61dee76172e4ae5f647ab9e7fd1e1fca51524f08"},
-    {file = "pydantic-1.9.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:afacf6d2a41ed91fc631bade88b1d319c51ab5418870802cedb590b709c5ae3c"},
-    {file = "pydantic-1.9.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3ee0d69b2a5b341fc7927e92cae7ddcfd95e624dfc4870b32a85568bd65e6131"},
-    {file = "pydantic-1.9.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:ff68fc85355532ea77559ede81f35fff79a6a5543477e168ab3a381887caea76"},
-    {file = "pydantic-1.9.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c0f5e142ef8217019e3eef6ae1b6b55f09a7a15972958d44fbd228214cede567"},
-    {file = "pydantic-1.9.2-cp310-cp310-win_amd64.whl", hash = "sha256:615661bfc37e82ac677543704437ff737418e4ea04bef9cf11c6d27346606044"},
-    {file = "pydantic-1.9.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:328558c9f2eed77bd8fffad3cef39dbbe3edc7044517f4625a769d45d4cf7555"},
-    {file = "pydantic-1.9.2-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bd446bdb7755c3a94e56d7bdfd3ee92396070efa8ef3a34fab9579fe6aa1d84"},
-    {file = "pydantic-1.9.2-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e0b214e57623a535936005797567231a12d0da0c29711eb3514bc2b3cd008d0f"},
-    {file = "pydantic-1.9.2-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:d8ce3fb0841763a89322ea0432f1f59a2d3feae07a63ea2c958b2315e1ae8adb"},
-    {file = "pydantic-1.9.2-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:b34ba24f3e2d0b39b43f0ca62008f7ba962cff51efa56e64ee25c4af6eed987b"},
-    {file = "pydantic-1.9.2-cp36-cp36m-win_amd64.whl", hash = "sha256:84d76ecc908d917f4684b354a39fd885d69dd0491be175f3465fe4b59811c001"},
-    {file = "pydantic-1.9.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:4de71c718c9756d679420c69f216776c2e977459f77e8f679a4a961dc7304a56"},
-    {file = "pydantic-1.9.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5803ad846cdd1ed0d97eb00292b870c29c1f03732a010e66908ff48a762f20e4"},
-    {file = "pydantic-1.9.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a8c5360a0297a713b4123608a7909e6869e1b56d0e96eb0d792c27585d40757f"},
-    {file = "pydantic-1.9.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:cdb4272678db803ddf94caa4f94f8672e9a46bae4a44f167095e4d06fec12979"},
-    {file = "pydantic-1.9.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:19b5686387ea0d1ea52ecc4cffb71abb21702c5e5b2ac626fd4dbaa0834aa49d"},
-    {file = "pydantic-1.9.2-cp37-cp37m-win_amd64.whl", hash = "sha256:32e0b4fb13ad4db4058a7c3c80e2569adbd810c25e6ca3bbd8b2a9cc2cc871d7"},
-    {file = "pydantic-1.9.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:91089b2e281713f3893cd01d8e576771cd5bfdfbff5d0ed95969f47ef6d676c3"},
-    {file = "pydantic-1.9.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e631c70c9280e3129f071635b81207cad85e6c08e253539467e4ead0e5b219aa"},
-    {file = "pydantic-1.9.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b3946f87e5cef3ba2e7bd3a4eb5a20385fe36521d6cc1ebf3c08a6697c6cfb3"},
-    {file = "pydantic-1.9.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5565a49effe38d51882cb7bac18bda013cdb34d80ac336428e8908f0b72499b0"},
-    {file = "pydantic-1.9.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:bd67cb2c2d9602ad159389c29e4ca964b86fa2f35c2faef54c3eb28b4efd36c8"},
-    {file = "pydantic-1.9.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:4aafd4e55e8ad5bd1b19572ea2df546ccace7945853832bb99422a79c70ce9b8"},
-    {file = "pydantic-1.9.2-cp38-cp38-win_amd64.whl", hash = "sha256:d70916235d478404a3fa8c997b003b5f33aeac4686ac1baa767234a0f8ac2326"},
-    {file = "pydantic-1.9.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f0ca86b525264daa5f6b192f216a0d1e860b7383e3da1c65a1908f9c02f42801"},
-    {file = "pydantic-1.9.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1061c6ee6204f4f5a27133126854948e3b3d51fcc16ead2e5d04378c199b2f44"},
-    {file = "pydantic-1.9.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e78578f0c7481c850d1c969aca9a65405887003484d24f6110458fb02cca7747"},
-    {file = "pydantic-1.9.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5da164119602212a3fe7e3bc08911a89db4710ae51444b4224c2382fd09ad453"},
-    {file = "pydantic-1.9.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:7ead3cd020d526f75b4188e0a8d71c0dbbe1b4b6b5dc0ea775a93aca16256aeb"},
-    {file = "pydantic-1.9.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:7d0f183b305629765910eaad707800d2f47c6ac5bcfb8c6397abdc30b69eeb15"},
-    {file = "pydantic-1.9.2-cp39-cp39-win_amd64.whl", hash = "sha256:f1a68f4f65a9ee64b6ccccb5bf7e17db07caebd2730109cb8a95863cfa9c4e55"},
-    {file = "pydantic-1.9.2-py3-none-any.whl", hash = "sha256:78a4d6bdfd116a559aeec9a4cfe77dda62acc6233f8b56a716edad2651023e5e"},
-    {file = "pydantic-1.9.2.tar.gz", hash = "sha256:8cb0bc509bfb71305d7a59d00163d5f9fc4530f0881ea32c74ff4f74c85f3d3d"},
+    {file = "pydantic-1.10.9-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e692dec4a40bfb40ca530e07805b1208c1de071a18d26af4a2a0d79015b352ca"},
+    {file = "pydantic-1.10.9-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3c52eb595db83e189419bf337b59154bdcca642ee4b2a09e5d7797e41ace783f"},
+    {file = "pydantic-1.10.9-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:939328fd539b8d0edf244327398a667b6b140afd3bf7e347cf9813c736211896"},
+    {file = "pydantic-1.10.9-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b48d3d634bca23b172f47f2335c617d3fcb4b3ba18481c96b7943a4c634f5c8d"},
+    {file = "pydantic-1.10.9-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:f0b7628fb8efe60fe66fd4adadd7ad2304014770cdc1f4934db41fe46cc8825f"},
+    {file = "pydantic-1.10.9-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:e1aa5c2410769ca28aa9a7841b80d9d9a1c5f223928ca8bec7e7c9a34d26b1d4"},
+    {file = "pydantic-1.10.9-cp310-cp310-win_amd64.whl", hash = "sha256:eec39224b2b2e861259d6f3c8b6290d4e0fbdce147adb797484a42278a1a486f"},
+    {file = "pydantic-1.10.9-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d111a21bbbfd85c17248130deac02bbd9b5e20b303338e0dbe0faa78330e37e0"},
+    {file = "pydantic-1.10.9-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2e9aec8627a1a6823fc62fb96480abe3eb10168fd0d859ee3d3b395105ae19a7"},
+    {file = "pydantic-1.10.9-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:07293ab08e7b4d3c9d7de4949a0ea571f11e4557d19ea24dd3ae0c524c0c334d"},
+    {file = "pydantic-1.10.9-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7ee829b86ce984261d99ff2fd6e88f2230068d96c2a582f29583ed602ef3fc2c"},
+    {file = "pydantic-1.10.9-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:4b466a23009ff5cdd7076eb56aca537c745ca491293cc38e72bf1e0e00de5b91"},
+    {file = "pydantic-1.10.9-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:7847ca62e581e6088d9000f3c497267868ca2fa89432714e21a4fb33a04d52e8"},
+    {file = "pydantic-1.10.9-cp311-cp311-win_amd64.whl", hash = "sha256:7845b31959468bc5b78d7b95ec52fe5be32b55d0d09983a877cca6aedc51068f"},
+    {file = "pydantic-1.10.9-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:517a681919bf880ce1dac7e5bc0c3af1e58ba118fd774da2ffcd93c5f96eaece"},
+    {file = "pydantic-1.10.9-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67195274fd27780f15c4c372f4ba9a5c02dad6d50647b917b6a92bf00b3d301a"},
+    {file = "pydantic-1.10.9-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2196c06484da2b3fded1ab6dbe182bdabeb09f6318b7fdc412609ee2b564c49a"},
+    {file = "pydantic-1.10.9-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:6257bb45ad78abacda13f15bde5886efd6bf549dd71085e64b8dcf9919c38b60"},
+    {file = "pydantic-1.10.9-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:3283b574b01e8dbc982080d8287c968489d25329a463b29a90d4157de4f2baaf"},
+    {file = "pydantic-1.10.9-cp37-cp37m-win_amd64.whl", hash = "sha256:5f8bbaf4013b9a50e8100333cc4e3fa2f81214033e05ac5aa44fa24a98670a29"},
+    {file = "pydantic-1.10.9-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b9cd67fb763248cbe38f0593cd8611bfe4b8ad82acb3bdf2b0898c23415a1f82"},
+    {file = "pydantic-1.10.9-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f50e1764ce9353be67267e7fd0da08349397c7db17a562ad036aa7c8f4adfdb6"},
+    {file = "pydantic-1.10.9-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:73ef93e5e1d3c8e83f1ff2e7fdd026d9e063c7e089394869a6e2985696693766"},
+    {file = "pydantic-1.10.9-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:128d9453d92e6e81e881dd7e2484e08d8b164da5507f62d06ceecf84bf2e21d3"},
+    {file = "pydantic-1.10.9-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:ad428e92ab68798d9326bb3e5515bc927444a3d71a93b4a2ca02a8a5d795c572"},
+    {file = "pydantic-1.10.9-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:fab81a92f42d6d525dd47ced310b0c3e10c416bbfae5d59523e63ea22f82b31e"},
+    {file = "pydantic-1.10.9-cp38-cp38-win_amd64.whl", hash = "sha256:963671eda0b6ba6926d8fc759e3e10335e1dc1b71ff2a43ed2efd6996634dafb"},
+    {file = "pydantic-1.10.9-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:970b1bdc6243ef663ba5c7e36ac9ab1f2bfecb8ad297c9824b542d41a750b298"},
+    {file = "pydantic-1.10.9-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7e1d5290044f620f80cf1c969c542a5468f3656de47b41aa78100c5baa2b8276"},
+    {file = "pydantic-1.10.9-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83fcff3c7df7adff880622a98022626f4f6dbce6639a88a15a3ce0f96466cb60"},
+    {file = "pydantic-1.10.9-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0da48717dc9495d3a8f215e0d012599db6b8092db02acac5e0d58a65248ec5bc"},
+    {file = "pydantic-1.10.9-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:0a2aabdc73c2a5960e87c3ffebca6ccde88665616d1fd6d3db3178ef427b267a"},
+    {file = "pydantic-1.10.9-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9863b9420d99dfa9c064042304868e8ba08e89081428a1c471858aa2af6f57c4"},
+    {file = "pydantic-1.10.9-cp39-cp39-win_amd64.whl", hash = "sha256:e7c9900b43ac14110efa977be3da28931ffc74c27e96ee89fbcaaf0b0fe338e1"},
+    {file = "pydantic-1.10.9-py3-none-any.whl", hash = "sha256:6cafde02f6699ce4ff643417d1a9223716ec25e228ddc3b436fe7e2d25a1f305"},
+    {file = "pydantic-1.10.9.tar.gz", hash = "sha256:95c70da2cd3b6ddf3b9645ecaa8d98f3d80c606624b6d245558d202cd23ea3be"},
 ]
 
 [package.dependencies]
 email-validator = {version = ">=1.0.3", optional = true, markers = "extra == \"email\""}
-typing-extensions = ">=3.7.4.3"
+typing-extensions = ">=4.2.0"
 
 [package.extras]
 dotenv = ["python-dotenv (>=0.10.4)"]
@@ -4943,4 +4944,4 @@ unity-catalog = ["databricks-cli"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.11"  # See https://github.com/googleapis/python-bigquery/issues/856
-content-hash = "bd965815988d9703a2365bdf8f1f9d2401c353cf43fa6c91a0190df0b028cecb"
+content-hash = "d309ff19b52c14611cd79c69b49d3c8eb94bc5c8973bf1fd1e5d97c76ceb3d6e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.12.0"
+version = "0.12.1"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.12.1"
+version = "0.12.2"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ lkml = { version = "^1.3.1", optional = true }
 looker-sdk = { version = "^23.6.0", optional = true }
 metaphor-models = "0.17.14"
 msal = { version = "^1.20.0", optional = true }
-pydantic = "~=1.9.0"
+pydantic = "^1.10.0"
 pymssql = { version = "^2.2.7", optional = true }
 pymysql = { version = "^1.0.2", optional = true }
 python = ">=3.8,<3.11"  # See https://github.com/googleapis/python-bigquery/issues/856
@@ -40,7 +40,7 @@ smart-open = "^6.3.0"
 snowflake-connector-python = { version = "~=3.0.3", optional = true }
 SQLAlchemy = { version = "^1.4.46", optional = true}
 sql-metadata = { version = "^2.8.0", optional = true }
-sqllineage = { version = "^1.3.8", optional = true }
+sqllineage = { version = "~=1.3.8", optional = true }
 tableauserverclient = { version = "^0.25", optional = true }
 thoughtspot_rest_api_v1 = { version = "1.4.1", optional = true }
 

--- a/tests/common/test_config.py
+++ b/tests/common/test_config.py
@@ -4,7 +4,7 @@ from pydantic.dataclasses import dataclass
 
 from metaphor.common.api_sink import ApiSinkConfig
 from metaphor.common.base_config import BaseConfig, OutputConfig
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.file_sink import FileSinkConfig
 
 
@@ -35,7 +35,7 @@ def test_yaml_config_with_extra_config(test_root_dir):
         BaseConfig.from_yaml_file(f"{test_root_dir}/common/configs/extend.yml")
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class ExtendConfig(BaseConfig):
     foo: str
 

--- a/tests/common/test_config.py
+++ b/tests/common/test_config.py
@@ -4,6 +4,7 @@ from pydantic.dataclasses import dataclass
 
 from metaphor.common.api_sink import ApiSinkConfig
 from metaphor.common.base_config import BaseConfig, OutputConfig
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.common.file_sink import FileSinkConfig
 
 
@@ -34,7 +35,7 @@ def test_yaml_config_with_extra_config(test_root_dir):
         BaseConfig.from_yaml_file(f"{test_root_dir}/common/configs/extend.yml")
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class ExtendConfig(BaseConfig):
     foo: str
 

--- a/tests/common/test_extractor.py
+++ b/tests/common/test_extractor.py
@@ -4,7 +4,7 @@ from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig, OutputConfig
 from metaphor.common.base_extractor import BaseExtractor
-from metaphor.common.dataclass import DataclassConfig
+from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.event_util import ENTITY_TYPES
 from metaphor.models.crawler_run_metadata import Platform
 from metaphor.models.metadata_change_event import (
@@ -15,7 +15,7 @@ from metaphor.models.metadata_change_event import (
 )
 
 
-@dataclass(config=DataclassConfig)
+@dataclass(config=ConnectorConfig)
 class DummyRunConfig(BaseConfig):
     dummy_attr: int
 

--- a/tests/common/test_extractor.py
+++ b/tests/common/test_extractor.py
@@ -4,6 +4,7 @@ from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig, OutputConfig
 from metaphor.common.base_extractor import BaseExtractor
+from metaphor.common.dataclass import DataclassConfig
 from metaphor.common.event_util import ENTITY_TYPES
 from metaphor.models.crawler_run_metadata import Platform
 from metaphor.models.metadata_change_event import (
@@ -14,7 +15,7 @@ from metaphor.models.metadata_change_event import (
 )
 
 
-@dataclass
+@dataclass(config=DataclassConfig)
 class DummyRunConfig(BaseConfig):
     dummy_attr: int
 


### PR DESCRIPTION
### 🤔 Why?

pydantic 1.9 is outdated (1.10 is out in 2022.8 and v2.0 alpha has been released), and because there are some breaking changes, it prevents us from upgrading some other dependencies, such as apache-airflow.

### 🤓 What?

- upgrade pydantic to latest 1.10 version
- since the 1.10 pydantic dataclass default behavior is to ignore extra fields, we need to add the config to force it to throw an error as before. 

### 🧪 Tested?

all unit tests passed
local run snowflake, bigquery, power_bi, thought_spot crawlers
