### PR TITLE
Display Tableau nested hierarchy in metaphor [sc-18850]

### DIFF
--- a/metaphor/tableau/extractor.py
+++ b/metaphor/tableau/extractor.py
@@ -1,5 +1,4 @@
 import base64
-import json
 import re
 import traceback
 from typing import Collection, Dict, List, Optional, Set, Union
@@ -133,7 +132,6 @@ class TableauExtractor(BaseExtractor):
             f"There are {len(views)} views on site: {[view.name for view in views]}\n"
         )
         for view in views:
-            logger.debug(json.dumps(view.__dict__, default=str))
             if not self._disable_preview_image:
                 server.views.populate_preview_image(view)
             if not view.id:
@@ -149,7 +147,6 @@ class TableauExtractor(BaseExtractor):
         )
         for workbook in workbooks:
             server.workbooks.populate_views(workbook, usage=True)
-            logger.debug(json.dumps(workbook.__dict__, default=str))
 
             try:
                 self._parse_dashboard(workbook)
@@ -193,7 +190,6 @@ class TableauExtractor(BaseExtractor):
 
     def _parse_project_names(self, projects: List[tableau.ProjectItem]) -> None:
         for project in projects:
-            logger.debug(json.dumps(project.__dict__, default=str))
             if project.id:
                 self._projects[project.id] = project.name
 

--- a/metaphor/tableau/extractor.py
+++ b/metaphor/tableau/extractor.py
@@ -194,11 +194,12 @@ class TableauExtractor(BaseExtractor):
     def _parse_project_names(self, projects: List[tableau.ProjectItem]) -> None:
         for project in projects:
             logger.debug(json.dumps(project.__dict__, default=str))
-            self._projects[project.id] = project.name
+            if project.id:
+                self._projects[project.id] = project.name
 
         # second iteration to link child to parent project
         for project in projects:
-            if project.parent_id in self._projects:
+            if project.id and project.parent_id in self._projects:
                 parent_name = self._projects[project.parent_id]
                 self._projects[project.id] = f"{parent_name}.{project.name}"
 
@@ -209,7 +210,7 @@ class TableauExtractor(BaseExtractor):
 
         workbook_id = TableauExtractor._extract_workbook_id(workbook.webpage_url)
         project_name = (
-            self._projects.get(workbook.project_id, None) or workbook.project_name
+            self._projects.get(workbook.project_id or "", None) or workbook.project_name
         )
 
         views: List[tableau.ViewItem] = workbook.views

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.12.7"
+version = "0.12.8"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/tableau/expected.json
+++ b/tests/tableau/expected.json
@@ -13,7 +13,7 @@
         }
       ],
       "description": "d",
-      "title": "project1.wb",
+      "title": "parent.child.wb",
       "viewCount": 100.0
     },
     "sourceInfo": {


### PR DESCRIPTION
### 🤔 Why?

The current tableau workbook extractor only used the immediate project name but did not include the parent project name. This will result in a flattened hierarchy. 

### 🤓 What?

- fetch all projects and build each project full name
- use project id to link to the project full name of each workbook

### 🧪 Tested?

tested against tableau server
