### PR TITLE
Provide timezone for `fromtimestamp` in unity catalog test_utils

### DIFF
--- a/tests/unity_catalog/test_utils.py
+++ b/tests/unity_catalog/test_utils.py
@@ -130,11 +130,13 @@ def test_parse_query_log_filter_by():
     assert sorted(query_filter.user_ids) == ["u0", "u3"]
     assert query_filter.query_start_time_range.start_time_ms is not None
     start_time = datetime.datetime.fromtimestamp(
-        query_filter.query_start_time_range.start_time_ms / 1000
+        timestamp=query_filter.query_start_time_range.start_time_ms / 1000,
+        tz=datetime.timezone.utc,
     )
     assert query_filter.query_start_time_range.end_time_ms is not None
     end_time = datetime.datetime.fromtimestamp(
-        query_filter.query_start_time_range.end_time_ms / 1000
+        timestamp=query_filter.query_start_time_range.end_time_ms / 1000,
+        tz=datetime.timezone.utc,
     )
     time_diff = end_time - start_time
     assert time_diff == datetime.timedelta(days=2)


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

The unity catalog unit test contains a `datetime.fromtimestamp` call without specifying timezone, thus causing the test to fail when run locally. This PR addresses that.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Add timezone to `fromtimestamp`.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Ran unit test locally.