### PR TITLE
Use v2 `ConfigDict` instead of custom class for pydantic dataclasses

### DIFF
--- a/metaphor/common/dataclass.py
+++ b/metaphor/common/dataclass.py
@@ -1,11 +1,5 @@
-from pydantic import Extra
+from pydantic import ConfigDict
 
-
-class ConnectorConfig:
-    """
-    Pydantic dataclass Config for metaphor connector configurations
-    """
-
-    validate_all = True
-    extra = Extra.forbid
-    coerce_numbers_to_str = True
+ConnectorConfig = ConfigDict(
+    validate_default=True, extra="forbid", coerce_numbers_to_str=True
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.30"
+version = "0.13.31"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Because I am wary of seeing
```
UserWarning: Valid config keys have changed in V2:
* 'validate_all' has been renamed to 'validate_default'
```

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Use properly typed `ConfigDict` instead of custom class as dataclass configs.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Ran unit tests.
