### PR TITLE
Tableau crawler throws exception when parsing [sc-21713]

### DIFF
--- a/metaphor/tableau/extractor.py
+++ b/metaphor/tableau/extractor.py
@@ -307,6 +307,7 @@ class TableauExtractor(BaseExtractor):
 
         query = custom_sql_table.query
         upstream_datasets = []
+        source_tables = []
 
         try:
             parser = LineageRunner(query)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.14"
+version = "0.13.15"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
### 🤔 Why?

Variable `source_tables` is created and assigned inside a try-catch block. If the parser failed, the `source_tables` is not initialized, so later references will throw error: local variable 'source_tables' referenced before assignment

### 🤓 What?

- initialize `source_tables` to empty array 

### 🧪 Tested?

n/a
