### PR TITLE
Lower case the Snowflake account name when normalizing

### DIFF
--- a/metaphor/common/snowflake.py
+++ b/metaphor/common/snowflake.py
@@ -7,6 +7,9 @@ def normalize_snowflake_account(account: str) -> str:
     See https://docs.snowflake.com/en/user-guide/admin-account-identifier
     """
 
+    # Account name is case insensitive
+    account = account.lower()
+
     # Strip PrivateLink suffix
     if account.endswith(PRIVATE_LINK_SUFFIX):
         return account[: -len(PRIVATE_LINK_SUFFIX)]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.12.3"
+version = "0.12.4"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/common/test_snowflake.py
+++ b/tests/common/test_snowflake.py
@@ -2,6 +2,7 @@ from metaphor.common.snowflake import normalize_snowflake_account
 
 
 def test_normalize_snowflake_account():
+    assert normalize_snowflake_account("ORG-ACC") == "org-acc"
     assert normalize_snowflake_account("org-acc") == "org-acc"
     assert normalize_snowflake_account("org.us-west-1") == "org.us-west-1"
     assert normalize_snowflake_account("foo.privatelink") == "foo"


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

While not explicitly documented in https://docs.snowflake.com/en/user-guide/admin-account-identifier, the Snowflake account name appears to be case insensitive. This makes sense since it's used as part of the URL (e.g. `https://acme-marketing-test-account.snowflakecomputing.com`). We need to normalize it as such across systems.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Unit tests.
