### PR TITLE
Skip publishing docker imeage for existingt tags

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -136,7 +136,13 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
+      - name: Check existing version
+        id: check
+        continue-on-error: true
+        run: docker manifest inspect ${{ env.DOCKER_IMAGE }}:${{ needs.version.outputs.full }} > /dev/null
+
       - name: Build Docker image
+        if: steps.check.outcome == 'failure'
         uses: docker/build-push-action@v2
         with:
           push: true

--- a/poetry.lock
+++ b/poetry.lock
@@ -3736,13 +3736,13 @@ files = [
 
 [[package]]
 name = "pymysql"
-version = "1.0.3"
+version = "1.1.0"
 description = "Pure Python MySQL Driver"
 optional = true
 python-versions = ">=3.7"
 files = [
-    {file = "PyMySQL-1.0.3-py3-none-any.whl", hash = "sha256:89fc6ae41c0aeb6e1f7710cdd623702ea2c54d040565767a78b00a5ebb12f4e5"},
-    {file = "PyMySQL-1.0.3.tar.gz", hash = "sha256:3dda943ef3694068a75d69d071755dbecacee1adf9a1fc5b206830d2b67d25e8"},
+    {file = "PyMySQL-1.1.0-py3-none-any.whl", hash = "sha256:8969ec6d763c856f7073c4c64662882675702efcb114b4bcbb955aea3a069fa7"},
+    {file = "PyMySQL-1.1.0.tar.gz", hash = "sha256:4f13a7df8bf36a51e81dd9f3605fede45a4878fe02f9236349fd82a3f0612f96"},
 ]
 
 [package.extras]
@@ -5140,4 +5140,4 @@ unity-catalog = ["databricks-cli"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "279f93267dfd1a6c5e47d5926559ec48dd198b29c3717929330b48cfb74acb30"
+content-hash = "9b6cd2675da511b0d16309147f2d90d221a985ddcdd65e43fa40646e4bdb3cba"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ metaphor-models = "0.23.0"
 msal = { version = "^1.20.0", optional = true }
 pycarlo = { version = "^0.7.6", optional = true }
 pydantic = "^1.10.0"
-pymssql = { version = "^2.2.7", optional = true }
+pymssql = { version = "2.2.7", optional = true } # pymssql 2.2.8 is currently broken
 pymysql = { version = "^1.0.2", optional = true }
 python = ">=3.8.1,<4.0"
 python-dateutil = "^2.8.1"


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Since PyPI doesn't allow re-publishing an existing version, we should do the same for Docker to prevent the 2 versions from going out of sync.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

https://github.com/MetaphorData/connectors/actions/runs/5713625309/job/15479353312

<img width="477" alt="Screenshot 2023-07-31 at 3 37 40 AM" src="https://github.com/MetaphorData/connectors/assets/24240669/a6c2d726-e780-46b7-85ca-c5a94c2c6204">


