### PR TITLE
Add Tableau config for ignoring certain projects

### DIFF
--- a/metaphor/tableau/README.md
+++ b/metaphor/tableau/README.md
@@ -100,7 +100,7 @@ disable_preview_image: true
 You can specify the project to be ignored by the connector. By default the project `Personal Space` is ignored. To specify more ignored projects, add the following configuration:
 
 ```yaml
-extra_excluded_projects:
+exclude_extra_projects:
   - <excluded project 1>
   - <excluded project 2>
 ```

--- a/metaphor/tableau/README.md
+++ b/metaphor/tableau/README.md
@@ -101,8 +101,8 @@ You can specify the project to be ignored by the connector. By default the proje
 
 ```yaml
 exclude_extra_projects:
-  - <excluded project 1>
-  - <excluded project 2>
+  - <excluded_project_name_1>
+  - <excluded_project_name_2>
 ```
 
 To override the default behavior and include `Personal Space` in the connector, use the following configuration:

--- a/metaphor/tableau/README.md
+++ b/metaphor/tableau/README.md
@@ -81,8 +81,8 @@ If one of the data sources is using BigQuery dataset, please provide the BigQuer
 
 ```yaml
 bigquery_project_name_to_id_map:
-  project_name1: prject_id1
-  project_name2: prject_id2
+  project_name1: project_id1
+  project_name2: project_id2
 ```
 
 More information about BigQuery project name and project ID can be found [here](https://cloud.google.com/resource-manager/docs/creating-managing-projects#before_you_begin) 
@@ -93,6 +93,22 @@ By default, the connector will request the server to generate a preview image fo
 
 ```yaml
 disable_preview_image: true
+```
+
+#### Excluding Projects
+
+You can specify the project to be ignored by the connector. By default the project `Personal Space` is ignored. To specify more ignored projects, add the following configuration:
+
+```yaml
+extra_excluded_projects:
+  - <excluded project 1>
+  - <excluded project 2>
+```
+
+To override the default behavior and include `Personal Space` in the connector, use the following configuration:
+
+```yaml
+include_personal_space: True
 ```
 
 ## Testing

--- a/metaphor/tableau/config.py
+++ b/metaphor/tableau/config.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Dict, Optional
+from typing import Dict, List, Optional, Set
 
 from pydantic import model_validator
 from pydantic.dataclasses import dataclass
@@ -42,6 +42,9 @@ class TableauRunConfig(BaseConfig):
         default_factory=dict
     )
 
+    extra_excluded_projects: List[str] = dataclasses.field(default_factory=list)
+    include_personal_space: bool = False
+
     # whether to disable Chart preview image
     disable_preview_image: bool = False
 
@@ -49,3 +52,9 @@ class TableauRunConfig(BaseConfig):
     def have_access_token_or_user_password(self):
         must_set_exactly_one(self.__dict__, ["access_token", "user_password"])
         return self
+
+    @property
+    def excluded_projects(self) -> Set[str]:
+        if self.include_personal_space:
+            return set(self.extra_excluded_projects)
+        return set(self.extra_excluded_projects + ["Personal Space"])

--- a/metaphor/tableau/config.py
+++ b/metaphor/tableau/config.py
@@ -42,7 +42,7 @@ class TableauRunConfig(BaseConfig):
         default_factory=dict
     )
 
-    extra_excluded_projects: List[str] = dataclasses.field(default_factory=list)
+    exclude_extra_projects: List[str] = dataclasses.field(default_factory=list)
     include_personal_space: bool = False
 
     # whether to disable Chart preview image
@@ -56,6 +56,6 @@ class TableauRunConfig(BaseConfig):
     @property
     def excluded_projects(self) -> Set[str]:
         return set(
-            self.extra_excluded_projects
+            self.exclude_extra_projects
             + ([] if self.include_personal_space else ["Personal Space"])
         )

--- a/metaphor/tableau/config.py
+++ b/metaphor/tableau/config.py
@@ -8,6 +8,8 @@ from metaphor.common.base_config import BaseConfig
 from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.utils import must_set_exactly_one
 
+PERSONAL_SPACE_PROJECT_NAME = "Personal Space"
+
 
 @dataclass(config=ConnectorConfig)
 class TableauTokenAuthConfig:
@@ -57,5 +59,5 @@ class TableauRunConfig(BaseConfig):
     def excluded_projects(self) -> Set[str]:
         return set(
             self.exclude_extra_projects
-            + ([] if self.include_personal_space else ["Personal Space"])
+            + ([] if self.include_personal_space else [PERSONAL_SPACE_PROJECT_NAME])
         )

--- a/metaphor/tableau/config.py
+++ b/metaphor/tableau/config.py
@@ -55,6 +55,7 @@ class TableauRunConfig(BaseConfig):
 
     @property
     def excluded_projects(self) -> Set[str]:
-        if self.include_personal_space:
-            return set(self.extra_excluded_projects)
-        return set(self.extra_excluded_projects + ["Personal Space"])
+        return set(
+            self.extra_excluded_projects
+            + ([] if self.include_personal_space else ["Personal Space"])
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.63"
+version = "0.13.64"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/power_bi/test_power_bi_client.py
+++ b/tests/power_bi/test_power_bi_client.py
@@ -173,6 +173,7 @@ async def test_get_activities(
 
 @patch("requests.get")
 @patch("msal.ConfidentialClientApplication")
+@pytest.mark.asyncio
 async def test_get_refresh_schedule(
     mock_msal_app: MagicMock, mock_get_method: MagicMock, test_root_dir: str
 ):

--- a/tests/tableau/config_extra_excluded_projects.yml
+++ b/tests/tableau/config_extra_excluded_projects.yml
@@ -1,0 +1,15 @@
+---
+server_url: https://10ay.online.tableau.com
+site_name: abc
+alternative_base_url: https://tableau.my_company.com
+access_token:
+  token_name: foo
+  token_value: bar
+snowflake_account: snow
+bigquery_project_name_to_id_map:
+  bq_name: bq_id
+disable_preview_image: true
+output: {}
+extra_excluded_projects:
+  - foo
+  - bar

--- a/tests/tableau/config_extra_excluded_projects.yml
+++ b/tests/tableau/config_extra_excluded_projects.yml
@@ -10,6 +10,6 @@ bigquery_project_name_to_id_map:
   bq_name: bq_id
 disable_preview_image: true
 output: {}
-extra_excluded_projects:
+exclude_extra_projects:
   - foo
   - bar

--- a/tests/tableau/config_include_personal_space.yml
+++ b/tests/tableau/config_include_personal_space.yml
@@ -1,0 +1,13 @@
+---
+server_url: https://10ay.online.tableau.com
+site_name: abc
+alternative_base_url: https://tableau.my_company.com
+access_token:
+  token_name: foo
+  token_value: bar
+snowflake_account: snow
+bigquery_project_name_to_id_map:
+  bq_name: bq_id
+disable_preview_image: true
+output: {}
+include_personal_space: true

--- a/tests/tableau/test_config.py
+++ b/tests/tableau/test_config.py
@@ -39,3 +39,18 @@ def test_yaml_config_no_optional(test_root_dir):
         disable_preview_image=False,
         output=OutputConfig(),
     )
+
+
+def test_excluded_projects(test_root_dir) -> None:
+    config = TableauRunConfig.from_yaml_file(
+        f"{test_root_dir}/tableau/config_extra_excluded_projects.yml"
+    )
+    assert config.excluded_projects == {"foo", "bar", "Personal Space"}
+
+    config = TableauRunConfig.from_yaml_file(
+        f"{test_root_dir}/tableau/config_include_personal_space.yml"
+    )
+    assert config.excluded_projects == set()
+
+    config = TableauRunConfig.from_yaml_file(f"{test_root_dir}/tableau/config.yml")
+    assert config.excluded_projects == {"Personal Space"}

--- a/tests/tableau/test_extractor.py
+++ b/tests/tableau/test_extractor.py
@@ -273,6 +273,26 @@ async def test_extractor(
     extractor._views = {"vid": view}
     extractor._parse_dashboard(workbook)
 
+    ignored_workbook = WorkbookItem("Personal Space")
+    ignored_workbook._set_values(
+        id="dont_care",
+        name="wb",
+        content_url="wb",
+        webpage_url="https://hostname/#/site/dont_care/workbooks/123",
+        created_at=None,
+        description="d",
+        updated_at=None,
+        size=1,
+        show_tabs=True,
+        project_id="child_project_id",
+        project_name="Personal Space",
+        owner_id=None,
+        tags=None,
+        views=[],
+        data_acceleration_config=None,
+    )
+    extractor._parse_dashboard(ignored_workbook)
+
     assert len(extractor._dashboards) == 1
     assert extractor._dashboards["123"] == Dashboard(
         logical_id=DashboardLogicalID(
@@ -361,7 +381,36 @@ async def test_extractor(
                     "upstreamTables": [],
                 },
             ],
-        }
+        },
+        {
+            "luid": "dont_care",
+            "name": "we dont care",
+            "projectLuid": "child_project_id",
+            "projectName": "Personal Space",
+            "vizportalUrlId": "5566",
+            "upstreamDatasources": [
+                {
+                    "id": "sourceId1",
+                    "luid": "sourceId1",
+                    "name": "source1",
+                    "vizportalUrlId": "777",
+                    "fields": [],
+                    "upstreamTables": [
+                        {
+                            "luid": "4ba4462e",
+                            "name": "CYCLE",
+                            "fullName": "[LONDON].[CYCLE]",
+                            "schema": "LONDON",
+                            "database": {
+                                "name": "DEV_DB",
+                                "connectionType": "snowflake",
+                            },
+                        }
+                    ],
+                }
+            ],
+            "embeddedDatasources": [],
+        },
     ]
 
     extractor._snowflake_account = "snow"


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

The `Personal Space` project should be ignored by the connector by default. Also, it would be nice to add configurations to allow users to either exclude other projects, or include `Personal Space`.

Ref: https://help.tableau.com/current/pro/desktop/en-us/personal_space.htm

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Added config values.
- Updated README.
- Modified unit test.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

- Tested locally.
- Unit test.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
