### PR TITLE
All virtual view crawlers emit entityUpstream

### DIFF
--- a/metaphor/dbt/artifact_parser.py
+++ b/metaphor/dbt/artifact_parser.py
@@ -38,6 +38,7 @@ from metaphor.models.metadata_change_event import (
     DbtMetric,
     DbtModel,
     DbtTest,
+    EntityUpstream,
     Metric,
     MetricFilter,
     OwnershipAssignment,
@@ -491,6 +492,16 @@ class ArtifactParser:
             dbt_model.source_models,
             dbt_model.macros,
         ) = self._parse_depends_on(model.depends_on, source_map, macro_map)
+
+        source_entities = []
+        if dbt_model.source_datasets is not None:
+            source_entities.extend(dbt_model.source_datasets)
+        if dbt_model.source_models is not None:
+            source_entities.extend(dbt_model.source_models)
+        if len(source_entities) > 0:
+            virtual_view.entity_upstream = EntityUpstream(
+                source_entities=source_entities,
+            )
 
     def _parse_macros(self, macros: MACRO_MAP) -> Dict[str, DbtMacro]:
         macro_map: Dict[str, DbtMacro] = {}

--- a/metaphor/looker/lookml_parser.py
+++ b/metaphor/looker/lookml_parser.py
@@ -23,6 +23,7 @@ from metaphor.common.entity_id import (
 )
 from metaphor.common.logger import get_logger
 from metaphor.models.metadata_change_event import (
+    EntityUpstream,
     LookerExplore,
     LookerExploreJoin,
     LookerView,
@@ -229,6 +230,7 @@ def _build_looker_view(
             name=fullname(model, name), type=VirtualViewType.LOOKER_VIEW
         ),
         looker_view=view,
+        entity_upstream=EntityUpstream(source_entities=view.source_datasets),
     )
 
 

--- a/metaphor/tableau/extractor.py
+++ b/metaphor/tableau/extractor.py
@@ -408,6 +408,7 @@ class TableauExtractor(BaseExtractor):
                     url=f"{self._base_url}/datasources/{published_source.vizportalUrlId}",
                     source_datasets=source_datasets or None,
                 ),
+                entity_upstream=EntityUpstream(source_entities=source_datasets or None),
             )
             source_virtual_views.append(virtual_view_id)
             published_datasources.append(published_source.name)
@@ -456,6 +457,7 @@ class TableauExtractor(BaseExtractor):
                     else None,
                     source_datasets=source_datasets or None,
                 ),
+                entity_upstream=EntityUpstream(source_entities=source_datasets or None),
             )
             source_virtual_views.append(virtual_view_id)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.58"
+version = "0.13.59"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/dbt/data/jaffle_v10/results.json
+++ b/tests/dbt/data/jaffle_v10/results.json
@@ -481,6 +481,13 @@
     "logicalId": {
       "name": "jaffle_shop.customers",
       "type": "DBT_MODEL"
+    },
+    "entityUpstream": {
+      "sourceEntities": [
+        "VIRTUAL_VIEW~F3CAA2D12722D7A5CB634D3277D91846",
+        "VIRTUAL_VIEW~A01D8D20460F0A5E1002EA6E565963AE",
+        "VIRTUAL_VIEW~FE32A419A352C0C5890E84AB1F6F25B3"
+      ]
     }
   },
   {
@@ -659,6 +666,14 @@
     "logicalId": {
       "name": "jaffle_shop.orders",
       "type": "DBT_MODEL"
+    },
+    "entityUpstream": {
+      "sourceEntities": [
+        "VIRTUAL_VIEW~B4C1C7825A401215D815D4520CD8ECF4",
+        "VIRTUAL_VIEW~CCD5BC591587FEE1871D151FCC12EEB1",
+        "VIRTUAL_VIEW~769DCFC28317E6CDC8B9D7E745BA61CB",
+        "VIRTUAL_VIEW~226AEA90AFE7D7925BCE6CE156C2D901"
+      ]
     }
   },
   {
@@ -716,6 +731,13 @@
     "logicalId": {
       "name": "jaffle_shop.order_items",
       "type": "DBT_MODEL"
+    },
+    "entityUpstream": {
+      "sourceEntities": [
+        "VIRTUAL_VIEW~CCD5BC591587FEE1871D151FCC12EEB1",
+        "VIRTUAL_VIEW~B4C1C7825A401215D815D4520CD8ECF4",
+        "VIRTUAL_VIEW~769DCFC28317E6CDC8B9D7E745BA61CB"
+      ]
     }
   }
 ]

--- a/tests/dbt/data/metaphor_subscriptions_v10/results.json
+++ b/tests/dbt/data/metaphor_subscriptions_v10/results.json
@@ -330,6 +330,11 @@
           "person": "PERSON~B39948BEACEF16E5E6F3D53BDB9BCD38"
         }
       ]
+    },
+    "entityUpstream": {
+      "sourceEntities": [
+        "VIRTUAL_VIEW~1BD666702EACA1E95384807DA0DC92C7"
+      ]
     }
   },
   {
@@ -394,6 +399,13 @@
           "person": "PERSON~B39948BEACEF16E5E6F3D53BDB9BCD38"
         }
       ]
+    },
+    "entityUpstream": {
+      "sourceEntities": [
+        "DATASET~83680E0286B0CF430192EFDE05B765F5",
+        "DATASET~239D4B030A506874ED0CB2C8FA1B1AB2",
+        "VIRTUAL_VIEW~40E84C63748265E978F781C89A23BE51"
+      ]
     }
   },
   {
@@ -454,6 +466,11 @@
     "logicalId": {
       "name": "metaphor_subscriptions.churn_region_agg",
       "type": "DBT_MODEL"
+    },
+    "entityUpstream": {
+      "sourceEntities": [
+        "VIRTUAL_VIEW~C0B4C324A0D6AB95F681101D76B04791"
+      ]
     },
     "ownershipAssignment": {
       "ownerships": [
@@ -584,6 +601,11 @@
       ],
       "url": "https://github.com/MetaphorData/dbt/tree/main/metaphor/models/metaphor/subscriptions_v2.sql"
     },
+    "entityUpstream": {
+      "sourceEntities": [
+        "DATASET~3904FBD7A1828492FFD11604A2E73442"
+      ]
+    },
     "logicalId": {
       "name": "metaphor_subscriptions.subscriptions_v2",
       "type": "DBT_MODEL"
@@ -699,6 +721,11 @@
     "logicalId": {
       "name": "metaphor_subscriptions.subscriptions_sales",
       "type": "DBT_MODEL"
+    },
+    "entityUpstream": {
+      "sourceEntities": [
+        "VIRTUAL_VIEW~C0B4C324A0D6AB95F681101D76B04791"
+      ]
     }
   },
   {
@@ -743,6 +770,11 @@
         "subscription"
       ],
       "url": "https://github.com/MetaphorData/dbt/tree/main/metaphor/models/metaphor/subscriptions_core.sql"
+    },
+    "entityUpstream": {
+      "sourceEntities": [
+        "DATASET~3904FBD7A1828492FFD11604A2E73442"
+      ]
     },
     "logicalId": {
       "name": "metaphor_subscriptions.subscriptions_core",

--- a/tests/dbt/data/trial_v4/results.json
+++ b/tests/dbt/data/trial_v4/results.json
@@ -277,6 +277,11 @@
     "logicalId": {
       "name": "trial.my_second_dbt_model",
       "type": "DBT_MODEL"
+    },
+    "entityUpstream": {
+      "sourceEntities": [
+        "VIRTUAL_VIEW~6792928812BBC200D2459741CFE02D9D"
+      ]
     }
   },
   {
@@ -392,6 +397,11 @@
     "logicalId": {
       "name": "trial.trial_model_1",
       "type": "DBT_MODEL"
+    },
+    "entityUpstream": {
+      "sourceEntities": [
+        "DATASET~0A27263039022A2F145CAB8A63CB2D58"
+      ]
     }
   },
   {
@@ -516,6 +526,11 @@
     "logicalId": {
       "name": "trial.trial_model_2",
       "type": "DBT_MODEL"
+    },
+    "entityUpstream": {
+      "sourceEntities": [
+        "DATASET~C931554DBA0604DA498A2E772F3D6FEF"
+      ]
     }
   },
   {

--- a/tests/dbt/data/trial_v5/results.json
+++ b/tests/dbt/data/trial_v5/results.json
@@ -277,6 +277,11 @@
     "logicalId": {
       "name": "trial.my_second_dbt_model",
       "type": "DBT_MODEL"
+    },
+    "entityUpstream": {
+      "sourceEntities": [
+        "VIRTUAL_VIEW~6792928812BBC200D2459741CFE02D9D"
+      ]
     }
   },
   {
@@ -392,6 +397,11 @@
     "logicalId": {
       "name": "trial.trial_model_1",
       "type": "DBT_MODEL"
+    },
+    "entityUpstream": {
+      "sourceEntities": [
+        "DATASET~0A27263039022A2F145CAB8A63CB2D58"
+      ]
     }
   },
   {
@@ -516,6 +526,11 @@
     "logicalId": {
       "name": "trial.trial_model_2",
       "type": "DBT_MODEL"
+    },
+    "entityUpstream": {
+      "sourceEntities": [
+        "DATASET~C931554DBA0604DA498A2E772F3D6FEF"
+      ]
     }
   },
   {

--- a/tests/dbt/data/trial_v6/results.json
+++ b/tests/dbt/data/trial_v6/results.json
@@ -277,6 +277,11 @@
     "logicalId": {
       "name": "trial.my_second_dbt_model",
       "type": "DBT_MODEL"
+    },
+    "entityUpstream": {
+      "sourceEntities": [
+        "VIRTUAL_VIEW~6792928812BBC200D2459741CFE02D9D"
+      ]
     }
   },
   {
@@ -392,6 +397,11 @@
     "logicalId": {
       "name": "trial.trial_model_1",
       "type": "DBT_MODEL"
+    },
+    "entityUpstream": {
+      "sourceEntities": [
+        "DATASET~0A27263039022A2F145CAB8A63CB2D58"
+      ]
     }
   },
   {
@@ -516,6 +526,11 @@
     "logicalId": {
       "name": "trial.trial_model_2",
       "type": "DBT_MODEL"
+    },
+    "entityUpstream": {
+      "sourceEntities": [
+        "DATASET~C931554DBA0604DA498A2E772F3D6FEF"
+      ]
     }
   },
   {

--- a/tests/dbt/data/trial_v7/results.json
+++ b/tests/dbt/data/trial_v7/results.json
@@ -277,6 +277,11 @@
     "logicalId": {
       "name": "trial.my_second_dbt_model",
       "type": "DBT_MODEL"
+    },
+    "entityUpstream": {
+      "sourceEntities": [
+        "VIRTUAL_VIEW~6792928812BBC200D2459741CFE02D9D"
+      ]
     }
   },
   {
@@ -392,6 +397,11 @@
     "logicalId": {
       "name": "trial.trial_model_1",
       "type": "DBT_MODEL"
+    },
+    "entityUpstream": {
+      "sourceEntities": [
+        "DATASET~0A27263039022A2F145CAB8A63CB2D58"
+      ]
     }
   },
   {
@@ -516,6 +526,11 @@
     "logicalId": {
       "name": "trial.trial_model_2",
       "type": "DBT_MODEL"
+    },
+    "entityUpstream": {
+      "sourceEntities": [
+        "DATASET~C931554DBA0604DA498A2E772F3D6FEF"
+      ]
     }
   },
   {

--- a/tests/dbt/data/trial_v8/results.json
+++ b/tests/dbt/data/trial_v8/results.json
@@ -277,6 +277,11 @@
     "logicalId": {
       "name": "trial.my_second_dbt_model",
       "type": "DBT_MODEL"
+    },
+    "entityUpstream": {
+      "sourceEntities": [
+        "VIRTUAL_VIEW~6792928812BBC200D2459741CFE02D9D"
+      ]
     }
   },
   {
@@ -392,6 +397,11 @@
     "logicalId": {
       "name": "trial.trial_model_1",
       "type": "DBT_MODEL"
+    },
+    "entityUpstream": {
+      "sourceEntities": [
+        "DATASET~0A27263039022A2F145CAB8A63CB2D58"
+      ]
     }
   },
   {
@@ -516,6 +526,11 @@
     "logicalId": {
       "name": "trial.trial_model_2",
       "type": "DBT_MODEL"
+    },
+    "entityUpstream": {
+      "sourceEntities": [
+        "DATASET~C931554DBA0604DA498A2E772F3D6FEF"
+      ]
     }
   },
   {

--- a/tests/dbt/data/trial_v9/results.json
+++ b/tests/dbt/data/trial_v9/results.json
@@ -277,6 +277,11 @@
     "logicalId": {
       "name": "trial.my_second_dbt_model",
       "type": "DBT_MODEL"
+    },
+    "entityUpstream": {
+      "sourceEntities": [
+        "VIRTUAL_VIEW~6792928812BBC200D2459741CFE02D9D"
+      ]
     }
   },
   {
@@ -392,6 +397,11 @@
     "logicalId": {
       "name": "trial.trial_model_1",
       "type": "DBT_MODEL"
+    },
+    "entityUpstream": {
+      "sourceEntities": [
+        "DATASET~0A27263039022A2F145CAB8A63CB2D58"
+      ]
     }
   },
   {
@@ -516,6 +526,11 @@
     "logicalId": {
       "name": "trial.trial_model_2",
       "type": "DBT_MODEL"
+    },
+    "entityUpstream": {
+      "sourceEntities": [
+        "DATASET~C931554DBA0604DA498A2E772F3D6FEF"
+      ]
     }
   },
   {

--- a/tests/looker/test_lookml_parser.py
+++ b/tests/looker/test_lookml_parser.py
@@ -5,6 +5,7 @@ from metaphor.models.metadata_change_event import (
     DataPlatform,
     DatasetLogicalID,
     EntityType,
+    EntityUpstream,
     LookerExplore,
     LookerExploreJoin,
     LookerView,
@@ -83,6 +84,7 @@ def test_basic(test_root_dir):
                 source_datasets=[str(dataset_id)],
                 url="http://foo/files/view1.view.lkml",
             ),
+            entity_upstream=EntityUpstream(source_entities=[str(dataset_id)]),
         ),
         VirtualView(
             logical_id=VirtualViewLogicalID(
@@ -159,6 +161,7 @@ def test_join(test_root_dir):
                     ],
                     source_datasets=[str(dataset_id1)],
                 ),
+                entity_upstream=EntityUpstream(source_entities=[str(dataset_id1)]),
             ),
             VirtualView(
                 logical_id=VirtualViewLogicalID(
@@ -173,6 +176,7 @@ def test_join(test_root_dir):
                     ],
                     source_datasets=[str(dataset_id2)],
                 ),
+                entity_upstream=EntityUpstream(source_entities=[str(dataset_id2)]),
             ),
             VirtualView(
                 logical_id=VirtualViewLogicalID(
@@ -249,6 +253,7 @@ def test_explore_in_view(test_root_dir):
                     ],
                     source_datasets=[str(dataset_id)],
                 ),
+                entity_upstream=EntityUpstream(source_entities=[str(dataset_id)]),
             ),
             VirtualView(
                 logical_id=VirtualViewLogicalID(
@@ -313,6 +318,7 @@ def test_derived_table(test_root_dir):
             looker_view=LookerView(
                 source_datasets=[str(dataset_id)],
             ),
+            entity_upstream=EntityUpstream(source_entities=[str(dataset_id)]),
         ),
         VirtualView(
             logical_id=VirtualViewLogicalID(
@@ -321,6 +327,7 @@ def test_derived_table(test_root_dir):
             looker_view=LookerView(
                 source_datasets=[str(dataset_id)],
             ),
+            entity_upstream=EntityUpstream(source_entities=[str(dataset_id)]),
         ),
         VirtualView(
             logical_id=VirtualViewLogicalID(
@@ -329,6 +336,7 @@ def test_derived_table(test_root_dir):
             looker_view=LookerView(
                 source_datasets=[str(dataset_id)],
             ),
+            entity_upstream=EntityUpstream(source_entities=[str(dataset_id)]),
         ),
         VirtualView(
             logical_id=VirtualViewLogicalID(
@@ -396,6 +404,7 @@ def test_sql_table_name(test_root_dir):
             looker_view=LookerView(
                 source_datasets=[str(dataset_id1)],
             ),
+            entity_upstream=EntityUpstream(source_entities=[str(dataset_id1)]),
         ),
         VirtualView(
             logical_id=VirtualViewLogicalID(
@@ -438,6 +447,7 @@ def test_include_relative_to_model(test_root_dir):
             looker_view=LookerView(
                 source_datasets=[str(dataset_id1)],
             ),
+            entity_upstream=EntityUpstream(source_entities=[str(dataset_id1)]),
         ),
         VirtualView(
             logical_id=VirtualViewLogicalID(
@@ -446,6 +456,7 @@ def test_include_relative_to_model(test_root_dir):
             looker_view=LookerView(
                 source_datasets=[str(dataset_id2)],
             ),
+            entity_upstream=EntityUpstream(source_entities=[str(dataset_id2)]),
         ),
     ]
 
@@ -510,6 +521,7 @@ def test_complex_includes(test_root_dir):
             looker_view=LookerView(
                 source_datasets=[str(dataset_id1)],
             ),
+            entity_upstream=EntityUpstream(source_entities=[str(dataset_id1)]),
         ),
         VirtualView(
             logical_id=VirtualViewLogicalID(
@@ -518,6 +530,7 @@ def test_complex_includes(test_root_dir):
             looker_view=LookerView(
                 source_datasets=[str(dataset_id2)],
             ),
+            entity_upstream=EntityUpstream(source_entities=[str(dataset_id2)]),
         ),
         VirtualView(
             logical_id=VirtualViewLogicalID(
@@ -526,6 +539,7 @@ def test_complex_includes(test_root_dir):
             looker_view=LookerView(
                 source_datasets=[str(dataset_id3)],
             ),
+            entity_upstream=EntityUpstream(source_entities=[str(dataset_id3)]),
         ),
         VirtualView(
             logical_id=VirtualViewLogicalID(
@@ -534,6 +548,7 @@ def test_complex_includes(test_root_dir):
             looker_view=LookerView(
                 source_datasets=[str(dataset_id4)],
             ),
+            entity_upstream=EntityUpstream(source_entities=[str(dataset_id4)]),
         ),
         VirtualView(
             logical_id=VirtualViewLogicalID(
@@ -605,6 +620,7 @@ def test_view_extension(test_root_dir):
             looker_view=LookerView(
                 source_datasets=[str(dataset_table1)],
             ),
+            entity_upstream=EntityUpstream(source_entities=[str(dataset_table1)]),
         ),
         VirtualView(
             logical_id=VirtualViewLogicalID(
@@ -613,6 +629,7 @@ def test_view_extension(test_root_dir):
             looker_view=LookerView(
                 source_datasets=[str(dataset_table2)],
             ),
+            entity_upstream=EntityUpstream(source_entities=[str(dataset_table2)]),
         ),
         VirtualView(
             logical_id=VirtualViewLogicalID(
@@ -621,6 +638,7 @@ def test_view_extension(test_root_dir):
             looker_view=LookerView(
                 source_datasets=[str(dataset_table2)],
             ),
+            entity_upstream=EntityUpstream(source_entities=[str(dataset_table2)]),
         ),
         VirtualView(
             logical_id=VirtualViewLogicalID(
@@ -629,6 +647,7 @@ def test_view_extension(test_root_dir):
             looker_view=LookerView(
                 source_datasets=[str(dataset_table3)],
             ),
+            entity_upstream=EntityUpstream(source_entities=[str(dataset_table3)]),
         ),
         VirtualView(
             logical_id=VirtualViewLogicalID(
@@ -637,6 +656,7 @@ def test_view_extension(test_root_dir):
             looker_view=LookerView(
                 source_datasets=[str(dataset_table2)],
             ),
+            entity_upstream=EntityUpstream(source_entities=[str(dataset_table2)]),
         ),
         VirtualView(
             logical_id=VirtualViewLogicalID(
@@ -645,6 +665,7 @@ def test_view_extension(test_root_dir):
             looker_view=LookerView(
                 source_datasets=[str(dataset_base_view3)],
             ),
+            entity_upstream=EntityUpstream(source_entities=[str(dataset_base_view3)]),
         ),
         VirtualView(
             logical_id=VirtualViewLogicalID(
@@ -724,6 +745,7 @@ def test_explore_extension(test_root_dir):
             looker_view=LookerView(
                 source_datasets=[str(dataset_view1)],
             ),
+            entity_upstream=EntityUpstream(source_entities=[str(dataset_view1)]),
         ),
         VirtualView(
             logical_id=VirtualViewLogicalID(
@@ -732,6 +754,7 @@ def test_explore_extension(test_root_dir):
             looker_view=LookerView(
                 source_datasets=[str(dataset_view2)],
             ),
+            entity_upstream=EntityUpstream(source_entities=[str(dataset_view2)]),
         ),
         VirtualView(
             logical_id=VirtualViewLogicalID(
@@ -740,6 +763,7 @@ def test_explore_extension(test_root_dir):
             looker_view=LookerView(
                 source_datasets=[str(dataset_view3)],
             ),
+            entity_upstream=EntityUpstream(source_entities=[str(dataset_view3)]),
         ),
         VirtualView(
             logical_id=VirtualViewLogicalID(

--- a/tests/tableau/expected.json
+++ b/tests/tableau/expected.json
@@ -61,6 +61,11 @@
         "DATASET~44EFB0A109CA87DB8792256D25D030C9"
       ],
       "url": "https://10ax.online.tableau.com/#/site/abc/datasources/777"
+    },
+    "entityUpstream": {
+      "sourceEntities": [
+        "DATASET~44EFB0A109CA87DB8792256D25D030C9"
+      ]
     }
   },
   {
@@ -79,6 +84,11 @@
       "fields": [],
       "name": "default.source2",
       "sourceDatasets": [
+        "DATASET~F9D8E5963019975462CB6CB2002D247B"
+      ]
+    },
+    "entityUpstream": {
+      "sourceEntities": [
         "DATASET~F9D8E5963019975462CB6CB2002D247B"
       ]
     }
@@ -101,6 +111,11 @@
       "query": "select * from db.schema.table",
       "source_platform": "BIGQUERY",
       "sourceDatasets": [
+        "DATASET~5375BC53A82C65FD48653B9418094BB0"
+      ]
+    },
+    "entityUpstream": {
+      "sourceEntities": [
         "DATASET~5375BC53A82C65FD48653B9418094BB0"
       ]
     }


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

All my homies want source info in entityUpstream instead of in the platform specific fields.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Added entityUpstream field for all virtual views.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Unit test.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
