### PR TITLE
Extract column description from Unity Catalog tables

### DIFF
--- a/metaphor/unity_catalog/extractor.py
+++ b/metaphor/unity_catalog/extractor.py
@@ -161,6 +161,7 @@ class UnityCatalogExtractor(BaseExtractor):
                     field_path=column.name,
                     native_type=column.type_name,
                     precision=float(column.type_precision),
+                    description=column.comment,
                 )
                 for column in table.columns
             ],

--- a/metaphor/unity_catalog/models.py
+++ b/metaphor/unity_catalog/models.py
@@ -13,6 +13,7 @@ class Column(BaseModel):
     type_name: str
     type_precision: int
     nullable: bool
+    comment: Optional[str] = None
 
 
 class TableType(str, Enum):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.23"
+version = "0.13.24"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/unity_catalog/expected.json
+++ b/tests/unity_catalog/expected.json
@@ -23,7 +23,8 @@
           "fieldName": "col1",
           "fieldPath": "col1",
           "nativeType": "int",
-          "precision": 32.0
+          "precision": 32.0,
+          "description": "some description"
         }
       ],
       "schemaType": "SQL",

--- a/tests/unity_catalog/test_extractor.py
+++ b/tests/unity_catalog/test_extractor.py
@@ -57,6 +57,7 @@ async def test_extractor(
                             "type_name": "int",
                             "type_precision": 32,
                             "nullable": True,
+                            "comment": "some description",
                         }
                     ],
                     "storage_location": "s3://path",


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

The connector currently only extracts table-level descriptions but not column-level ones.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified against a production instance.
