### PR TITLE
Extract dataset URL from Monte Carlo

### DIFF
--- a/metaphor/monte_carlo/extractor.py
+++ b/metaphor/monte_carlo/extractor.py
@@ -118,7 +118,7 @@ class MonteCarloExtractor(BaseExtractor):
                     logger.warning(f"Unknown severity {monitor['severity']}")
 
             data_monitor = DataMonitor(
-                title=monitor["description"],
+                title=monitor["name"],
                 description=monitor["description"],
                 owner=monitor["creatorId"],
                 status=monitor_status_map.get(

--- a/metaphor/monte_carlo/extractor.py
+++ b/metaphor/monte_carlo/extractor.py
@@ -118,7 +118,7 @@ class MonteCarloExtractor(BaseExtractor):
                     logger.warning(f"Unknown severity {monitor['severity']}")
 
             data_monitor = DataMonitor(
-                title=monitor["name"],
+                title=monitor["description"],
                 description=monitor["description"],
                 owner=monitor["creatorId"],
                 status=monitor_status_map.get(
@@ -128,7 +128,7 @@ class MonteCarloExtractor(BaseExtractor):
                 url=f"{monitors_base_url}/{monitor['uuid']}",
                 last_run=parser.parse(monitor["prevExecutionTime"]),
                 targets=[
-                    DataMonitorTarget(column=field)
+                    DataMonitorTarget(column=field.upper())
                     for field in monitor["monitorFields"] or []
                 ],
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.12.6"
+version = "0.12.7"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/monte_carlo/expected.json
+++ b/tests/monte_carlo/expected.json
@@ -13,7 +13,8 @@
           "url": "https://getmontecarlo.com/monitors/e0dc143e-dd8a-4cb9-b4cc-dedec715d955"
         }
       ],
-      "provider": "MONTE_CARLO"
+      "provider": "MONTE_CARLO",
+      "url": "https://getmontecarlo.com/assets/MCON++6418a1e2-9718-4413-9d2b-6a354e01ddf8++a19e22b4-7659-4064-8fd4-8d6122fabe1c++table++db:metaphor.test1/custom-monitors"
     },
     "id": "DATASET~A2409EBE8D27134A0A453E315CF94DF8",
     "logicalId": {
@@ -43,7 +44,8 @@
           "url": "https://getmontecarlo.com/monitors/ce4c4568-35f4-4365-a6fe-95f233fcf6c3"
         }
       ],
-      "provider": "MONTE_CARLO"
+      "provider": "MONTE_CARLO",
+      "url": "https://getmontecarlo.com/assets/MCON++6418a1e2-9718-4413-9d2b-6a354e01ddf8++a19e22b4-7659-4064-8fd4-8d6122fabe1c++table++db:metaphor.test2/custom-monitors"
     },
     "id": "DATASET~7C8302C79EF72479256B0B30E12AD2D7",
     "logicalId": {

--- a/tests/monte_carlo/expected.json
+++ b/tests/monte_carlo/expected.json
@@ -9,7 +9,7 @@
           "severity": "UNKNOWN",
           "status": "ERROR",
           "targets": [],
-          "title": "auto_monitor_name_cd5b69bd-e465-4545-b3f9-a5d507ea766c",
+          "title": "Field Health for all fields in db:metaphor.test1",
           "url": "https://getmontecarlo.com/monitors/e0dc143e-dd8a-4cb9-b4cc-dedec715d955"
         }
       ],
@@ -34,13 +34,13 @@
           "status": "PASSED",
           "targets": [
             {
-              "column": "foo"
+              "column": "FOO"
             },
             {
-              "column": "bar"
+              "column": "BAR"
             }
           ],
-          "title": "auto_monitor_name_53c985e6-8f49-4af7-8ef1-7b402a27538b",
+          "title": "Field Health for all fields in db:metaphor.test2",
           "url": "https://getmontecarlo.com/monitors/ce4c4568-35f4-4365-a6fe-95f233fcf6c3"
         }
       ],

--- a/tests/monte_carlo/expected.json
+++ b/tests/monte_carlo/expected.json
@@ -9,7 +9,7 @@
           "severity": "UNKNOWN",
           "status": "ERROR",
           "targets": [],
-          "title": "Field Health for all fields in db:metaphor.test1",
+          "title": "auto_monitor_name_cd5b69bd-e465-4545-b3f9-a5d507ea766c",
           "url": "https://getmontecarlo.com/monitors/e0dc143e-dd8a-4cb9-b4cc-dedec715d955"
         }
       ],
@@ -40,7 +40,7 @@
               "column": "BAR"
             }
           ],
-          "title": "Field Health for all fields in db:metaphor.test2",
+          "title": "auto_monitor_name_53c985e6-8f49-4af7-8ef1-7b402a27538b",
           "url": "https://getmontecarlo.com/monitors/ce4c4568-35f4-4365-a6fe-95f233fcf6c3"
         }
       ],

--- a/tests/monte_carlo/test_extractor.py
+++ b/tests/monte_carlo/test_extractor.py
@@ -30,6 +30,9 @@ async def test_extractor(mock_pycarlo_client: MagicMock, test_root_dir: str):
                 "name": "auto_monitor_name_cd5b69bd-e465-4545-b3f9-a5d507ea766c",
                 "description": "Field Health for all fields in db:metaphor.test1",
                 "entities": ["db:metaphor.test1"],
+                "entityMcons": [
+                    "MCON++6418a1e2-9718-4413-9d2b-6a354e01ddf8++a19e22b4-7659-4064-8fd4-8d6122fabe1c++table++db:metaphor.test1"
+                ],
                 "severity": None,
                 "monitorStatus": "MISCONFIGURED",
                 "monitorFields": None,
@@ -41,6 +44,9 @@ async def test_extractor(mock_pycarlo_client: MagicMock, test_root_dir: str):
                 "name": "auto_monitor_name_53c985e6-8f49-4af7-8ef1-7b402a27538b",
                 "description": "Field Health for all fields in db:metaphor.test2",
                 "entities": ["db:metaphor.test2"],
+                "entityMcons": [
+                    "MCON++6418a1e2-9718-4413-9d2b-6a354e01ddf8++a19e22b4-7659-4064-8fd4-8d6122fabe1c++table++db:metaphor.test2"
+                ],
                 "severity": "LOW",
                 "monitorStatus": "SUCCESS",
                 "monitorFields": ["foo", "bar"],


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

To fill in the `url` field, which can be used to access the dataset page on Monte Carlo side.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Extract MC dataset URL
- Normalize column names
- Store the raw GraphQL response JSON in `log.zip` to help debug issues.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Manually tested against a production instance.
