### PR TITLE
Support fetching metadata from multiple dbt cloud jobs

### DIFF
--- a/metaphor/common/utils.py
+++ b/metaphor/common/utils.py
@@ -29,7 +29,7 @@ def chunks(list, n):
 def must_set_exactly_one(values: Dict, keys: List[str]):
     not_none = [k for k in keys if values.get(k) is not None]
     if len(not_none) != 1:
-        raise ValueError(f"must set exactly one of {keys}, found {not_none}")
+        raise ValueError(f"Must set exactly one of {keys}, found {not_none}")
 
 
 def md5_digest(value: bytes) -> str:

--- a/metaphor/dbt/cloud/client.py
+++ b/metaphor/dbt/cloud/client.py
@@ -1,0 +1,93 @@
+import json
+import shutil
+import tempfile
+from os import path
+from typing import Dict, Optional, Tuple
+
+import requests
+
+from metaphor.common.logger import get_logger
+
+logger = get_logger()
+
+
+class DbtAdminAPIClient:
+    """A client that wraps the dbt Cloud Administrative API
+
+    See https://docs.getdbt.com/dbt-cloud/api-v2 for more details.
+    """
+
+    def __init__(self, base_url: str, account_id: int, service_token: str):
+        self.admin_api_base_url = f"{base_url}/api/v2"
+        self.account_id = account_id
+        self.service_token = service_token
+
+    def _get(self, path: str, params: Optional[Dict] = None):
+        url = f"{self.admin_api_base_url}/accounts/{self.account_id}/{path}"
+        logger.debug(f"Sending request to {url}")
+        req = requests.get(
+            url,
+            params=params,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Token {self.service_token}",
+            },
+            timeout=600,  # request timeout 600s
+        )
+
+        assert req.status_code == 200, f"{url} returned {req.status_code}"
+        return req.json()
+
+    def get_last_successful_run(self, job_id: int) -> Tuple[int, int]:
+        """Get the project and run IDs of the last successful run for a job"""
+
+        offset = 0
+        page_size = 50
+        while True:
+            # https://docs.getdbt.com/dbt-cloud/api-v2#operation/listRunsForAccount
+            resp = self._get(
+                "runs/",
+                {
+                    "job_definition_id": job_id,
+                    "order_by": "-id",
+                    "limit": page_size,
+                    "offset": offset,
+                },
+            )
+
+            data = resp.get("data")
+            assert len(data) > 0, "Unable to find any successful run"
+
+            for run in data:
+                if run.get("status") == 10:
+                    return run.get("project_id"), run.get("id")
+
+            offset += page_size
+
+    def get_snowflake_account(self, project_id: int) -> Optional[str]:
+        """Get the Snowflake account name for a particular project
+
+        Return None if the project doesn't have a Snowflake connection
+        """
+
+        # https://docs.getdbt.com/dbt-cloud/api-v2#operation/getProjectById
+        resp = self._get(f"projects/{project_id}")
+        connection = resp.get("data").get("connection", {})
+        if connection.get("type") != "snowflake":
+            return None
+
+        return connection.get("details").get("account")
+
+    def get_run_artifact(self, job_id: int, run_id: int, artifact: str) -> str:
+        """Write a particular artifact from a run to a temp file."""
+
+        # https://docs.getdbt.com/dbt-cloud/api-v2#operation/getArtifactsByRunId
+        artifact_json = self._get(f"runs/{run_id}/artifacts/{artifact}")
+
+        fd, temp_name = tempfile.mkstemp()
+        with open(fd, "w") as fp:
+            json.dump(artifact_json, fp)
+
+        pretty_name = f"{path.dirname(temp_name)}/{job_id}-{artifact}"
+        shutil.copyfile(temp_name, pretty_name)
+        return pretty_name

--- a/metaphor/dbt/cloud/config.py
+++ b/metaphor/dbt/cloud/config.py
@@ -1,6 +1,7 @@
 from dataclasses import field as dataclass_field
-from typing import List
+from typing import List, Optional
 
+from pydantic import root_validator
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
@@ -13,11 +14,14 @@ class DbtCloudConfig(BaseConfig):
     # dbt cloud account ID
     account_id: int
 
-    # dbt cloud job ID
-    job_id: int
-
     # Service token for dbt cloud
     service_token: str
+
+    # (Deprecated. Use job_ids instead) dbt cloud job ID
+    job_id: Optional[int] = None
+
+    # dbt cloud job IDs
+    job_ids: List[int] = dataclass_field(default_factory=lambda: [])
 
     # map meta field to ownerships
     meta_ownerships: List[MetaOwnership] = dataclass_field(default_factory=lambda: [])
@@ -27,3 +31,10 @@ class DbtCloudConfig(BaseConfig):
 
     # Base URL for dbt instance
     base_url: str = "https://cloud.getdbt.com"
+
+    @root_validator
+    def set_job_ids_or_job_id(cls, values):
+        if values.get("job_id") is None and not values.get("job_ids"):
+            raise ValueError("Must set job_ids")
+
+        return values

--- a/metaphor/dbt/cloud/extractor.py
+++ b/metaphor/dbt/cloud/extractor.py
@@ -1,102 +1,15 @@
-import json
-import shutil
-import tempfile
-from os import path
-from typing import Collection, Dict, Optional, Tuple
-
-import requests
+from typing import Collection, List
 
 from metaphor.common.base_extractor import BaseExtractor
 from metaphor.common.event_util import ENTITY_TYPES
 from metaphor.common.logger import get_logger
+from metaphor.dbt.cloud.client import DbtAdminAPIClient
 from metaphor.dbt.cloud.config import DbtCloudConfig
 from metaphor.dbt.config import DbtRunConfig
 from metaphor.dbt.extractor import DbtExtractor
 from metaphor.models.crawler_run_metadata import Platform
 
 logger = get_logger()
-
-
-class DbtAdminAPIClient:
-    """A client that wraps the dbt Cloud Administrative API
-
-    See https://docs.getdbt.com/dbt-cloud/api-v2 for more details.
-    """
-
-    def __init__(self, base_url: str, account_id: int, service_token: str):
-        self.admin_api_base_url = f"{base_url}/api/v2"
-        self.account_id = account_id
-        self.service_token = service_token
-
-    def _get(self, path: str, params: Optional[Dict] = None):
-        url = f"{self.admin_api_base_url}/accounts/{self.account_id}/{path}"
-        logger.debug(f"Sending request to {url}")
-        req = requests.get(
-            url,
-            params=params,
-            headers={
-                "Content-Type": "application/json",
-                "Authorization": f"Token {self.service_token}",
-            },
-            timeout=600,  # request timeout 600s
-        )
-
-        assert req.status_code == 200, f"{url} returned {req.status_code}"
-        return req.json()
-
-    def get_last_successful_run(self, job_id: int) -> Tuple[int, int]:
-        """Get the project and run IDs of the last successful run for a job"""
-
-        offset = 0
-        page_size = 50
-        while True:
-            # https://docs.getdbt.com/dbt-cloud/api-v2#operation/listRunsForAccount
-            resp = self._get(
-                "runs/",
-                {
-                    "job_definition_id": job_id,
-                    "order_by": "-id",
-                    "limit": page_size,
-                    "offset": offset,
-                },
-            )
-
-            data = resp.get("data")
-            assert len(data) > 0, "Unable to find any successful run"
-
-            for run in data:
-                if run.get("status") == 10:
-                    return run.get("project_id"), run.get("id")
-
-            offset += page_size
-
-    def get_snowflake_account(self, project_id: int) -> Optional[str]:
-        """Get the Snowflake account name for a particular project
-
-        Return None if the project doesn't have a Snowflake connection
-        """
-
-        # https://docs.getdbt.com/dbt-cloud/api-v2#operation/getProjectById
-        resp = self._get(f"projects/{project_id}")
-        connection = resp.get("data").get("connection", {})
-        if connection.get("type") != "snowflake":
-            return None
-
-        return connection.get("details").get("account")
-
-    def get_run_artifact(self, run_id: int, artifact: str) -> str:
-        """Write a particular artifact from a run to a temp file."""
-
-        # https://docs.getdbt.com/dbt-cloud/api-v2#operation/getArtifactsByRunId
-        artifact_json = self._get(f"runs/{run_id}/artifacts/{artifact}")
-
-        fd, temp_name = tempfile.mkstemp()
-        with open(fd, "w") as fp:
-            json.dump(artifact_json, fp)
-
-        pretty_name = f"{path.dirname(temp_name)}/{artifact}"
-        shutil.copyfile(temp_name, pretty_name)
-        return pretty_name
 
 
 class DbtCloudExtractor(BaseExtractor):
@@ -111,37 +24,50 @@ class DbtCloudExtractor(BaseExtractor):
     def __init__(self, config: DbtCloudConfig):
         super().__init__(config, "dbt cloud metadata crawler", Platform.DBT_MODEL)
         self._account_id = config.account_id
-        self._job_id = config.job_id
+        self._job_ids = (
+            [config.job_id]
+            if config.job_id and len(config.job_ids) == 0
+            else config.job_ids
+        )
         self._service_token = config.service_token
         self._meta_ownerships = config.meta_ownerships
         self._meta_tags = config.meta_tags
         self._base_url = config.base_url
 
-    async def extract(self) -> Collection[ENTITY_TYPES]:
-        logger.info("Fetching metadata from DBT cloud")
-
-        client = DbtAdminAPIClient(
+        self._entities: List[ENTITY_TYPES] = []
+        self._client = DbtAdminAPIClient(
             base_url=self._base_url,
             account_id=self._account_id,
             service_token=self._service_token,
         )
 
-        project_id, run_id = client.get_last_successful_run(self._job_id)
+    async def extract(self) -> Collection[ENTITY_TYPES]:
+        logger.info("Fetching metadata from DBT cloud")
+
+        for job_id in self._job_ids:
+            await self._extract_job(job_id)
+
+        return self._entities
+
+    async def _extract_job(self, job_id: int):
+        logger.info(f"Fetching metadata for job ID: {job_id}")
+
+        project_id, run_id = self._client.get_last_successful_run(job_id)
         logger.info(f"Last successful run ID: {run_id}, project ID: {project_id}")
 
-        account = client.get_snowflake_account(project_id)
+        account = self._client.get_snowflake_account(project_id)
         if account is not None:
             logger.info(f"Snowflake account: {account}")
 
-        manifest_json = client.get_run_artifact(run_id, "manifest.json")
+        manifest_json = self._client.get_run_artifact(job_id, run_id, "manifest.json")
         logger.info(f"manifest.json saved to {manifest_json}")
 
         docs_base_url = (
-            f"{self._base_url}/accounts/{self._account_id}/jobs/{self._job_id}/docs"
+            f"{self._base_url}/accounts/{self._account_id}/jobs/{job_id}/docs"
         )
 
         # Pass the path of the downloaded manifest file to the dbt Core extractor
-        return await DbtExtractor(
+        entities = await DbtExtractor(
             DbtRunConfig(
                 manifest=manifest_json,
                 account=account,
@@ -151,3 +77,4 @@ class DbtCloudExtractor(BaseExtractor):
                 meta_tags=self._meta_tags,
             )
         ).extract()
+        self._entities.extend(entities)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.12.42"
+version = "0.12.43"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/dbt/cloud/config_legacy.yml
+++ b/tests/dbt/cloud/config_legacy.yml
@@ -1,8 +1,6 @@
 ---
 account_id: 1234
-job_ids:
-  - 5678
-  - 9012
+job_id: 5678
 service_token: token
 base_url: https://cloud.metaphor.getdbt.com
 output: {}

--- a/tests/dbt/cloud/test_client.py
+++ b/tests/dbt/cloud/test_client.py
@@ -1,0 +1,117 @@
+from typing import Dict
+from unittest.mock import patch
+
+from metaphor.dbt.cloud.client import DbtAdminAPIClient
+
+
+class Response:
+    def __init__(self, status_code: int, json: Dict):
+        self.status_code = status_code
+        self._json = json
+
+    def json(self) -> Dict:
+        return self._json
+
+
+@patch("metaphor.dbt.cloud.client.requests")
+def test_get_last_successful_run(mock_requests):
+    client = DbtAdminAPIClient(
+        base_url="http://base.url",
+        account_id=1111,
+        service_token="service_token",
+    )
+
+    mock_requests.get.return_value = Response(
+        200,
+        {
+            "data": [
+                {
+                    "id": 1,
+                    "project_id": 111,
+                    "status": 20,
+                },
+                {
+                    "id": 2,
+                    "project_id": 222,
+                    "status": 10,
+                },
+            ]
+        },
+    )
+
+    (project_id, run_id) = client.get_last_successful_run(2222)
+    assert project_id == 222
+    assert run_id == 2
+
+    mock_requests.get.assert_called_once_with(
+        "http://base.url/api/v2/accounts/1111/runs/",
+        params={
+            "job_definition_id": 2222,
+            "order_by": "-id",
+            "limit": 50,
+            "offset": 0,
+        },
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": "Token service_token",
+        },
+        timeout=600,
+    )
+
+
+@patch("metaphor.dbt.cloud.client.requests")
+def test_get_snowflake_account(mock_requests):
+    client = DbtAdminAPIClient(
+        base_url="http://base.url",
+        account_id=1111,
+        service_token="service_token",
+    )
+
+    mock_requests.get.return_value = Response(
+        200,
+        {
+            "data": {
+                "connection": {
+                    "type": "snowflake",
+                    "details": {"account": "snowflake_account"},
+                }
+            }
+        },
+    )
+
+    account = client.get_snowflake_account(2222)
+    assert account == "snowflake_account"
+
+    mock_requests.get.assert_called_once_with(
+        "http://base.url/api/v2/accounts/1111/projects/2222",
+        params=None,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": "Token service_token",
+        },
+        timeout=600,
+    )
+
+
+@patch("metaphor.dbt.cloud.client.requests")
+def test_get_run_artifact(mock_requests):
+    client = DbtAdminAPIClient(
+        base_url="http://base.url",
+        account_id=1111,
+        service_token="service_token",
+    )
+
+    mock_requests.get.return_value = Response(200, {"artifact": "json"})
+
+    path = client.get_run_artifact(2222, 3333, "manifest.json")
+    assert path.endswith("/2222-manifest.json")
+
+    mock_requests.get.assert_called_once_with(
+        "http://base.url/api/v2/accounts/1111/runs/3333/artifacts/manifest.json",
+        params=None,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": "Token service_token",
+        },
+        timeout=600,
+    )

--- a/tests/dbt/cloud/test_config.py
+++ b/tests/dbt/cloud/test_config.py
@@ -7,7 +7,23 @@ def test_yaml_config(test_root_dir):
 
     assert config == DbtCloudConfig(
         account_id=1234,
+        job_id=None,
+        job_ids=[5678, 9012],
+        service_token="token",
+        base_url="https://cloud.metaphor.getdbt.com",
+        output=OutputConfig(),
+    )
+
+
+def test_yaml_config_legacy(test_root_dir):
+    config = DbtCloudConfig.from_yaml_file(
+        f"{test_root_dir}/dbt/cloud/config_legacy.yml"
+    )
+
+    assert config == DbtCloudConfig(
+        account_id=1234,
         job_id=5678,
+        job_ids=[],
         service_token="token",
         base_url="https://cloud.metaphor.getdbt.com",
         output=OutputConfig(),

--- a/tests/dbt/cloud/test_extractor.py
+++ b/tests/dbt/cloud/test_extractor.py
@@ -32,7 +32,7 @@ async def test_extractor(
     config = DbtCloudConfig(
         output=OutputConfig(),
         account_id=1111,
-        job_id=2222,
+        job_ids=[2222],
         base_url="https://cloud.metaphor.getdbt.com",
         service_token="service_token",
     )


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Setting up separate connectors for multiple dbt jobs quickly becomes a maintenance headache. Given how quickly it is to fetch metadata for a single dbt job, supporting multiple jobs in a single connector seems like an obvious extension.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Add `job_ids` config and deprecate `job_id`
- Update connector to support multiple job IDs
- Move `DbtAdminAPIClient` into a separate file and add tests

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified end-to-end against a production instance.
