### PR TITLE
Pin oscrypto to specific hash to fix compatiblity issue with OpenSSL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.2"
+version = "0.13.3"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]
@@ -31,6 +31,7 @@ lkml = { version = "^1.3.1", optional = true }
 looker-sdk = { version = "^23.6.0", optional = true }
 metaphor-models = "0.27.0"
 msal = { version = "^1.20.0", optional = true }
+oscrypto = { git = "https://github.com/wbond/oscrypto.git", rev = "1547f53" } # Until oscrypto 1.3.1 is release: https://github.com/wbond/oscrypto/issues/78
 pycarlo = { version = "^0.8.1", optional = true }
 pydantic = "^1.10.0"
 pymssql = { version = "2.2.7", optional = true } # pymssql 2.2.8 is currently broken


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

https://github.com/MetaphorData/connectors/pull/624 didn't fix the issue. As explained [here](https://community.snowflake.com/s/article/Python-Connector-fails-to-connect-with-LibraryNotFoundError-Error-detecting-the-version-of-libcrypto), it's a compatibility issue between `oscrypto` & newer version of `OpenSSL`.  

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

While the issue has been [fixed](https://github.com/wbond/oscrypto/pull/76) upstream, no new version has been released on PyPI yet. Pinning down the version for now as suggested in https://github.com/wbond/oscrypto/issues/78

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified against a production instance.