### PR TITLE
`DataMonitorTarget.dataset` does not need to be specified

### DIFF
--- a/metaphor/dbt/artifact_parser.py
+++ b/metaphor/dbt/artifact_parser.py
@@ -421,18 +421,13 @@ class ArtifactParser:
 
         dataset = self._datasets.get(model.unique_id)
         if dataset is None:
-            logger.warn(
+            logger.warning(
                 "Cannot find target dataset for test: "
                 f"model unique id = {model.unique_id}"
             )
             return
 
-        dataset_name = dataset_normalized_name(
-            model.database, model.schema_, model.alias or model.name
-        )
-        add_data_quality_monitor(
-            dataset, test.name, dataset_name, test.column_name, status
-        )
+        add_data_quality_monitor(dataset, test.name, test.column_name, status)
 
     def _parse_model(
         self,

--- a/metaphor/dbt/util.py
+++ b/metaphor/dbt/util.py
@@ -250,7 +250,6 @@ def find_run_result_ouptput_by_id(
 def add_data_quality_monitor(
     dataset: Dataset,
     name: str,
-    dataset_name: str,
     column_name: Optional[str],
     status: DataMonitorStatus,
 ) -> None:
@@ -259,9 +258,12 @@ def add_data_quality_monitor(
             monitors=[], provider=DataQualityProvider.DBT
         )
     dataset.data_quality.monitors.append(
+        # For `DataMonitorTarget`:
+        # column: Name of the target column. Not set if the monitor performs dataset-level tests, e.g. row count.
+        # dataset: Entity ID of the target dataset. Set only if the monitor uses a different dataset from the one the da
         DataMonitor(
             title=name,
-            targets=[DataMonitorTarget(dataset=dataset_name, column=column_name)],
+            targets=[DataMonitorTarget(column=column_name)],
             status=status,
         )
     )

--- a/metaphor/dbt/util.py
+++ b/metaphor/dbt/util.py
@@ -260,7 +260,7 @@ def add_data_quality_monitor(
     dataset.data_quality.monitors.append(
         # For `DataMonitorTarget`:
         # column: Name of the target column. Not set if the monitor performs dataset-level tests, e.g. row count.
-        # dataset: Entity ID of the target dataset. Set only if the monitor uses a different dataset from the one the da
+        # dataset: Entity ID of the target dataset. Set only if the monitor uses a different dataset from the one the data quality metadata is attached to.
         DataMonitor(
             title=name,
             targets=[DataMonitorTarget(column=column_name)],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.41"
+version = "0.13.42"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/dbt/data/metaphor_subscriptions_v10/results.json
+++ b/tests/dbt/data/metaphor_subscriptions_v10/results.json
@@ -169,8 +169,7 @@
           "status": "PASSED",
           "targets": [
             {
-              "column": "SUB_ID",
-              "dataset": "demo_db.metaphor.subscriptions_v2"
+              "column": "SUB_ID"
             }
           ],
           "title": "unique_subscriptions_v2_SUB_ID"
@@ -179,8 +178,7 @@
           "status": "PASSED",
           "targets": [
             {
-              "column": "SUB_ID",
-              "dataset": "demo_db.metaphor.subscriptions_v2"
+              "column": "SUB_ID"
             }
           ],
           "title": "not_null_subscriptions_v2_SUB_ID"


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

`DataMonitorTarget.dataset` is a stringified `EntityId`, not a normalized name.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Removed unnecessary assignment for `DataMonitorTarget.dataset`.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Fixed unit test.