### PR TITLE
Add `OwnershipAssignment` to dbt `VirtualView`

### DIFF
--- a/metaphor/dbt/README.md
+++ b/metaphor/dbt/README.md
@@ -76,7 +76,7 @@ You can also choose between assigning the owner to the materialized table, the d
 
 ```yaml
 meta_ownerships:
-  - meta_key: owner@test.com
+  - meta_key: owner
     ownership_type: Data Steward
     assignment_target: dbt_model # Valid choices: "dbt_model", "materialized_table", both. Default is "materialized_table"
 ```

--- a/metaphor/dbt/README.md
+++ b/metaphor/dbt/README.md
@@ -78,7 +78,7 @@ You can also choose between assigning the owner to the materialized table, the d
 meta_ownerships:
   - meta_key: owner
     ownership_type: Data Steward
-    assignment_target: dbt_model # Valid choices: "dbt_model", "materialized_table", "both". Default is "materialized_table"
+    assignment_target: dbt_model # Valid choices: "dbt_model", "materialized_table", "both". Default is "both"
 ```
 
 #### Governed Tags

--- a/metaphor/dbt/README.md
+++ b/metaphor/dbt/README.md
@@ -72,6 +72,15 @@ meta_ownerships:
     email_domain: test.com
 ```
 
+You can also choose between assigning the owner to the materialized table, the dbt model, or both:
+
+```yaml
+meta_ownerships:
+  - meta_key: owner@test.com
+    ownership_type: Data Steward
+    assignment_target: dbt_model # Valid choices: dbt_model, materialized_table, both. Default is materialized table
+```
+
 #### Governed Tags
 
 Similar to [Ownership](#ownership), you can optionally specify certain attributes in meta. For example:

--- a/metaphor/dbt/README.md
+++ b/metaphor/dbt/README.md
@@ -78,7 +78,7 @@ You can also choose between assigning the owner to the materialized table, the d
 meta_ownerships:
   - meta_key: owner@test.com
     ownership_type: Data Steward
-    assignment_target: dbt_model # Valid choices: dbt_model, materialized_table, both. Default is materialized table
+    assignment_target: dbt_model # Valid choices: "dbt_model", "materialized_table", both. Default is "materialized_table"
 ```
 
 #### Governed Tags

--- a/metaphor/dbt/README.md
+++ b/metaphor/dbt/README.md
@@ -78,7 +78,7 @@ You can also choose between assigning the owner to the materialized table, the d
 meta_ownerships:
   - meta_key: owner
     ownership_type: Data Steward
-    assignment_target: dbt_model # Valid choices: "dbt_model", "materialized_table", both. Default is "materialized_table"
+    assignment_target: dbt_model # Valid choices: "dbt_model", "materialized_table", "both". Default is "materialized_table"
 ```
 
 #### Governed Tags

--- a/metaphor/dbt/config.py
+++ b/metaphor/dbt/config.py
@@ -1,10 +1,12 @@
 from dataclasses import field as dataclass_field
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
 from metaphor.common.dataclass import ConnectorConfig
+
+MetaOwnershipAssignmentTarget = Literal["dbt_model", "materialized_table", "both"]
 
 
 @dataclass(config=ConnectorConfig)
@@ -17,6 +19,10 @@ class MetaOwnership:
 
     # Domain for user names
     email_domain: Optional[str] = None
+
+    # The target to assign this ownership to. Can be either the dbt model, the materialized table, or both.
+    # Defaults to the materialized table.
+    assignment_target: MetaOwnershipAssignmentTarget = "materialized_table"
 
 
 @dataclass(config=ConnectorConfig)

--- a/metaphor/dbt/config.py
+++ b/metaphor/dbt/config.py
@@ -21,8 +21,8 @@ class MetaOwnership:
     email_domain: Optional[str] = None
 
     # The target to assign this ownership to. Can be either the dbt model, the materialized table, or both.
-    # Defaults to the materialized table.
-    assignment_target: MetaOwnershipAssignmentTarget = "materialized_table"
+    # Defaults to both.
+    assignment_target: MetaOwnershipAssignmentTarget = "both"
 
 
 @dataclass(config=ConnectorConfig)

--- a/metaphor/dbt/manifest_parser.py
+++ b/metaphor/dbt/manifest_parser.py
@@ -417,7 +417,7 @@ class ManifestParser:
             virtual_view.dbt_model.raw_sql = model.raw_code
             dbt_model.compiled_sql = model.compiled_code
 
-        self._parse_model_meta(model)
+        self._parse_model_meta(model, virtual_view)
 
         self._parse_model_materialization(model, dbt_model)
 
@@ -457,7 +457,9 @@ class ManifestParser:
 
         return macro_map
 
-    def _parse_model_meta(self, model: MODEL_NODE_TYPE) -> None:
+    def _parse_model_meta(
+        self, model: MODEL_NODE_TYPE, virtual_view: VirtualView
+    ) -> None:
         if model.config is None or model.database is None:
             logger.warning("Skipping model without config or database")
             return
@@ -488,9 +490,9 @@ class ManifestParser:
         # Assign ownership & tags to materialized table/view
         ownerships = get_ownerships_from_meta(meta, self._meta_ownerships)
         if len(ownerships) > 0:
-            get_dataset().ownership_assignment = OwnershipAssignment(
-                ownerships=ownerships
-            )
+            ownership_assignment = OwnershipAssignment(ownerships=ownerships)
+            get_dataset().ownership_assignment = ownership_assignment
+            virtual_view.ownership_assignment = ownership_assignment
 
         tag_names = get_tags_from_meta(meta, self._meta_tags)
         if len(tag_names) > 0:

--- a/metaphor/dbt/manifest_parser.py
+++ b/metaphor/dbt/manifest_parser.py
@@ -489,10 +489,14 @@ class ManifestParser:
 
         # Assign ownership & tags to materialized table/view
         ownerships = get_ownerships_from_meta(meta, self._meta_ownerships)
-        if len(ownerships) > 0:
-            ownership_assignment = OwnershipAssignment(ownerships=ownerships)
-            get_dataset().ownership_assignment = ownership_assignment
-            virtual_view.ownership_assignment = ownership_assignment
+        if len(ownerships.materialized_table) > 0:
+            get_dataset().ownership_assignment = OwnershipAssignment(
+                ownerships=ownerships.materialized_table
+            )
+        if len(ownerships.dbt_model) > 0:
+            virtual_view.ownership_assignment = OwnershipAssignment(
+                ownerships=ownerships.dbt_model
+            )
 
         tag_names = get_tags_from_meta(meta, self._meta_tags)
         if len(tag_names) > 0:

--- a/metaphor/dbt/util.py
+++ b/metaphor/dbt/util.py
@@ -83,12 +83,7 @@ def get_ownerships_from_meta(
         value = meta.get(meta_ownership.meta_key)
         email_or_usernames = []
         if isinstance(value, str):
-            # If there's a comma in the string, treat it as a sequence of strings
-            if "," in value:
-                values = [x.strip() for x in value.split(",") if x.strip()]
-                email_or_usernames.extend(values)
-            else:
-                email_or_usernames.append(value)
+            email_or_usernames.append(value)
         elif isinstance(value, list):
             email_or_usernames.extend(value)
 

--- a/metaphor/dbt/util.py
+++ b/metaphor/dbt/util.py
@@ -83,7 +83,12 @@ def get_ownerships_from_meta(
         value = meta.get(meta_ownership.meta_key)
         email_or_usernames = []
         if isinstance(value, str):
-            email_or_usernames.append(value)
+            # If there's a comma in the string, treat it as a sequence of strings
+            if "," in value:
+                values = [x.strip() for x in value.split(",") if x.strip()]
+                email_or_usernames.extend(values)
+            else:
+                email_or_usernames.append(value)
         elif isinstance(value, list):
             email_or_usernames.extend(value)
 

--- a/metaphor/dbt/util.py
+++ b/metaphor/dbt/util.py
@@ -94,9 +94,9 @@ def get_ownerships_from_meta(
                     contact_designation_name=meta_ownership.ownership_type,
                     person=owner,
                 )
-                if meta_ownership.assignment_target != "materialized_table":
+                if meta_ownership.assignment_target in ["dbt_model", "both"]:
                     ownerships.dbt_model.append(ownership)
-                if meta_ownership.assignment_target != "dbt_model":
+                if meta_ownership.assignment_target in ["materialized_table", "both"]:
                     ownerships.materialized_table.append(ownership)
 
     return ownerships

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.27"
+version = "0.13.28"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.25"
+version = "0.13.26"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.26"
+version = "0.13.27"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/dbt/data/trial_v4/results.json
+++ b/tests/dbt/data/trial_v4/results.json
@@ -211,14 +211,6 @@
     "logicalId": {
       "name": "trial.my_first_dbt_model",
       "type": "DBT_MODEL"
-    },
-    "ownershipAssignment": {
-      "ownerships": [
-        {
-          "contactDesignationName": "Maintainer",
-          "person": "PERSON~8B6974C32BFCBBF6AB3930E1B7A17846"
-        }
-      ]
     }
   },
   {

--- a/tests/dbt/data/trial_v4/results.json
+++ b/tests/dbt/data/trial_v4/results.json
@@ -211,6 +211,14 @@
     "logicalId": {
       "name": "trial.my_first_dbt_model",
       "type": "DBT_MODEL"
+    },
+    "ownershipAssignment": {
+      "ownerships": [
+        {
+          "contactDesignationName": "Maintainer",
+          "person": "PERSON~8B6974C32BFCBBF6AB3930E1B7A17846"
+        }
+      ]
     }
   },
   {

--- a/tests/dbt/data/trial_v5/results.json
+++ b/tests/dbt/data/trial_v5/results.json
@@ -211,14 +211,6 @@
     "logicalId": {
       "name": "trial.my_first_dbt_model",
       "type": "DBT_MODEL"
-    },
-    "ownershipAssignment": {
-      "ownerships": [
-        {
-          "contactDesignationName": "Maintainer",
-          "person": "PERSON~8B6974C32BFCBBF6AB3930E1B7A17846"
-        }
-      ]
     }
   },
   {

--- a/tests/dbt/data/trial_v5/results.json
+++ b/tests/dbt/data/trial_v5/results.json
@@ -211,6 +211,14 @@
     "logicalId": {
       "name": "trial.my_first_dbt_model",
       "type": "DBT_MODEL"
+    },
+    "ownershipAssignment": {
+      "ownerships": [
+        {
+          "contactDesignationName": "Maintainer",
+          "person": "PERSON~8B6974C32BFCBBF6AB3930E1B7A17846"
+        }
+      ]
     }
   },
   {

--- a/tests/dbt/data/trial_v6/results.json
+++ b/tests/dbt/data/trial_v6/results.json
@@ -211,14 +211,6 @@
     "logicalId": {
       "name": "trial.my_first_dbt_model",
       "type": "DBT_MODEL"
-    },
-    "ownershipAssignment": {
-      "ownerships": [
-        {
-          "contactDesignationName": "Maintainer",
-          "person": "PERSON~8B6974C32BFCBBF6AB3930E1B7A17846"
-        }
-      ]
     }
   },
   {

--- a/tests/dbt/data/trial_v6/results.json
+++ b/tests/dbt/data/trial_v6/results.json
@@ -211,6 +211,14 @@
     "logicalId": {
       "name": "trial.my_first_dbt_model",
       "type": "DBT_MODEL"
+    },
+    "ownershipAssignment": {
+      "ownerships": [
+        {
+          "contactDesignationName": "Maintainer",
+          "person": "PERSON~8B6974C32BFCBBF6AB3930E1B7A17846"
+        }
+      ]
     }
   },
   {

--- a/tests/dbt/data/trial_v7/results.json
+++ b/tests/dbt/data/trial_v7/results.json
@@ -211,14 +211,6 @@
     "logicalId": {
       "name": "trial.my_first_dbt_model",
       "type": "DBT_MODEL"
-    },
-    "ownershipAssignment": {
-      "ownerships": [
-        {
-          "contactDesignationName": "Maintainer",
-          "person": "PERSON~8B6974C32BFCBBF6AB3930E1B7A17846"
-        }
-      ]
     }
   },
   {

--- a/tests/dbt/data/trial_v7/results.json
+++ b/tests/dbt/data/trial_v7/results.json
@@ -211,6 +211,14 @@
     "logicalId": {
       "name": "trial.my_first_dbt_model",
       "type": "DBT_MODEL"
+    },
+    "ownershipAssignment": {
+      "ownerships": [
+        {
+          "contactDesignationName": "Maintainer",
+          "person": "PERSON~8B6974C32BFCBBF6AB3930E1B7A17846"
+        }
+      ]
     }
   },
   {

--- a/tests/dbt/data/trial_v8/results.json
+++ b/tests/dbt/data/trial_v8/results.json
@@ -211,14 +211,6 @@
     "logicalId": {
       "name": "trial.my_first_dbt_model",
       "type": "DBT_MODEL"
-    },
-    "ownershipAssignment": {
-      "ownerships": [
-        {
-          "contactDesignationName": "Maintainer",
-          "person": "PERSON~8B6974C32BFCBBF6AB3930E1B7A17846"
-        }
-      ]
     }
   },
   {

--- a/tests/dbt/data/trial_v8/results.json
+++ b/tests/dbt/data/trial_v8/results.json
@@ -211,6 +211,14 @@
     "logicalId": {
       "name": "trial.my_first_dbt_model",
       "type": "DBT_MODEL"
+    },
+    "ownershipAssignment": {
+      "ownerships": [
+        {
+          "contactDesignationName": "Maintainer",
+          "person": "PERSON~8B6974C32BFCBBF6AB3930E1B7A17846"
+        }
+      ]
     }
   },
   {

--- a/tests/dbt/data/trial_v9/results.json
+++ b/tests/dbt/data/trial_v9/results.json
@@ -211,14 +211,6 @@
     "logicalId": {
       "name": "trial.my_first_dbt_model",
       "type": "DBT_MODEL"
-    },
-    "ownershipAssignment": {
-      "ownerships": [
-        {
-          "contactDesignationName": "Maintainer",
-          "person": "PERSON~8B6974C32BFCBBF6AB3930E1B7A17846"
-        }
-      ]
     }
   },
   {

--- a/tests/dbt/data/trial_v9/results.json
+++ b/tests/dbt/data/trial_v9/results.json
@@ -211,6 +211,14 @@
     "logicalId": {
       "name": "trial.my_first_dbt_model",
       "type": "DBT_MODEL"
+    },
+    "ownershipAssignment": {
+      "ownerships": [
+        {
+          "contactDesignationName": "Maintainer",
+          "person": "PERSON~8B6974C32BFCBBF6AB3930E1B7A17846"
+        }
+      ]
     }
   },
   {

--- a/tests/dbt/test_util.py
+++ b/tests/dbt/test_util.py
@@ -50,6 +50,9 @@ def test_get_ownerships_from_meta(test_root_dir):
         get_ownerships_from_meta(meta, meta_ownerships).materialized_table
         == expected_ownerships
     )
+    assert (
+        get_ownerships_from_meta(meta, meta_ownerships).dbt_model == expected_ownerships
+    )
 
 
 def test_get_ownerships_with_assignment_targets(test_root_dir):

--- a/tests/dbt/test_util.py
+++ b/tests/dbt/test_util.py
@@ -52,6 +52,34 @@ def test_get_ownerships_from_meta(test_root_dir):
     )
 
 
+def test_get_ownerships_comma_sep_str_value(test_root_dir):
+    meta = {"owner": "foo@test.io,bar@test.io  ,  baz@test.io    "}
+    meta_ownerships = [
+        MetaOwnership(
+            meta_key="owner",
+            ownership_type="Data Owner",
+        )
+    ]
+    expected_ownerships = [
+        Ownership(
+            contact_designation_name="Data Owner",
+            person=str(to_person_entity_id("foo@test.io")),
+        ),
+        Ownership(
+            contact_designation_name="Data Owner",
+            person=str(to_person_entity_id("bar@test.io")),
+        ),
+        Ownership(
+            contact_designation_name="Data Owner",
+            person=str(to_person_entity_id("baz@test.io")),
+        ),
+    ]
+    assert (
+        get_ownerships_from_meta(meta, meta_ownerships).materialized_table
+        == expected_ownerships
+    )
+
+
 def test_get_ownerships_with_assignment_targets(test_root_dir):
     meta = {
         "owners_dbt_model": ["foo", "bar"],

--- a/tests/dbt/test_util.py
+++ b/tests/dbt/test_util.py
@@ -52,34 +52,6 @@ def test_get_ownerships_from_meta(test_root_dir):
     )
 
 
-def test_get_ownerships_comma_sep_str_value(test_root_dir):
-    meta = {"owner": "foo@test.io,bar@test.io  ,  baz@test.io    "}
-    meta_ownerships = [
-        MetaOwnership(
-            meta_key="owner",
-            ownership_type="Data Owner",
-        )
-    ]
-    expected_ownerships = [
-        Ownership(
-            contact_designation_name="Data Owner",
-            person=str(to_person_entity_id("foo@test.io")),
-        ),
-        Ownership(
-            contact_designation_name="Data Owner",
-            person=str(to_person_entity_id("bar@test.io")),
-        ),
-        Ownership(
-            contact_designation_name="Data Owner",
-            person=str(to_person_entity_id("baz@test.io")),
-        ),
-    ]
-    assert (
-        get_ownerships_from_meta(meta, meta_ownerships).materialized_table
-        == expected_ownerships
-    )
-
-
 def test_get_ownerships_with_assignment_targets(test_root_dir):
     meta = {
         "owners_dbt_model": ["foo", "bar"],

--- a/tests/dbt/test_util.py
+++ b/tests/dbt/test_util.py
@@ -46,7 +46,69 @@ def test_get_ownerships_from_meta(test_root_dir):
         ),
     ]
 
-    assert get_ownerships_from_meta(meta, meta_ownerships) == expected_ownerships
+    assert (
+        get_ownerships_from_meta(meta, meta_ownerships).materialized_table
+        == expected_ownerships
+    )
+
+
+def test_get_ownerships_with_assignment_targets(test_root_dir):
+    meta = {
+        "owners_dbt_model": ["foo", "bar"],
+        "owners_materialized_table": ["bar", "qux"],
+        "owners_both": ["baz"],
+    }
+    meta_ownerships = [
+        MetaOwnership(
+            meta_key="owners_dbt_model",
+            ownership_type="dbt model owner",
+            email_domain="metaphor.io",
+            assignment_target="dbt_model",
+        ),
+        MetaOwnership(
+            meta_key="owners_both",
+            ownership_type="owner of both dbt model and materialized table",
+            email_domain="metaphor.io",
+            assignment_target="both",
+        ),
+        MetaOwnership(
+            meta_key="owners_materialized_table",
+            ownership_type="materialized table owner",
+            email_domain="metaphor.io",
+            assignment_target="materialized_table",
+        ),
+    ]
+    ownerships = get_ownerships_from_meta(meta, meta_ownerships)
+    expected_dbt_model_ownerships = [
+        Ownership(
+            contact_designation_name="dbt model owner",
+            person=str(to_person_entity_id("foo@metaphor.io")),
+        ),
+        Ownership(
+            contact_designation_name="dbt model owner",
+            person=str(to_person_entity_id("bar@metaphor.io")),
+        ),
+        Ownership(
+            contact_designation_name="owner of both dbt model and materialized table",
+            person=str(to_person_entity_id("baz@metaphor.io")),
+        ),
+    ]
+    expected_materialized_table_ownerships = [
+        Ownership(
+            contact_designation_name="owner of both dbt model and materialized table",
+            person=str(to_person_entity_id("baz@metaphor.io")),
+        ),
+        Ownership(
+            contact_designation_name="materialized table owner",
+            person=str(to_person_entity_id("bar@metaphor.io")),
+        ),
+        Ownership(
+            contact_designation_name="materialized table owner",
+            person=str(to_person_entity_id("qux@metaphor.io")),
+        ),
+    ]
+    assert ownerships.dbt_model == expected_dbt_model_ownerships
+    assert ownerships.materialized_table == expected_materialized_table_ownerships
 
 
 def test_get_tags_from_meta(test_root_dir):


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Enables assigning ownership to dbt model's virtual views, or both the virtual view and the dataset itself.

Tracked by [SC20587](https://app.shortcut.com/metaphor-data/story/20587)

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Added a config field for meta_ownerships:
```yaml
meta_ownerships:
  - meta_key: owner
    ownership_type: Data Steward
    assignment_target: materialized_table # assigns the owner to either "materialized_table" (the dataset), "dbt_model" (the virtual view), or "both". Default is the materialized table.
```
- Added support for parsing string values in dbt model's meta field, such that a string value containing commas will be parsed as a sequence of string values

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Tested with the newly added config, the ownership information was added correctly.
