### PR TITLE
Remove unused UnityCatalog dataclass

### DIFF
--- a/metaphor/unity_catalog/models.py
+++ b/metaphor/unity_catalog/models.py
@@ -1,4 +1,3 @@
-from enum import Enum
 from typing import List, Optional, Union
 
 from databricks.sdk.service.catalog import ColumnInfo
@@ -8,23 +7,6 @@ from metaphor.common.logger import get_logger
 from metaphor.models.metadata_change_event import SchemaField
 
 logger = get_logger()
-
-
-class DataSourceFormat(str, Enum):
-    DELTA = "DELTA"
-    CSV = "CSV"
-    JSON = "JSON"
-    AVRO = "AVRO"
-    PARQUET = "PARQUET"
-    ORC = "ORC"
-    TEXT = "TEXT"
-    UNITY_CATALOG = (
-        "UNITY_CATALOG"  # a Table within the Unity Catalog’s Information Schema
-    )
-    DELTASHARING = "DELTASHARING"  # a Table shared through the Delta Sharing protocol
-
-    def __str__(self):
-        return str(self.value)
 
 
 def extract_schema_field_from_column_info(column: ColumnInfo) -> SchemaField:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.42"
+version = "0.13.43"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/unity_catalog/test_models.py
+++ b/tests/unity_catalog/test_models.py
@@ -2,7 +2,6 @@ import pytest
 from databricks.sdk.service.catalog import ColumnInfo
 
 from metaphor.unity_catalog.models import (
-    DataSourceFormat,
     NoPermission,
     extract_schema_field_from_column_info,
 )
@@ -18,8 +17,3 @@ def test_parse_schema_field_from_invalid_column_info() -> None:
         extract_schema_field_from_column_info(
             ColumnInfo(comment="does not have a type")
         )
-
-
-def test_stringify_data_source_format() -> None:
-    for fmt in DataSourceFormat:
-        assert str(fmt) == fmt.value


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Removed `DataSourceFormat`, which is no longer used once we switched to `databricks-sdk-py`.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

No need.