### PR TITLE
Install git in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,8 @@ RUN pip install '/src[all]'
 
 RUN rm -rf /src
 
+RUN apt-get clean
+RUN apt-get update
+RUN apt-get install -y git
+
 CMD ["sh", "-c", "metaphor ${CONNECTOR} ${CONFIG_FILE}"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.12.0"
+version = "0.12.1"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

`GitPython` requires git to be installed. Instead of relying on child images to install git explicitly, it makes more sense to preinstall it in the base image.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled. Also added a script to automate docker image building.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

```
% ./scripts/build_docker_image.sh
...
 => CACHED [1/7] FROM docker.io/library/python:3.8-slim@sha256:8f9d73f3f3ffcabcfbe7c8a0330c8cb054bde96dd46992e97539d43153434db  0.0s
 => [2/7] COPY . /src                                                                                                           0.2s
 => [3/7] RUN pip install '/src[all]'                                                                                         196.6s
 => [4/7] RUN rm -rf /src                                                                                                       0.4s
 => [5/7] RUN apt-get clean                                                                                                     0.3s 
 => [6/7] RUN apt-get update                                                                                                   11.5s 
 => [7/7] RUN apt-get install -y git                                                                                           21.5s 
 => exporting to image                                                                                                          2.2s 
 => => exporting layers                                                                                                         2.1s 
 => => writing image sha256:5a0067f7ae3396de50bdfb72ab18cc709e41695b604fe48681b20a50d06daf4e                                    0.0s 
 => => naming to docker.io/metaphordata/connectors:dev                                                                          0.0s
```