### PR TITLE
Drop unused data_platform field from MC's config

### DIFF
--- a/metaphor/monte_carlo/config.py
+++ b/metaphor/monte_carlo/config.py
@@ -4,16 +4,12 @@ from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
 from metaphor.common.dataclass import ConnectorConfig
-from metaphor.models.metadata_change_event import DataPlatform
 
 
 @dataclass(config=ConnectorConfig)
 class MonteCarloRunConfig(BaseConfig):
     api_key_id: str
     api_key_secret: str
-
-    # (Do not use) data platform of the monitored assets
-    data_platform: Optional[DataPlatform] = None
 
     # Snowflake data source account
     snowflake_account: Optional[str] = None

--- a/tests/monte_carlo/config.yml
+++ b/tests/monte_carlo/config.yml
@@ -1,5 +1,4 @@
 ---
 api_key_id: key_id
 api_key_secret: key_secret
-data_platform: SNOWFLAKE
 output: {}

--- a/tests/monte_carlo/test_config.py
+++ b/tests/monte_carlo/test_config.py
@@ -1,5 +1,4 @@
 from metaphor.common.base_config import OutputConfig
-from metaphor.models.metadata_change_event import DataPlatform
 from metaphor.monte_carlo.config import MonteCarloRunConfig
 
 
@@ -11,6 +10,5 @@ def test_yaml_config(test_root_dir):
     assert config == MonteCarloRunConfig(
         api_key_id="key_id",
         api_key_secret="key_secret",
-        data_platform=DataPlatform.SNOWFLAKE,
         output=OutputConfig(),
     )


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

The field has long been deprecated and unused.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled. Will bump up the minor version once all [breaking changes](https://github.com/MetaphorData/connectors/issues/523) are merged. 

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified against a production instance.