### PR TITLE
NaN value in MCE [sc-19559]

### DIFF
--- a/metaphor/bigquery/profile/extractor.py
+++ b/metaphor/bigquery/profile/extractor.py
@@ -3,8 +3,6 @@ from functools import partial
 from time import sleep
 from typing import Collection, List, Set, Union
 
-from metaphor.common.entity_id import dataset_normalized_name
-
 try:
     import google.cloud.bigquery as bigquery
     from google.cloud.bigquery import QueryJob, TableReference
@@ -12,14 +10,17 @@ except ImportError:
     print("Please install metaphor[bigquery] extra\n")
     raise
 
+
 from metaphor.bigquery.extractor import BigQueryExtractor
 from metaphor.bigquery.profile.config import BigQueryProfileRunConfig, SamplingConfig
 from metaphor.bigquery.utils import build_client, get_credentials
 from metaphor.common.base_extractor import BaseExtractor
 from metaphor.common.column_statistics import ColumnStatistics
+from metaphor.common.entity_id import dataset_normalized_name
 from metaphor.common.event_util import ENTITY_TYPES
 from metaphor.common.filter import DatasetFilter
 from metaphor.common.logger import get_logger
+from metaphor.common.utils import convert_to_float
 from metaphor.models.crawler_run_metadata import Platform
 from metaphor.models.metadata_change_event import (
     DataPlatform,
@@ -245,23 +246,19 @@ class BigQueryProfileExtractor(BaseExtractor):
             min_value, max_value, avg, std_dev = None, None, None, None
             if BigQueryProfileExtractor._is_numeric(data_type):
                 if column_statistics.min_value:
-                    min_value = (
-                        None if results[index] is None else float(results[index])
-                    )
+                    min_value = convert_to_float(results[index])
                     index += 1
 
                 if column_statistics.max_value:
-                    max_value = (
-                        None if results[index] is None else float(results[index])
-                    )
+                    max_value = convert_to_float(results[index])
                     index += 1
 
                 if column_statistics.avg_value:
-                    avg = None if results[index] is None else float(results[index])
+                    avg = convert_to_float(results[index])
                     index += 1
 
                 if column_statistics.std_dev:
-                    std_dev = None if results[index] is None else float(results[index])
+                    std_dev = convert_to_float(results[index])
                     index += 1
 
             fields.append(

--- a/metaphor/common/utils.py
+++ b/metaphor/common/utils.py
@@ -1,6 +1,6 @@
 from datetime import datetime, time, timedelta, timezone
 from hashlib import md5
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Optional, Union
 
 
 def start_of_day(daysAgo=0) -> datetime:
@@ -44,6 +44,11 @@ def generate_querylog_id(platform: str, id: str) -> str:
 def to_utc_time(time: datetime) -> datetime:
     """convert local datatime to utc timezone"""
     return time.replace(tzinfo=timezone.utc)
+
+
+def convert_to_float(value: Optional[Union[float, int, str]]) -> Optional[float]:
+    """Converts a value to float, return None if the original value is None or NaN"""
+    return None if value is None or value != value else float(value)
 
 
 def chunk_by_size(

--- a/metaphor/snowflake/profile/extractor.py
+++ b/metaphor/snowflake/profile/extractor.py
@@ -1,20 +1,21 @@
 import logging
 from typing import Collection, Dict, List, Tuple
 
-from metaphor.common.snowflake import normalize_snowflake_account
-from metaphor.models.crawler_run_metadata import Platform
-
 try:
     from snowflake.connector import ProgrammingError, SnowflakeConnection
 except ImportError:
     print("Please install metaphor[snowflake] extra\n")
     raise
 
+
 from metaphor.common.base_extractor import BaseExtractor
 from metaphor.common.entity_id import dataset_normalized_name
 from metaphor.common.event_util import ENTITY_TYPES
 from metaphor.common.logger import get_logger
 from metaphor.common.sampling import SamplingConfig
+from metaphor.common.snowflake import normalize_snowflake_account
+from metaphor.common.utils import convert_to_float
+from metaphor.models.crawler_run_metadata import Platform
 from metaphor.models.metadata_change_event import (
     DataPlatform,
     Dataset,
@@ -254,23 +255,19 @@ class SnowflakeProfileExtractor(BaseExtractor):
             min_value, max_value, avg, std_dev = None, None, None, None
             if SnowflakeProfileExtractor._is_numeric(data_type):
                 if column_statistics.min_value:
-                    min_value = (
-                        None if results[index] is None else float(results[index])
-                    )
+                    min_value = convert_to_float(results[index])
                     index += 1
 
                 if column_statistics.max_value:
-                    max_value = (
-                        None if results[index] is None else float(results[index])
-                    )
+                    max_value = convert_to_float(results[index])
                     index += 1
 
                 if column_statistics.avg_value:
-                    avg = None if results[index] is None else float(results[index])
+                    avg = convert_to_float(results[index])
                     index += 1
 
                 if column_statistics.std_dev:
-                    std_dev = None if results[index] is None else float(results[index])
+                    std_dev = convert_to_float(results[index])
                     index += 1
 
             fields.append(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.12.16"
+version = "0.12.17"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/snowflake/profile/test_extractor.py
+++ b/tests/snowflake/profile/test_extractor.py
@@ -205,7 +205,7 @@ def test_parse_profiling_result():
         11,
         12,
         13,
-        14,
+        float("NAN"),
     )
     dataset = SnowflakeProfileExtractor._init_dataset(
         account="a", normalized_name="foo"
@@ -242,7 +242,7 @@ def test_parse_profiling_result():
                     min_value=11.0,
                     nonnull_value_count=0.0,
                     null_value_count=10.0,
-                    std_dev=14.0,
+                    std_dev=None,
                 ),
             ]
         ),


### PR DESCRIPTION
### 🤔 Why?

The data profiler may receive values that's python `NaN`, and that's put into JSON like `"maxValue": NaN` which can't be decoded.

### 🤓 What?

- convert `NaN` value to None in the profiler

### 🧪 Tested?

unit tests
