### PR TITLE
Add region_name to S3StorageConfig

### DIFF
--- a/metaphor/common/docs/output.md
+++ b/metaphor/common/docs/output.md
@@ -23,7 +23,20 @@ output:
     assume_role_arn: <iam_role_arn>
 ```
 
-To write the output to a S3 bucket, you must also set the AWS region & credentials using the [AWS CLI environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html), specifically, `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`.
+### Write to S3
+
+To write the output to a S3 bucket, you must also add the AWS region & credentials to the config:
+
+```yaml
+output:
+  file:
+    directory: s3://<bucket>/<path>
+
+    s3_auth_config:
+      aws_access_key_id: <AWS_ACCESS_KEY_ID>
+      aws_secret_access_key: <AWS_SECRET_ACCESS_KEY>
+      region_name: <AWS_REGION>
+```
 
 ## Output to API
 

--- a/metaphor/common/storage.py
+++ b/metaphor/common/storage.py
@@ -74,6 +74,7 @@ class LocalStorage(BaseStorage):
 class S3StorageConfig:
     aws_access_key_id: Optional[str] = None
     aws_secret_access_key: Optional[str] = None
+    region_name: Optional[str] = None
 
 
 class S3Storage(BaseStorage):
@@ -87,6 +88,7 @@ class S3Storage(BaseStorage):
         session = boto3.Session(
             aws_access_key_id=config.aws_access_key_id,
             aws_secret_access_key=config.aws_secret_access_key,
+            region_name=config.region_name,
         )
         if assume_role_arn is not None:
             self._session = assume_role(session, assume_role_arn)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.12.15"
+version = "0.12.16"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/common/test_storage.py
+++ b/tests/common/test_storage.py
@@ -1,7 +1,8 @@
 import os
 import tempfile
+from unittest.mock import ANY, MagicMock, patch
 
-from metaphor.common.storage import LocalStorage, S3Storage
+from metaphor.common.storage import LocalStorage, S3Storage, S3StorageConfig
 
 
 def test_parse_s3_uri():
@@ -29,3 +30,23 @@ def test_local_storage(test_root_dir):
     # mkstemp may create more than 1 temp files
     _, temp_file = tempfile.mkstemp(suffix=".tmp")
     assert len(storage.list_files(os.path.dirname(temp_file), ".tmp")) > 0
+
+
+@patch("metaphor.common.storage.boto3.Session")
+@patch("metaphor.common.storage.assume_role")
+def test_s3_storage_configs(mock_assume_role, mock_session_class, test_root_dir):
+    S3Storage(
+        assume_role_arn="arn",
+        config=S3StorageConfig(
+            aws_access_key_id="id", aws_secret_access_key="secret", region_name="region"
+        ),
+    )
+
+    mock_session = MagicMock()
+    mock_session_class.side_effect = mock_session
+
+    mock_session_class.assert_called_with(
+        aws_access_key_id="id", aws_secret_access_key="secret", region_name="region"
+    )
+
+    mock_assume_role.assert_called_with(ANY, "arn")


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

It was missing before, which prevents users from specifying all S3 credentials via config files.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled. Also updated README & added tests.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified end-to-end against a production instance.

