### PR TITLE
Handle email-based Snowflake user ID in query logs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.31"
+version = "0.13.32"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

It's possible to have email address as a Snowflake user ID. Query issued by these users should have the `email` address field set instead of `user_id`. 

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified against a production instance. Example:

```
...
                {
                    "_id": "SNOWFLAKE:01b01a65-0603-c12b-0029-c00304f93dae",
                    "account": "metaphor-dev",
                    "bytesRead": 0.0,
                    "bytesWritten": 0.0,
                    "cost": 0.0,
                    "duration": 0.326,
                    "email": "mars@metaphor.io",
                    "platform": "SNOWFLAKE",
                    "queryId": "01b01a65-0603-c12b-0029-c00304f93dae",
                    "rowsWritten": 0.0,
                    "sources":
                    [],
                    "sql": "GET '@~/worksheet_data/metadata' 'file:///'",
                    "sqlHash": "70496b3935c36ec0fc4027d9a26d1dd5",
                    "startTime": "2023-11-04T03:49:52.298000-08:00",
                    "targets":
                    []
                },
...
```
