### PR TITLE
Fix dbt 1.6.6 manifest schema validation errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.4"
+version = "0.13.5"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

dbt 1.6.6 introduced changes that are not compatible with the latest manifest JSON schema: https://github.com/dbt-labs/dbt-core/issues/8851

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Strip off the extra fields in metrics as a temporary work around. Also add tests for all current workarounds.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified against a production instance.
