### PR TITLE
Fix Fivetran pipeline associating MSSQL

### DIFF
--- a/metaphor/fivetran/extractor.py
+++ b/metaphor/fivetran/extractor.py
@@ -238,16 +238,13 @@ class FivetranExtractor(BaseExtractor):
         source_platform = (
             SOURCE_PLATFORM_MAPPING.get(connector.service) or DataPlatform.EXTERNAL
         )
-        source_account = (
-            self.get_snowflake_account_from_config(connector.config)
-            if source_platform == DataPlatform.SNOWFLAKE
-            else None
-        )
 
         source_logical_id = DatasetLogicalID(
             name=source_dataset_name,
             platform=source_platform,
-            account=source_account,
+            account=self.get_source_account_from_config(
+                connector.config, source_platform
+            ),
         )
 
         return source_logical_id
@@ -390,6 +387,18 @@ class FivetranExtractor(BaseExtractor):
         # remove snowflakecomputing.com parts
         account = ".".join(host.split(".")[:-2])
         return normalize_snowflake_account(account)
+
+    @staticmethod
+    def get_source_account_from_config(
+        config: dict, source_platform: DataPlatform
+    ) -> Optional[str]:
+        if source_platform == DataPlatform.SNOWFLAKE:
+            return FivetranExtractor.get_snowflake_account_from_config(config)
+        elif source_platform == DataPlatform.MSSQL:
+            host = config.get("host")
+            if host:
+                return host.lower()
+        return None
 
     @staticmethod
     def get_database_name_from_destination(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.12.46"
+version = "0.12.47"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/fivetran/data/v1__connectors__connector_3.json
+++ b/tests/fivetran/data/v1__connectors__connector_3.json
@@ -1,0 +1,32 @@
+{
+  "code": "Success",
+  "data": {
+    "id": "connector_3",
+    "group_id": "group_id_1",
+    "service": "sql_server",
+    "service_version": 0,
+    "schema": "source_schema",
+    "connected_by": "user",
+    "created_at": "2023-04-10T18:02:35.655597Z",
+    "succeeded_at": "2023-04-19T08:56:03.467Z",
+    "failed_at": null,
+    "paused": false,
+    "pause_after_trial": false,
+    "sync_frequency": 1440,
+    "schedule_type": "auto",
+    "status": {
+      "setup_state": "connected",
+      "sync_state": "paused",
+      "update_state": "on_schedule",
+      "is_historical_sync": false,
+      "tasks": [],
+      "warnings": []
+    },
+    "config": {
+      "database": "source_db",
+      "password": "******",
+      "host": "sql-Server.foo.bar",
+      "user": "user"
+    }
+  }
+}

--- a/tests/fivetran/data/v1__groups__group_id_1__connectors_2.json
+++ b/tests/fivetran/data/v1__groups__group_id_1__connectors_2.json
@@ -28,6 +28,32 @@
         "setup_tests": null,
         "config": null,
         "source_sync_details": null
+      },
+      {
+        "id": "connector_3",
+        "group_id": "group_id_1",
+        "service": "sql_server",
+        "service_version": 0,
+        "schema": "sqldb_foo",
+        "connected_by": "user_id",
+        "created_at": "2023-04-10T18:02:35.655597Z",
+        "succeeded_at": "2023-04-19T08:56:03.467Z",
+        "failed_at": null,
+        "paused": false,
+        "pause_after_trial": false,
+        "sync_frequency": 1440,
+        "daily_sync_time": null,
+        "schedule_type": "auto",
+        "status": {
+          "setup_state": "connected",
+          "sync_state": "paused",
+          "update_state": "on_schedule",
+          "is_historical_sync": false,
+          "tasks": [],
+          "warnings": []
+        },
+        "setup_tests": null,
+        "source_sync_details": null
       }
     ]
   }

--- a/tests/fivetran/data/v1__metadata__connectors__connector_3__columns.json
+++ b/tests/fivetran/data/v1__metadata__connectors__connector_3__columns.json
@@ -1,0 +1,37 @@
+{
+  "code": "Success",
+  "data": {
+    "items": [
+      {
+        "id": "MzI4NDE5MTg0",
+        "parent_id": "OTI2OTU2OQ",
+        "name_in_source": "col1",
+        "name_in_destination": "col1",
+        "type_in_source": "BigDecimal",
+        "type_in_destination": "DECIMAL(38, 6)",
+        "is_primary_key": false,
+        "is_foreign_key": false
+      },
+      {
+        "id": "MzI4NDE5MTg0",
+        "parent_id": "OTI2OTU2OQ",
+        "name_in_source": "col2",
+        "name_in_destination": "col2",
+        "type_in_source": "BigDecimal",
+        "type_in_destination": "DECIMAL(38, 6)",
+        "is_primary_key": false,
+        "is_foreign_key": false
+      },
+      {
+        "id": "MzI4NDE5MTg1",
+        "parent_id": "OTI2OTU2OR",
+        "name_in_source": "col1",
+        "name_in_destination": "col1",
+        "type_in_source": "BigDecimal",
+        "type_in_destination": "DECIMAL(38, 6)",
+        "is_primary_key": false,
+        "is_foreign_key": false
+      }
+    ]
+  }
+}

--- a/tests/fivetran/data/v1__metadata__connectors__connector_3__schemas.json
+++ b/tests/fivetran/data/v1__metadata__connectors__connector_3__schemas.json
@@ -1,0 +1,12 @@
+{
+  "code": "Success",
+  "data": {
+    "items": [
+      {
+        "id": "c25vd2ZsYWtlX2RiX3JpZGVfc2hhcmU",
+        "name_in_source": "schema",
+        "name_in_destination": "sqldb_foo"
+      }
+    ]
+  }
+}

--- a/tests/fivetran/data/v1__metadata__connectors__connector_3__tables.json
+++ b/tests/fivetran/data/v1__metadata__connectors__connector_3__tables.json
@@ -1,0 +1,19 @@
+{
+  "code": "Success",
+  "data": {
+    "items": [
+      {
+        "id": "OTI2OTU2OQ",
+        "parent_id": "c25vd2ZsYWtlX2RiX3JpZGVfc2hhcmU",
+        "name_in_source": "table",
+        "name_in_destination": "table"
+      },
+      {
+        "id": "OTI2OTU2OR",
+        "parent_id": "c25vd2ZsYWtlX2RiX3JpZGVfc2hhcmU",
+        "name_in_source": "table2",
+        "name_in_destination": "table2"
+      }
+    ]
+  }
+}

--- a/tests/fivetran/expected.json
+++ b/tests/fivetran/expected.json
@@ -85,6 +85,78 @@
   },
   {
     "logicalId": {
+      "account": "dest_account",
+      "name": "fivetran.sqldb_foo.table",
+      "platform": "SNOWFLAKE"
+    },
+    "upstream": {
+      "fieldMappings": [
+        {
+          "destination": "col1",
+          "sources": [
+            {
+              "dataset": {
+                "account": "sql-server.foo.bar",
+                "name": "source_db.schema.table",
+                "platform": "MSSQL"
+              },
+              "field": "col1",
+              "sourceEntityId": "DATASET~CA36B7F1E380295A5286B5E231A6A088"
+            }
+          ]
+        },
+        {
+          "destination": "col2",
+          "sources": [
+            {
+              "dataset": {
+                "account": "sql-server.foo.bar",
+                "name": "source_db.schema.table",
+                "platform": "MSSQL"
+              },
+              "field": "col2",
+              "sourceEntityId": "DATASET~CA36B7F1E380295A5286B5E231A6A088"
+            }
+          ]
+        }
+      ],
+      "pipelineEntityId": "PIPELINE~A49A21FB45EC17B27B135D4905DFB0AA",
+      "sourceDatasets": [
+        "DATASET~CA36B7F1E380295A5286B5E231A6A088"
+      ]
+    }
+  },
+  {
+    "logicalId": {
+      "account": "dest_account",
+      "name": "fivetran.sqldb_foo.table2",
+      "platform": "SNOWFLAKE"
+    },
+    "upstream": {
+      "fieldMappings": [
+        {
+          "destination": "col1",
+          "sources": [
+            {
+              "dataset": {
+                "account": "sql-server.foo.bar",
+                "name": "source_db.schema.table2",
+                "platform": "MSSQL"
+              },
+              "field": "col1",
+              "sourceEntityId": "DATASET~640B6534F4B207F3A50447769DB47B38"
+            }
+          ]
+        }
+      ],
+      "pipelineEntityId": "PIPELINE~A49A21FB45EC17B27B135D4905DFB0AA",
+      "sourceDatasets": [
+        "DATASET~640B6534F4B207F3A50447769DB47B38"
+      ]
+    }
+  },
+  {
+    "logicalId": {
       "account": "source_account",
       "name": "source_db.schema.table",
       "platform": "SNOWFLAKE"
@@ -95,6 +167,20 @@
       "account": "source_account",
       "name": "source_db.schema.table2",
       "platform": "SNOWFLAKE"
+    }
+  },
+  {
+    "logicalId": {
+      "account": "sql-server.foo.bar",
+      "name": "source_db.schema.table",
+      "platform": "MSSQL"
+    }
+  },
+  {
+    "logicalId": {
+      "account": "sql-server.foo.bar",
+      "name": "source_db.schema.table2",
+      "platform": "MSSQL"
     }
   },
   {
@@ -156,6 +242,38 @@
     },
     "logicalId": {
       "name": "connector_2",
+      "type": "FIVETRAN"
+    }
+  },
+  {
+    "fivetran": {
+      "config": "{\"database\": \"source_db\", \"password\": \"******\", \"host\": \"sql-Server.foo.bar\", \"user\": \"user\"}",
+      "connectorLogsUrl": "https://fivetran.com/dashboard/connectors/connector_3/logs",
+      "connectorName": "source_schema",
+      "connectorTypeId": "sql_server",
+      "connectorUrl": "https://fivetran.com/dashboard/connectors/connector_3",
+      "created": "2023-04-10T18:02:35.655597+00:00",
+      "creatorEmail": "user@foo.com",
+      "lastSucceeded": "2023-04-19T08:56:03.467000+00:00",
+      "paused": false,
+      "schemaMetadata": "[{\"name_in_source\": \"schema\", \"name_in_destination\": \"sqldb_foo\", \"tables\": [{\"name_in_source\": \"table\", \"name_in_destination\": \"table\", \"columns\": [{\"name_in_source\": \"col1\", \"name_in_destination\": \"col1\", \"type_in_source\": \"BigDecimal\", \"type_in_destination\": \"DECIMAL(38, 6)\", \"is_primary_key\": false, \"is_foreign_key\": false}, {\"name_in_source\": \"col2\", \"name_in_destination\": \"col2\", \"type_in_source\": \"BigDecimal\", \"type_in_destination\": \"DECIMAL(38, 6)\", \"is_primary_key\": false, \"is_foreign_key\": false}]}, {\"name_in_source\": \"table2\", \"name_in_destination\": \"table2\", \"columns\": [{\"name_in_source\": \"col1\", \"name_in_destination\": \"col1\", \"type_in_source\": \"BigDecimal\", \"type_in_destination\": \"DECIMAL(38, 6)\", \"is_primary_key\": false, \"is_foreign_key\": false}]}]}]",
+      "sources": [
+        "DATASET~640B6534F4B207F3A50447769DB47B38",
+        "DATASET~CA36B7F1E380295A5286B5E231A6A088"
+      ],
+      "status": {
+        "setupState": "connected",
+        "syncState": "paused",
+        "updateState": "on_schedule"
+      },
+      "syncIntervalInMinute": 1440.0,
+      "targets": [
+        "DATASET~661DF54472FF1E1B8CDEB15867237572",
+        "DATASET~F1E5D0FDE9CEC9D0823EE564C457CD16"
+      ]
+    },
+    "logicalId": {
+      "name": "connector_3",
       "type": "FIVETRAN"
     }
   }

--- a/tests/fivetran/test_extractor.py
+++ b/tests/fivetran/test_extractor.py
@@ -56,6 +56,9 @@ async def test_extractor(mock_get: MagicMock, test_root_dir: str):
             load_json(f"{test_root_dir}/fivetran/data/v1__connectors__connector_2.json")
         ),
         MockResponse(
+            load_json(f"{test_root_dir}/fivetran/data/v1__connectors__connector_3.json")
+        ),
+        MockResponse(
             load_json(
                 f"{test_root_dir}/fivetran/data/v1__groups__group_id_1__users.json"
             )
@@ -88,6 +91,21 @@ async def test_extractor(mock_get: MagicMock, test_root_dir: str):
         MockResponse(
             load_json(
                 f"{test_root_dir}/fivetran/data/v1__metadata__connectors__connector_2__columns.json"
+            )
+        ),
+        MockResponse(
+            load_json(
+                f"{test_root_dir}/fivetran/data/v1__metadata__connectors__connector_3__schemas.json"
+            )
+        ),
+        MockResponse(
+            load_json(
+                f"{test_root_dir}/fivetran/data/v1__metadata__connectors__connector_3__tables.json"
+            )
+        ),
+        MockResponse(
+            load_json(
+                f"{test_root_dir}/fivetran/data/v1__metadata__connectors__connector_3__columns.json"
             )
         ),
     ]

--- a/tests/fivetran/test_get_account.py
+++ b/tests/fivetran/test_get_account.py
@@ -1,0 +1,23 @@
+from metaphor.fivetran.extractor import FivetranExtractor
+from metaphor.models.metadata_change_event import DataPlatform
+
+
+def test_get_account():
+    assert (
+        FivetranExtractor.get_source_account_from_config({}, DataPlatform.BIGQUERY)
+        is None
+    )
+
+    assert (
+        FivetranExtractor.get_source_account_from_config(
+            {"host": "Test-Sqldb.Domain.com"}, DataPlatform.MSSQL
+        )
+        == "test-sqldb.domain.com"
+    )
+
+    assert (
+        FivetranExtractor.get_source_account_from_config(
+            {"host": "account.snowflakecomputing.com"}, DataPlatform.SNOWFLAKE
+        )
+        == "account"
+    )


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

We only fill account field in dataset logical ID for `Snowflake`, so the lineage associating with sqlserver connector was broken.

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

Fill account for MSSQL tables

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

unit tests

<!--
  Describe how the change was tested end-to-end.
-->
