### PR TITLE
Lower the default query size limit to 512KiB

### DIFF
--- a/metaphor/snowflake/config.py
+++ b/metaphor/snowflake/config.py
@@ -12,8 +12,8 @@ from metaphor.snowflake.utils import DEFAULT_THREAD_POOL_SIZE
 # number of query logs to fetch from Snowflake in one batch
 DEFAULT_QUERY_LOG_FETCH_SIZE = 100000
 
-# By default ignore queries larger than 10MB
-DEFAULT_MAX_QUERY_SIZE = 10 * 1024 * 1024
+# By default ignore queries larger than 512KiB
+DEFAULT_MAX_QUERY_SIZE = 512 * 1024
 
 
 @dataclass(config=ConnectorConfig)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.20"
+version = "0.13.21"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

10 MB still seems unreasonably large for queries.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

N/A