### PR TITLE
Add column stats to unity catalog profiler

### DIFF
--- a/metaphor/unity_catalog/profile/extractor.py
+++ b/metaphor/unity_catalog/profile/extractor.py
@@ -105,9 +105,7 @@ class UnityCatalogProfileExtractor(BaseExtractor):
                 platform=DataPlatform.UNITY_CATALOG,
             ),
         )
-        return self._get_statistics(dataset, table_info)
 
-    def _get_statistics(self, dataset: Dataset, table_info: TableInfo) -> Dataset:
         if table_info.table_type is TableType.VIEW:
             return dataset
 

--- a/metaphor/unity_catalog/profile/extractor.py
+++ b/metaphor/unity_catalog/profile/extractor.py
@@ -8,7 +8,7 @@ from metaphor.unity_catalog.profile.utils import escape_special_characters
 try:
     from databricks import sql
     from databricks.sdk import WorkspaceClient
-    from databricks.sdk.service.catalog import TableInfo, TableType
+    from databricks.sdk.service.catalog import ColumnTypeName, TableInfo, TableType
     from databricks.sdk.service.sql import EndpointInfo
     from databricks.sql.client import Connection
 except ImportError:
@@ -24,8 +24,10 @@ from metaphor.models.crawler_run_metadata import Platform
 from metaphor.models.metadata_change_event import (
     DataPlatform,
     Dataset,
+    DatasetFieldStatistics,
     DatasetLogicalID,
     DatasetStatistics,
+    FieldStatistics,
 )
 from metaphor.unity_catalog.extractor import DEFAULT_FILTER, UnityCatalogExtractor
 
@@ -38,6 +40,15 @@ NON_MODIFICATION_OPERATIONS = {
     "ADD CONSTRAINT",
 }
 """These are the operations that do not count as modifications."""
+
+NUMERIC_TYPES = {
+    ColumnTypeName.DECIMAL,
+    ColumnTypeName.DOUBLE,
+    ColumnTypeName.FLOAT,
+    ColumnTypeName.INT,
+    ColumnTypeName.LONG,
+    ColumnTypeName.SHORT,
+}
 
 
 class UnityCatalogProfileExtractor(BaseExtractor):
@@ -88,40 +99,92 @@ class UnityCatalogProfileExtractor(BaseExtractor):
         return entities
 
     def _init_dataset(self, table_info: TableInfo) -> Dataset:
-        return Dataset(
+        dataset = Dataset(
             logical_id=DatasetLogicalID(
                 name=normalize_full_dataset_name(table_info.full_name),
                 platform=DataPlatform.UNITY_CATALOG,
             ),
-            statistics=self._get_dataset_statistics(table_info=table_info),
         )
+        return self._get_statistics(dataset, table_info)
 
-    def _get_dataset_statistics(self, table_info: TableInfo) -> DatasetStatistics:
-        dataset_statistics = DatasetStatistics()
-        if table_info.table_type is not TableType.VIEW:
-            with self._connection.cursor() as cursor:
-                escaped_name = escape_special_characters(table_info.full_name)
-                # This can take a while
-                cursor.execute(f"ANALYZE TABLE {escaped_name} COMPUTE STATISTICS")
-                cursor.execute(f"DESCRIBE TABLE EXTENDED {escaped_name}")
-                rows = cursor.fetchall()
-                statistics = next(
-                    (row for row in rows if row.col_name == "Statistics"), None
+    def _get_statistics(self, dataset: Dataset, table_info: TableInfo) -> Dataset:
+        if table_info.table_type is TableType.VIEW:
+            return dataset
+
+        dataset.statistics = DatasetStatistics()
+
+        # Gather this first, if this is nonempty in the end then we actually save
+        # this to `Dataset`.
+        field_statistics = DatasetFieldStatistics(field_statistics=[])
+        assert field_statistics.field_statistics is not None
+
+        with self._connection.cursor() as cursor:
+            escaped_name = escape_special_characters(table_info.full_name)
+            # Gather numeric columns
+            numeric_columns = [
+                column.name
+                for column in (table_info.columns or [])
+                if column.type_name in NUMERIC_TYPES and column.name
+            ]
+
+            analyze_query = f"ANALYZE TABLE {escaped_name} COMPUTE STATISTICS"
+            if numeric_columns:
+                analyze_query += f" FOR COLUMNS {', '.join(numeric_columns)}"
+
+            # This can take a while
+            cursor.execute(analyze_query)
+            cursor.execute(f"DESCRIBE TABLE EXTENDED {escaped_name}")
+            rows = cursor.fetchall()
+            statistics = next(
+                (row for row in rows if row.col_name == "Statistics"), None
+            )
+            if statistics:
+                # `statistics.data_type` looks like "X bytes, Y rows"
+                bytes_count, row_count = [
+                    float(x) for x in re.findall(r"(\d+)", statistics.data_type)
+                ]
+                dataset.statistics.data_size_bytes = bytes_count
+                dataset.statistics.record_count = row_count
+
+            for numeric_column in numeric_columns:
+                # Parse numeric column stats
+                cursor.execute(f"DESCRIBE EXTENDED {escaped_name} {numeric_column}")
+                column_details = cursor.fetchall()
+
+                def get_value_from_row(key: str) -> Optional[float]:
+                    value = next(
+                        (
+                            row.info_value
+                            for row in column_details
+                            if row.info_name == key
+                        ),
+                        None,
+                    )
+                    if value:
+                        if value == "NULL":
+                            return None
+                        return float(value)
+                    return value
+
+                stats = FieldStatistics(
+                    distinct_value_count=get_value_from_row("distinct_count"),
+                    field_path=numeric_column,
+                    max_value=get_value_from_row("max"),
+                    min_value=get_value_from_row("min"),
+                    null_value_count=get_value_from_row("num_nulls"),
                 )
-                if statistics:
-                    # `statistics.data_type` looks like "X bytes, Y rows"
-                    bytes_count, row_count = [
-                        float(x) for x in re.findall(r"(\d+)", statistics.data_type)
-                    ]
-                    dataset_statistics.data_size_bytes = bytes_count
-                    dataset_statistics.record_count = row_count
-                cursor.execute(f"DESCRIBE HISTORY {escaped_name}")
-                for history in cursor.fetchall():
-                    if history["operation"] not in NON_MODIFICATION_OPERATIONS:
-                        dataset_statistics.last_updated = history["timestamp"]
-                        break
+                field_statistics.field_statistics.append(stats)
 
-        return dataset_statistics
+            cursor.execute(f"DESCRIBE HISTORY {escaped_name}")
+            for history in cursor.fetchall():
+                if history["operation"] not in NON_MODIFICATION_OPERATIONS:
+                    dataset.statistics.last_updated = history["timestamp"]
+                    break
+
+        if field_statistics.field_statistics:
+            dataset.field_statistics = field_statistics
+
+        return dataset
 
     @staticmethod
     def create_connection(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.77"
+version = "0.13.78"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/unity_catalog/profile/expected.json
+++ b/tests/unity_catalog/profile/expected.json
@@ -1,13 +1,23 @@
 [
   {
+    "fieldStatistics": {
+      "fieldStatistics": [
+        {
+          "distinctValueCount": 1234.0,
+          "fieldPath": "col2",
+          "maxValue": 9999.0,
+          "minValue": -9999.0
+        }
+      ]
+    },
     "logicalId": {
       "name": "catalog.schema.table",
       "platform": "UNITY_CATALOG"
     },
     "statistics": {
       "dataSizeBytes": 5566.0,
-      "recordCount": 9487.0,
-      "lastUpdated": "2023-10-30T12:06:19+00:00"
+      "lastUpdated": "2023-10-30T12:06:19+00:00",
+      "recordCount": 9487.0
     }
   }
 ]

--- a/tests/unity_catalog/profile/test_extractor.py
+++ b/tests/unity_catalog/profile/test_extractor.py
@@ -4,7 +4,14 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from databricks.sdk.core import DatabricksError
-from databricks.sdk.service.catalog import CatalogInfo, SchemaInfo, TableInfo, TableType
+from databricks.sdk.service.catalog import (
+    CatalogInfo,
+    ColumnInfo,
+    ColumnTypeName,
+    SchemaInfo,
+    TableInfo,
+    TableType,
+)
 
 from metaphor.common.base_config import OutputConfig
 from metaphor.common.event_util import EventUtil
@@ -46,13 +53,26 @@ async def test_extractor(
     mock_client.tables.list = MagicMock()
     mock_client.tables.list.return_value = [
         TableInfo(
-            name="table", full_name="catalog.schema.table", table_type=TableType.MANAGED
+            name="table",
+            full_name="catalog.schema.table",
+            table_type=TableType.MANAGED,
+            columns=[
+                ColumnInfo(name="col1", type_name=ColumnTypeName.STRING),
+                ColumnInfo(name="col2", type_name=ColumnTypeName.INT),
+            ],
         ),
     ]
     mock_create_api.return_value = mock_client
 
     mock_rows = [
         SimpleNamespace(col_name="Statistics", data_type="5566 bytes, 9487 rows")
+    ]
+
+    mock_col2_stats = [
+        SimpleNamespace(info_name="distinct_count", info_value="1234"),
+        SimpleNamespace(info_name="max", info_value="9999"),
+        SimpleNamespace(info_name="min", info_value="-9999"),
+        SimpleNamespace(info_name="num_nulls", info_value="NULL"),
     ]
 
     mock_latest_history = [
@@ -66,6 +86,7 @@ async def test_extractor(
     mock_cursor.fetchall = MagicMock()
     mock_cursor.fetchall.side_effect = [
         mock_rows,
+        mock_col2_stats,
         mock_latest_history,
     ]
 


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

It is also possible to get column stats from databricks sql client, best if we can support that.

### 🤓 What?

Parses column stats with databricks sql client, and stores the info in `Dataset.field_statistics`.

### 🧪 Tested?

Tested locally.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
