### PR TITLE
Remove deprecated Fivertran field from crawler [sc-19619]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.12.18"
+version = "0.12.19"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/fivetran/expected.json
+++ b/tests/fivetran/expected.json
@@ -7,24 +7,6 @@
     },
     "upstream": {
       "fieldMappings": [],
-      "fiveTranConnector": {
-        "config": "{\"service_account\": \"service_account\", \"is_single_table_mode\": false, \"folder_id\": \"folder_url\"}",
-        "connectorLogsUrl": "https://fivetran.com/dashboard/connectors/connector_1/logs",
-        "connectorName": "google_drive",
-        "connectorTypeId": "google_drive",
-        "connectorUrl": "https://fivetran.com/dashboard/connectors/connector_1",
-        "createdAt": "2023-04-18T06:28:41.339405+00:00",
-        "creatorEmail": "user@foo.com",
-        "paused": false,
-        "schemaMetadata": "[{\"name_in_source\": \"google_drive\", \"name_in_destination\": \"google_drive\", \"tables\": [{\"name_in_source\": \"dataset_foo_sheet_1\", \"name_in_destination\": \"dataset_foo_sheet_1\", \"columns\": [{\"name_in_source\": \"_line\", \"name_in_destination\": \"_line\", \"type_in_source\": \"Long\", \"type_in_destination\": \"INTEGER\", \"is_primary_key\": true, \"is_foreign_key\": false}, {\"name_in_source\": \"name\", \"name_in_destination\": \"name\", \"type_in_source\": \"Unknown\", \"type_in_destination\": \"STRING\", \"is_primary_key\": false, \"is_foreign_key\": false}, {\"name_in_source\": \"user\", \"name_in_destination\": \"user\", \"type_in_source\": \"Unknown\", \"type_in_destination\": \"STRING\", \"is_primary_key\": false, \"is_foreign_key\": false}]}]}]",
-        "status": {
-          "setupState": "connected",
-          "syncState": "scheduled",
-          "updateState": "on_schedule"
-        },
-        "succeededAt": "2023-04-25T08:29:28.373000+00:00",
-        "syncIntervalInMinute": 1440.0
-      },
       "pipelineEntityId": "PIPELINE~1E2532BAB8D4B86B7FB893D1D1DD256D",
       "sourceDatasets": []
     }
@@ -66,27 +48,6 @@
           ]
         }
       ],
-      "fiveTranConnector": {
-        "config": "{\"database\": \"source_db\", \"password\": \"******\", \"is_private_key_encrypted\": false, \"port\": 443, \"auth\": \"PASSWORD\", \"update_method\": \"TELEPORT\", \"host\": \"source_account.snowflakecomputing.com\", \"user\": \"user\"}",
-        "connectorLogsUrl": "https://fivetran.com/dashboard/connectors/connector_2/logs",
-        "connectorName": "snowflake_db",
-        "connectorTypeId": "snowflake_db",
-        "connectorTypeName": "Snowflake",
-        "connectorUrl": "https://fivetran.com/dashboard/connectors/connector_2",
-        "createdAt": "2023-04-10T18:02:35.655597+00:00",
-        "creatorEmail": "user@foo.com",
-        "iconUrl": "http://icon-url",
-        "paused": true,
-        "schemaMetadata": "[{\"name_in_source\": \"schema\", \"name_in_destination\": \"snowflake_db_schema\", \"tables\": [{\"name_in_source\": \"table\", \"name_in_destination\": \"table\", \"columns\": [{\"name_in_source\": \"col1\", \"name_in_destination\": \"col1\", \"type_in_source\": \"BigDecimal\", \"type_in_destination\": \"DECIMAL(38, 6)\", \"is_primary_key\": false, \"is_foreign_key\": false}, {\"name_in_source\": \"col2\", \"name_in_destination\": \"col2\", \"type_in_source\": \"BigDecimal\", \"type_in_destination\": \"DECIMAL(38, 6)\", \"is_primary_key\": false, \"is_foreign_key\": false}]}, {\"name_in_source\": \"table2\", \"name_in_destination\": \"table2\", \"columns\": [{\"name_in_source\": \"col1\", \"name_in_destination\": \"col1\", \"type_in_source\": \"BigDecimal\", \"type_in_destination\": \"DECIMAL(38, 6)\", \"is_primary_key\": false, \"is_foreign_key\": false}]}]}]",
-        "sourceEntityId": "DATASET~E71466A1A1CE8D63F92424B3CF3F3F4E",
-        "status": {
-          "setupState": "connected",
-          "syncState": "paused",
-          "updateState": "on_schedule"
-        },
-        "succeededAt": "2023-04-19T08:56:03.467000+00:00",
-        "syncIntervalInMinute": 1440.0
-      },
       "pipelineEntityId": "PIPELINE~77C9E0FE312C3E93891D2D8C3869F283",
       "sourceDatasets": [
         "DATASET~E71466A1A1CE8D63F92424B3CF3F3F4E"
@@ -116,27 +77,6 @@
           ]
         }
       ],
-      "fiveTranConnector": {
-        "config": "{\"database\": \"source_db\", \"password\": \"******\", \"is_private_key_encrypted\": false, \"port\": 443, \"auth\": \"PASSWORD\", \"update_method\": \"TELEPORT\", \"host\": \"source_account.snowflakecomputing.com\", \"user\": \"user\"}",
-        "connectorLogsUrl": "https://fivetran.com/dashboard/connectors/connector_2/logs",
-        "connectorName": "snowflake_db",
-        "connectorTypeId": "snowflake_db",
-        "connectorTypeName": "Snowflake",
-        "connectorUrl": "https://fivetran.com/dashboard/connectors/connector_2",
-        "createdAt": "2023-04-10T18:02:35.655597+00:00",
-        "creatorEmail": "user@foo.com",
-        "iconUrl": "http://icon-url",
-        "paused": true,
-        "schemaMetadata": "[{\"name_in_source\": \"schema\", \"name_in_destination\": \"snowflake_db_schema\", \"tables\": [{\"name_in_source\": \"table\", \"name_in_destination\": \"table\", \"columns\": [{\"name_in_source\": \"col1\", \"name_in_destination\": \"col1\", \"type_in_source\": \"BigDecimal\", \"type_in_destination\": \"DECIMAL(38, 6)\", \"is_primary_key\": false, \"is_foreign_key\": false}, {\"name_in_source\": \"col2\", \"name_in_destination\": \"col2\", \"type_in_source\": \"BigDecimal\", \"type_in_destination\": \"DECIMAL(38, 6)\", \"is_primary_key\": false, \"is_foreign_key\": false}]}, {\"name_in_source\": \"table2\", \"name_in_destination\": \"table2\", \"columns\": [{\"name_in_source\": \"col1\", \"name_in_destination\": \"col1\", \"type_in_source\": \"BigDecimal\", \"type_in_destination\": \"DECIMAL(38, 6)\", \"is_primary_key\": false, \"is_foreign_key\": false}]}]}]",
-        "sourceEntityId": "DATASET~F31B21D3EDB9FF855528E9D6679840C7",
-        "status": {
-          "setupState": "connected",
-          "syncState": "paused",
-          "updateState": "on_schedule"
-        },
-        "succeededAt": "2023-04-19T08:56:03.467000+00:00",
-        "syncIntervalInMinute": 1440.0
-      },
       "pipelineEntityId": "PIPELINE~77C9E0FE312C3E93891D2D8C3869F283",
       "sourceDatasets": [
         "DATASET~F31B21D3EDB9FF855528E9D6679840C7"


### PR DESCRIPTION

### 🤔 Why?

We have migrated to use the `upstream.pipeline_entity_id`, no need to keep the redundant information in `fivetran_connector` field

### 🤓 What?

- stop filling the `dataset.upstream.five_tran_connector` field

### 🧪 Tested?

unit tests
run locally and verified MCE file
