### PR TITLE
Upgrade to Python 3.10

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@
 name: CD
 
 env:
-  PYTHON_VERSION: 3.10
+  PYTHON_VERSION: '3.10'
   POETRY_VERSION: 1.2.2
   NODE_VERSION: 16
   DOCKER_IMAGE: metaphordata/connectors

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@
 name: CD
 
 env:
-  PYTHON_VERSION: 3.8
+  PYTHON_VERSION: 3.10
   POETRY_VERSION: 1.2.2
   NODE_VERSION: 16
   DOCKER_IMAGE: metaphordata/connectors

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 name: CI
 
 env:
-  PYTHON_VERSION: 3.8
+  PYTHON_VERSION: 3.10
   POETRY_VERSION: 1.2.2
 
 # Run this build workflow for every new PR

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 name: CI
 
 env:
-  PYTHON_VERSION: 3.10
+  PYTHON_VERSION: '3.10'
   POETRY_VERSION: 1.2.2
 
 # Run this build workflow for every new PR

--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,7 @@ dmypy.json
 .config
 .data
 .DS_Store
+poetry.toml
 
 # vscode
 .vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM python:3.8-slim
+FROM python:3.10-slim
 
 RUN apt-get clean
 RUN apt-get update

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Codecov](https://img.shields.io/codecov/c/github/MetaphorData/connectors)](https://app.codecov.io/gh/MetaphorData/connectors/tree/main)
 [![CodeQL](https://github.com/MetaphorData/connectors/workflows/CodeQL/badge.svg)](https://github.com/MetaphorData/connectors/actions/workflows/codeql-analysis.yml)
 [![PyPI Version](https://img.shields.io/pypi/v/metaphor-connectors)](https://pypi.org/project/metaphor-connectors/)
-![Python version 3.8+](https://img.shields.io/badge/python-3.8%2B-blue)
+![Python version 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)
 ![PyPI Downloads](https://img.shields.io/pypi/dm/metaphor-connectors)
 [![Docker Pulls](https://img.shields.io/docker/pulls/metaphordata/connectors)](https://hub.docker.com/r/metaphordata/connectors)
 [![License](https://img.shields.io/github/license/MetaphorData/connectors)](https://github.com/MetaphorData/connectors/blob/master/LICENSE)

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -4,34 +4,26 @@
 
 We recommend using [pyenv](https://github.com/pyenv/pyenv) to manage multiple versions of Python on your system. Refer to the [installation guide](https://github.com/pyenv/pyenv#installation) for your system.
 
-Install Python `3.8` if haven't done so already
+Install Python `3.10` if haven't done so already
 
 ```shell
-pyenv install 3.8
+pyenv install 3.10
 ```
 
 Verify that it's the version selected by `pyenv` for the project.
 
 ```shell
 python -V
-Python 3.8
+Python 3.10
 ```
 
-If you prefer to use Python 3.8 only for this project, you can run the following command to generate a `.python_version` file.
+If you prefer to use Python 3.10 only for this project, you can run the following command to generate a `.python_version` file.
 
 ```shell
-pyenv local 3.8
+pyenv local 3.10
 ```
 
-> Note: We recommend using the latest 3.8 release to ensure maximum compatibility. However, if you're developing on an Apple Silicon Mac, please either run in a [Rosetta Terminal](https://www.courier.com/blog/tips-and-tricks-to-setup-your-apple-m1-for-development) or use the closest version that natively supports Apple Silicon (3.8.10 as of now).
-
-## (macOS only) Install External Dependencies
-
-Some Python packages require external dependencies to build on macOS, e.g. [pymssql](https://github.com/pymssql/pymssql). You can use [homebrew](https://brew.sh/) to install these:
-
-```shell
-brew install freetds
-```
+> Note: We recommend using the latest 3.10 release to ensure maximum compatibility. However, if you're developing on an Apple Silicon Mac, please either run in a [Rosetta Terminal](https://www.courier.com/blog/tips-and-tricks-to-setup-your-apple-m1-for-development) or use the closest version that natively supports Apple Silicon.
 
 ## Install Poetry
 

--- a/metaphor/bigquery/config.py
+++ b/metaphor/bigquery/config.py
@@ -81,7 +81,9 @@ class BigQueryRunConfig(BaseConfig):
     tag_matchers: List[TagMatcher] = field(default_factory=lambda: [])
 
     # configs for fetching query logs
-    query_log: BigQueryQueryLogConfig = BigQueryQueryLogConfig()
+    query_log: BigQueryQueryLogConfig = field(
+        default_factory=lambda: BigQueryQueryLogConfig()
+    )
 
     @model_validator(mode="after")
     def have_key_path_or_credentials(self) -> "BigQueryRunConfig":

--- a/metaphor/glue/extractor.py
+++ b/metaphor/glue/extractor.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime
-from typing import Any, Collection, Dict, List
+from typing import Any, Collection, Dict, List, Optional
 
 import boto3
 from aws_assume_role_lib import assume_role
@@ -109,7 +109,11 @@ class GlueExtractor(BaseExtractor):
                 )
                 table_type = table.get("TableType")
                 parameters = table.get("Parameters")
-                row_count = parameters.get("numRows") if parameters else None
+                row_count = (
+                    int(parameters["numRows"])
+                    if parameters and "numRows" in parameters
+                    else None
+                )
                 description = table.get("Description")
 
                 dataset = self._init_dataset(
@@ -141,6 +145,7 @@ class GlueExtractor(BaseExtractor):
                     else None
                 )
 
+                assert dataset.schema is not None
                 dataset.schema.fields = columns
 
     def _init_dataset(
@@ -148,9 +153,9 @@ class GlueExtractor(BaseExtractor):
         schema: str,
         name: str,
         table_type: str,
-        description: str,
-        row_count: int,
-        last_updated: datetime,
+        description: Optional[str],
+        row_count: Optional[int],
+        last_updated: Optional[datetime],
     ) -> Dataset:
         normalized_name = dataset_normalized_name(schema=schema, table=name)
         dataset = Dataset()

--- a/metaphor/mssql/README.md
+++ b/metaphor/mssql/README.md
@@ -59,3 +59,23 @@ metaphor mssql <config_file>
 ```
 
 Manually verify the output after the command finishes.
+
+### Installing on Apple Silicon machines
+
+If you encounter linking issues when installing `pymssql` on a machine with Apple Silicon CPU, here is a possible fix:
+1. Set poetry config to build the package instead of using pre-compiled binary:
+```shell
+poetry config --local installer.no-binary pymssql
+```
+2. Instead of using system wide `ssl` module, install `openssl` and `FreeTDS` with Homebrew:
+```shell
+brew install FreeTDS openssl@1.1
+```
+3. Set `LDFLAGS` and `CFLAGS` when installing `pymssql`:
+```shell
+LDFLAGS="-L$(brew --prefix)/opt/freetds/lib -L$(brew --prefix)/opt/openssl@1.1/lib" \
+CFLAGS="-I$(brew --prefix)/opt/freetds/include -I$(brew --prefix)/opt/openssl@1.1/include" \
+poetry install -E mssql
+```
+
+If the above procedure does not fix the issue, please file an issue ticket.

--- a/metaphor/redshift/config.py
+++ b/metaphor/redshift/config.py
@@ -25,4 +25,6 @@ class RedshiftRunConfig(PostgreSQLRunConfig):
     tag_matchers: List[TagMatcher] = field(default_factory=lambda: [])
 
     # configs for fetching query logs
-    query_log: RedshiftQueryLogConfig = RedshiftQueryLogConfig()
+    query_log: RedshiftQueryLogConfig = field(
+        default_factory=lambda: RedshiftQueryLogConfig()
+    )

--- a/metaphor/snowflake/config.py
+++ b/metaphor/snowflake/config.py
@@ -55,7 +55,11 @@ class SnowflakeConfig(SnowflakeBaseConfig):
     tag_matchers: List[TagMatcher] = field(default_factory=lambda: [])
 
     # configs for fetching query logs
-    query_log: SnowflakeQueryLogConfig = SnowflakeQueryLogConfig()
+    query_log: SnowflakeQueryLogConfig = field(
+        default_factory=lambda: SnowflakeQueryLogConfig()
+    )
 
     # configs for fetching Snowflake streams
-    streams: SnowflakeStreamsConfig = SnowflakeStreamsConfig()
+    streams: SnowflakeStreamsConfig = field(
+        default_factory=lambda: SnowflakeStreamsConfig()
+    )

--- a/metaphor/synapse/config.py
+++ b/metaphor/synapse/config.py
@@ -1,3 +1,4 @@
+from dataclasses import field
 from typing import Optional
 
 from pydantic.dataclasses import dataclass
@@ -14,4 +15,6 @@ class SynapseQueryLogConfig:
 
 @dataclass(config=ConnectorConfig)
 class SynapseConfig(MssqlConfig):
-    query_log: Optional[SynapseQueryLogConfig] = SynapseQueryLogConfig()
+    query_log: Optional[SynapseQueryLogConfig] = field(
+        default_factory=lambda: SynapseQueryLogConfig()
+    )

--- a/metaphor/unity_catalog/config.py
+++ b/metaphor/unity_catalog/config.py
@@ -35,4 +35,6 @@ class UnityCatalogRunConfig(BaseConfig):
     warehouse_id: Optional[str] = None
 
     # configs for fetching query logs
-    query_log: UnityCatalogQueryLogConfig = UnityCatalogQueryLogConfig()
+    query_log: UnityCatalogQueryLogConfig = field(
+        default_factory=lambda: UnityCatalogQueryLogConfig()
+    )

--- a/poetry.lock
+++ b/poetry.lock
@@ -121,9 +121,6 @@ files = [
     {file = "annotated_types-0.6.0.tar.gz", hash = "sha256:563339e807e53ffd9c267e99fc6d9ea23eb8443c08f112651963e24e22f84a5d"},
 ]
 
-[package.dependencies]
-typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.9\""}
-
 [[package]]
 name = "anyio"
 version = "4.0.0"
@@ -373,34 +370,6 @@ files = [
 ]
 
 [[package]]
-name = "backports-zoneinfo"
-version = "0.2.1"
-description = "Backport of the standard library zoneinfo module"
-optional = true
-python-versions = ">=3.6"
-files = [
-    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:da6013fd84a690242c310d77ddb8441a559e9cb3d3d59ebac9aca1a57b2e18bc"},
-    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:89a48c0d158a3cc3f654da4c2de1ceba85263fafb861b98b59040a5086259722"},
-    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:1c5742112073a563c81f786e77514969acb58649bcdf6cdf0b4ed31a348d4546"},
-    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-win32.whl", hash = "sha256:e8236383a20872c0cdf5a62b554b27538db7fa1bbec52429d8d106effbaeca08"},
-    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-win_amd64.whl", hash = "sha256:8439c030a11780786a2002261569bdf362264f605dfa4d65090b64b05c9f79a7"},
-    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:f04e857b59d9d1ccc39ce2da1021d196e47234873820cbeaad210724b1ee28ac"},
-    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:17746bd546106fa389c51dbea67c8b7c8f0d14b5526a579ca6ccf5ed72c526cf"},
-    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5c144945a7752ca544b4b78c8c41544cdfaf9786f25fe5ffb10e838e19a27570"},
-    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-win32.whl", hash = "sha256:e55b384612d93be96506932a786bbcde5a2db7a9e6a4bb4bffe8b733f5b9036b"},
-    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-win_amd64.whl", hash = "sha256:a76b38c52400b762e48131494ba26be363491ac4f9a04c1b7e92483d169f6582"},
-    {file = "backports.zoneinfo-0.2.1-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:8961c0f32cd0336fb8e8ead11a1f8cd99ec07145ec2931122faaac1c8f7fd987"},
-    {file = "backports.zoneinfo-0.2.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e81b76cace8eda1fca50e345242ba977f9be6ae3945af8d46326d776b4cf78d1"},
-    {file = "backports.zoneinfo-0.2.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7b0a64cda4145548fed9efc10322770f929b944ce5cee6c0dfe0c87bf4c0c8c9"},
-    {file = "backports.zoneinfo-0.2.1-cp38-cp38-win32.whl", hash = "sha256:1b13e654a55cd45672cb54ed12148cd33628f672548f373963b0bff67b217328"},
-    {file = "backports.zoneinfo-0.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:4a0f800587060bf8880f954dbef70de6c11bbe59c673c3d818921f042f9954a6"},
-    {file = "backports.zoneinfo-0.2.1.tar.gz", hash = "sha256:fadbfe37f74051d024037f223b8e001611eac868b5c5b06144ef4d8b799862f2"},
-]
-
-[package.extras]
-tzdata = ["tzdata"]
-
-[[package]]
 name = "bandit"
 version = "1.7.5"
 description = "Security oriented static analyser for python code."
@@ -498,10 +467,7 @@ files = [
 [package.dependencies]
 jmespath = ">=0.7.1,<2.0.0"
 python-dateutil = ">=2.1,<3.0.0"
-urllib3 = [
-    {version = ">=1.25.4,<2.1", markers = "python_version >= \"3.10\""},
-    {version = ">=1.25.4,<1.27", markers = "python_version < \"3.10\""},
-]
+urllib3 = {version = ">=1.25.4,<2.1", markers = "python_version >= \"3.10\""}
 
 [package.extras]
 crt = ["awscrt (==0.19.17)"]
@@ -1001,7 +967,6 @@ packaging = "*"
 pydantic = [
     {version = ">=1.10.0,<2.0.0 || >2.0.0,<2.0.1 || >2.0.1,<2.4.0 || >2.4.0,<3.0", extras = ["email"], markers = "python_version >= \"3.12\" and python_version < \"4.0\""},
     {version = ">=1.10.0,<2.4.0 || >2.4.0,<3.0", extras = ["email"], markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
-    {version = ">=1.5.1,<2.4.0 || >2.4.0,<3.0", extras = ["email"], markers = "python_version < \"3.10\""},
     {version = ">=1.9.0,<2.4.0 || >2.4.0,<3.0", extras = ["email"], markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
 ]
 pyyaml = ">=6.0.1"
@@ -1568,42 +1533,43 @@ grpc = ["grpcio (>=1.44.0,<2.0.0.dev0)"]
 
 [[package]]
 name = "gql"
-version = "3.4.1"
+version = "3.5.0b9"
 description = "GraphQL client for Python"
 optional = true
 python-versions = "*"
 files = [
-    {file = "gql-3.4.1-py2.py3-none-any.whl", hash = "sha256:315624ca0f4d571ef149d455033ebd35e45c1a13f18a059596aeddcea99135cf"},
-    {file = "gql-3.4.1.tar.gz", hash = "sha256:11dc5d8715a827f2c2899593439a4f36449db4f0eafa5b1ea63948f8a2f8c545"},
+    {file = "gql-3.5.0b9-py2.py3-none-any.whl", hash = "sha256:b0604c40bf3f8c8cd57b85266c1834e93e5e0f887542f59833eec8632e1a4a0d"},
+    {file = "gql-3.5.0b9.tar.gz", hash = "sha256:e20e8cbbe0f0b8e56dc7dac1734a60ad388e5e08f8e650ea682fc1cfb90b65c4"},
 ]
 
 [package.dependencies]
+anyio = ">=3.0,<5"
 backoff = ">=1.11.1,<3.0"
-graphql-core = ">=3.2,<3.3"
+graphql-core = ">=3.3.0a3,<3.4"
 requests = {version = ">=2.26,<3", optional = true, markers = "extra == \"requests\""}
-requests-toolbelt = {version = ">=0.9.1,<1", optional = true, markers = "extra == \"requests\""}
-urllib3 = {version = ">=1.26,<2", optional = true, markers = "extra == \"requests\""}
+requests-toolbelt = {version = ">=1.0.0,<2", optional = true, markers = "extra == \"requests\""}
 yarl = ">=1.6,<2.0"
 
 [package.extras]
-aiohttp = ["aiohttp (>=3.7.1,<3.9.0)"]
-all = ["aiohttp (>=3.7.1,<3.9.0)", "botocore (>=1.21,<2)", "requests (>=2.26,<3)", "requests-toolbelt (>=0.9.1,<1)", "urllib3 (>=1.26,<2)", "websockets (>=10,<11)", "websockets (>=9,<10)"]
+aiohttp = ["aiohttp (>=3.8.0,<4)", "aiohttp (>=3.9.0b0,<4)"]
+all = ["aiohttp (>=3.8.0,<4)", "aiohttp (>=3.9.0b0,<4)", "botocore (>=1.21,<2)", "httpx (>=0.23.1,<1)", "requests (>=2.26,<3)", "requests-toolbelt (>=1.0.0,<2)", "websockets (>=10,<12)"]
 botocore = ["botocore (>=1.21,<2)"]
-dev = ["aiofiles", "aiohttp (>=3.7.1,<3.9.0)", "black (==22.3.0)", "botocore (>=1.21,<2)", "check-manifest (>=0.42,<1)", "flake8 (==3.8.1)", "isort (==4.3.21)", "mock (==4.0.2)", "mypy (==0.910)", "parse (==1.15.0)", "pytest (==6.2.5)", "pytest-asyncio (==0.16.0)", "pytest-console-scripts (==1.3.1)", "pytest-cov (==3.0.0)", "requests (>=2.26,<3)", "requests-toolbelt (>=0.9.1,<1)", "sphinx (>=3.0.0,<4)", "sphinx-argparse (==0.2.5)", "sphinx-rtd-theme (>=0.4,<1)", "types-aiofiles", "types-mock", "types-requests", "urllib3 (>=1.26,<2)", "vcrpy (==4.0.2)", "websockets (>=10,<11)", "websockets (>=9,<10)"]
-requests = ["requests (>=2.26,<3)", "requests-toolbelt (>=0.9.1,<1)", "urllib3 (>=1.26,<2)"]
-test = ["aiofiles", "aiohttp (>=3.7.1,<3.9.0)", "botocore (>=1.21,<2)", "mock (==4.0.2)", "parse (==1.15.0)", "pytest (==6.2.5)", "pytest-asyncio (==0.16.0)", "pytest-console-scripts (==1.3.1)", "pytest-cov (==3.0.0)", "requests (>=2.26,<3)", "requests-toolbelt (>=0.9.1,<1)", "urllib3 (>=1.26,<2)", "vcrpy (==4.0.2)", "websockets (>=10,<11)", "websockets (>=9,<10)"]
-test-no-transport = ["aiofiles", "mock (==4.0.2)", "parse (==1.15.0)", "pytest (==6.2.5)", "pytest-asyncio (==0.16.0)", "pytest-console-scripts (==1.3.1)", "pytest-cov (==3.0.0)", "vcrpy (==4.0.2)"]
-websockets = ["websockets (>=10,<11)", "websockets (>=9,<10)"]
+dev = ["aiofiles", "aiohttp (>=3.8.0,<4)", "aiohttp (>=3.9.0b0,<4)", "black (==22.3.0)", "botocore (>=1.21,<2)", "check-manifest (>=0.42,<1)", "flake8 (==3.8.1)", "httpx (>=0.23.1,<1)", "isort (==4.3.21)", "mock (==4.0.2)", "mypy (==0.910)", "parse (==1.15.0)", "pytest (==7.4.2)", "pytest-asyncio (==0.21.1)", "pytest-console-scripts (==1.3.1)", "pytest-cov (==3.0.0)", "requests (>=2.26,<3)", "requests-toolbelt (>=1.0.0,<2)", "sphinx (>=5.3.0,<6)", "sphinx-argparse (==0.2.5)", "sphinx-rtd-theme (>=0.4,<1)", "types-aiofiles", "types-mock", "types-requests", "vcrpy (==4.4.0)", "websockets (>=10,<12)"]
+httpx = ["httpx (>=0.23.1,<1)"]
+requests = ["requests (>=2.26,<3)", "requests-toolbelt (>=1.0.0,<2)"]
+test = ["aiofiles", "aiohttp (>=3.8.0,<4)", "aiohttp (>=3.9.0b0,<4)", "botocore (>=1.21,<2)", "httpx (>=0.23.1,<1)", "mock (==4.0.2)", "parse (==1.15.0)", "pytest (==7.4.2)", "pytest-asyncio (==0.21.1)", "pytest-console-scripts (==1.3.1)", "pytest-cov (==3.0.0)", "requests (>=2.26,<3)", "requests-toolbelt (>=1.0.0,<2)", "vcrpy (==4.4.0)", "websockets (>=10,<12)"]
+test-no-transport = ["aiofiles", "mock (==4.0.2)", "parse (==1.15.0)", "pytest (==7.4.2)", "pytest-asyncio (==0.21.1)", "pytest-console-scripts (==1.3.1)", "pytest-cov (==3.0.0)", "vcrpy (==4.4.0)"]
+websockets = ["websockets (>=10,<12)"]
 
 [[package]]
 name = "graphql-core"
-version = "3.2.3"
-description = "GraphQL implementation for Python, a port of GraphQL.js, the JavaScript reference implementation for GraphQL."
+version = "3.3.0a3"
+description = "GraphQL-core is a Python port of GraphQL.js,the JavaScript reference implementation for GraphQL."
 optional = true
-python-versions = ">=3.6,<4"
+python-versions = ">=3.7,<4.0"
 files = [
-    {file = "graphql-core-3.2.3.tar.gz", hash = "sha256:06d2aad0ac723e35b1cb47885d3e5c45e956a53bc1b209a9fc5369007fe46676"},
-    {file = "graphql_core-3.2.3-py3-none-any.whl", hash = "sha256:5766780452bd5ec8ba133f8bf287dc92713e3868ddd83aee4faab9fc3e303dc3"},
+    {file = "graphql_core-3.3.0a3-py3-none-any.whl", hash = "sha256:b441346e61b2d7465a6f4001334ba1ddb123498a7e9dfe76cd323db8159aa707"},
+    {file = "graphql_core-3.3.0a3.tar.gz", hash = "sha256:065d23881d00d0b52b9a7c0a8d63451585549c13f3f05a214923b20dabbda290"},
 ]
 
 [[package]]
@@ -1967,24 +1933,6 @@ perf = ["ipython"]
 testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)", "pytest-ruff"]
 
 [[package]]
-name = "importlib-resources"
-version = "5.13.0"
-description = "Read resources from Python packages"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "importlib_resources-5.13.0-py3-none-any.whl", hash = "sha256:9f7bd0c97b79972a6cce36a366356d16d5e13b09679c11a58f1014bfdf8e64b2"},
-    {file = "importlib_resources-5.13.0.tar.gz", hash = "sha256:82d5c6cca930697dbbd86c93333bb2c2e72861d4789a11c2662b933e5ad2b528"},
-]
-
-[package.dependencies]
-zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
-
-[[package]]
 name = "inflect"
 version = "5.6.2"
 description = "Correctly generate plurals, singular nouns, ordinals, indefinite articles; convert numbers to words"
@@ -2082,9 +2030,7 @@ files = [
 
 [package.dependencies]
 attrs = ">=22.2.0"
-importlib-resources = {version = ">=1.4.0", markers = "python_version < \"3.9\""}
 jsonschema-specifications = ">=2023.03.6"
-pkgutil-resolve-name = {version = ">=1.3.10", markers = "python_version < \"3.9\""}
 referencing = ">=0.28.4"
 rpds-py = ">=0.7.1"
 
@@ -2104,7 +2050,6 @@ files = [
 ]
 
 [package.dependencies]
-importlib-resources = {version = ">=1.4.0", markers = "python_version < \"3.9\""}
 referencing = ">=0.31.0"
 
 [[package]]
@@ -2841,7 +2786,6 @@ files = [
 [package.dependencies]
 numpy = [
     {version = ">=1.23.2", markers = "python_version >= \"3.11\""},
-    {version = ">=1.20.3", markers = "python_version < \"3.10\""},
     {version = ">=1.21.0", markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
 ]
 python-dateutil = ">=2.8.2"
@@ -2941,17 +2885,6 @@ files = [
 [package.dependencies]
 python-dateutil = ">=2.6,<3.0"
 pytzdata = ">=2020.1"
-
-[[package]]
-name = "pkgutil-resolve-name"
-version = "1.3.10"
-description = "Resolve a name to an object."
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "pkgutil_resolve_name-1.3.10-py3-none-any.whl", hash = "sha256:ca27cc078d25c5ad71a9de0a7a330146c4e014c2462d9af19c6b828280649c5e"},
-    {file = "pkgutil_resolve_name-1.3.10.tar.gz", hash = "sha256:357d6c9e6a755653cfd78893817c0853af365dd51ec97f3d358a819373bbd174"},
-]
 
 [[package]]
 name = "platformdirs"
@@ -3336,72 +3269,79 @@ tests = ["coverage[toml] (==5.0.4)", "pytest (>=6.0.0,<7.0.0)"]
 
 [[package]]
 name = "pymssql"
-version = "2.2.10"
+version = "2.2.11"
 description = "DB-API interface to Microsoft SQL Server for Python. (new Cython-based version)"
 optional = true
 python-versions = "*"
 files = [
-    {file = "pymssql-2.2.10-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:d01eefecea6d42f0da2d6d5953f4b7a9d7cabb0374354332628f0780cf0a84e0"},
-    {file = "pymssql-2.2.10-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:37712ed768dc06421db65464ffff62210cbbff335c54e2318cba20a8ba87b491"},
-    {file = "pymssql-2.2.10-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:83d154ba3d7fbcbc63e58da25a274a1b1ade5d9ca51c12e1e28558074982728d"},
-    {file = "pymssql-2.2.10-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:75589914b8b562527b7ddee0cd372990d0526769c4ebcb280dd9c40485308d34"},
-    {file = "pymssql-2.2.10-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c837e58416634d29905b006096191a5864dd61e81283cd83f19d10fc68a796fa"},
-    {file = "pymssql-2.2.10-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:de1be6e0fa8541cce2a2dff8eda197f26ba4f24b35c61b2b503a24962292d5be"},
-    {file = "pymssql-2.2.10-cp310-cp310-win32.whl", hash = "sha256:bae2f75bede8d5f7ba73ab1416ef6e25f3d1c1c21348b817caf099dcc3cfb4fa"},
-    {file = "pymssql-2.2.10-cp310-cp310-win_amd64.whl", hash = "sha256:904def2be4b055b1cb32cdd212da17f89d1569a1a51e50fc417ff8a41c3f16ee"},
-    {file = "pymssql-2.2.10-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9b01a4ca1de7e4e8267e82c849f455acf12241864324976844334638bc2e3366"},
-    {file = "pymssql-2.2.10-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ffcba1f01bcdb7c2720debeba1b418e1bd0253470911c1f3852f2edf5ff38b73"},
-    {file = "pymssql-2.2.10-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94835123196ce12c3176301757836447cb80be183603bb17eeda6d42b8f31451"},
-    {file = "pymssql-2.2.10-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:b78f808a972219a6f72c010efc30df03d2b67a2f9008ae155460495de0ba3b4c"},
-    {file = "pymssql-2.2.10-cp311-cp311-win32.whl", hash = "sha256:21761842b098e0e51ba948233e7c82d5b8e4bc39e4a5f28d252ef19fcdf25413"},
-    {file = "pymssql-2.2.10-cp311-cp311-win_amd64.whl", hash = "sha256:ea0291a7916c94c0df1aa7ab948580a1aebb7f73181d9f3b9d98d37f8edd7528"},
-    {file = "pymssql-2.2.10-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:ba44147490ba9aa23aca0f7e348202af6643682fc88b6419981012af8e8388bc"},
-    {file = "pymssql-2.2.10-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6eb8afdfc0b5e3ba82808ba3558a9fa1b762295c9e1491cff306dcc592a8ac8c"},
-    {file = "pymssql-2.2.10-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2dab815204b9f298961da93af0c30fda982c2f143e3eced84b36945a3ebe3911"},
-    {file = "pymssql-2.2.10-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:a1ad363fd24d14863892f96fa2761ab9a29255d49322ff22118579d2967320a7"},
-    {file = "pymssql-2.2.10-cp312-cp312-win32.whl", hash = "sha256:77322e18dc116e098d59aeb1f4fbbe58b77a42d7d7727bf9e660713f7e20a54d"},
-    {file = "pymssql-2.2.10-cp312-cp312-win_amd64.whl", hash = "sha256:2b9fa3183c23d2689128cda1cb380e6525d840b4c98bc0b32e8d4155fcd9db40"},
-    {file = "pymssql-2.2.10-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:4297c6b3a6e9d92bcbd5916c98c9a790208f2510982ca1c93f4064ebe7e65c54"},
-    {file = "pymssql-2.2.10-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:fd219e3dc94e3952fc6ff734930a8ba4f30423b098442404d876747b1fd194c8"},
-    {file = "pymssql-2.2.10-cp36-cp36m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:923f3006415d788855c48a5d1ff4613b0fc1ea27d6116e044929cebf27e035b3"},
-    {file = "pymssql-2.2.10-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5111719497226a88f44ff9a6c86bea59bf9f6fd6f15f623b05ac115b9b9f50ba"},
-    {file = "pymssql-2.2.10-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:883ab03ac3abbf474f25f8bf3fcbe362c42ac3ba61d6284c68dd3f13d0b78987"},
-    {file = "pymssql-2.2.10-cp36-cp36m-manylinux_2_28_x86_64.whl", hash = "sha256:c5709faf6bb5a1226cf57fb4ff0f7a552ef25778698674edb9842fbc87d4adfd"},
-    {file = "pymssql-2.2.10-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d53f347d0b8903400c3f0d72d8cd4b3b8638d826ceb8aa1592721bbf4c4376c2"},
-    {file = "pymssql-2.2.10-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:7cd3d7fc5952e7d3a1d96ec51b1260d5d4c70e4a01712e0f758653d0d1a7bdfc"},
-    {file = "pymssql-2.2.10-cp36-cp36m-win32.whl", hash = "sha256:01381bf8a4ac749f67d57b6b354afb56d710be53eabe9aeff5fb4aa464f47bf7"},
-    {file = "pymssql-2.2.10-cp36-cp36m-win_amd64.whl", hash = "sha256:0ed66eeee0721863cd96538b99896f44c7e2196c173fb1771b1cbd009ee9fa17"},
-    {file = "pymssql-2.2.10-cp37-cp37m-macosx_11_0_x86_64.whl", hash = "sha256:7ee477e576275c212c9cce4faa16e8fdfed9a7f2ec7bc8a5324551d8aadeece2"},
-    {file = "pymssql-2.2.10-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:42926adf11f0ea3a2f5014906ee2b76ea8c6b76e73a09ec90d019a2f8d11b1b6"},
-    {file = "pymssql-2.2.10-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:21a41f32223da4fd1441b10642475995da07c4f431d27d6cb008caa9b38640da"},
-    {file = "pymssql-2.2.10-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3aac611291e75d6ab8cd960055776580a475300272fe12a9cc732ca574887e71"},
-    {file = "pymssql-2.2.10-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a13eddc8f970884dbf2b5cad678b8e8cbe463dc8bcd081e9c42d3e3968b46484"},
-    {file = "pymssql-2.2.10-cp37-cp37m-manylinux_2_28_x86_64.whl", hash = "sha256:e2a9ea7422f596dcc595539df297cec5359863383ca398d5d428c9b8f6a0cb8a"},
-    {file = "pymssql-2.2.10-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f95fbd56e673662496470dc958537ce7b1f799e9cd13f45f468a67eed4feb6a5"},
-    {file = "pymssql-2.2.10-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:f0d3a0406d024e9f6330a45d6186edef2a12af45706e44538d25146b8555187c"},
-    {file = "pymssql-2.2.10-cp37-cp37m-win32.whl", hash = "sha256:5fc9463100698e71979af6ec4c7748bc5decc6acf6a06bfbb73fa8ecdf5ed508"},
-    {file = "pymssql-2.2.10-cp37-cp37m-win_amd64.whl", hash = "sha256:1191d1e877f13cb8bb7b4720c550cef1f904343528b5eeb700ed05eb1f5f9ead"},
-    {file = "pymssql-2.2.10-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:fadee967a8a4c7b208e852c6cfd8e6b6bf92820ecdad9430a96e2a9c2498cb4a"},
-    {file = "pymssql-2.2.10-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:9d437ad3e9ef2b32391abbbbad0059d620c0f08f32a416d88cf5b4fa67b83927"},
-    {file = "pymssql-2.2.10-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:47a135bd21da454bd80588384746b496b1e8c5945c194c8e465fecd3a3c87bc5"},
-    {file = "pymssql-2.2.10-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6a5fbad20b37d52f831ca18c8962e45583f6f2c99f383ac5ccc0cae65fe9f648"},
-    {file = "pymssql-2.2.10-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e3acf2e192d221619c4f2cde848d6728e80475a7d797790a40ef0fb0905d31b"},
-    {file = "pymssql-2.2.10-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:65e65366da4c554ff7b37df85c8cb120523b676559983c82ace657b95e6ca2a1"},
-    {file = "pymssql-2.2.10-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:59d1543522e94c3aeb1a0e1732d0cb739552a61773bf4802b382a7e3d92837d3"},
-    {file = "pymssql-2.2.10-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:984ed8d56aed277a0d769e00f258e7ba30daeda46d59a3a372e473f3a518c287"},
-    {file = "pymssql-2.2.10-cp38-cp38-win32.whl", hash = "sha256:2dcdf240cfd96c06b3c5193d7016a0c875f4874492af76fe38082a6c2a9f75f9"},
-    {file = "pymssql-2.2.10-cp38-cp38-win_amd64.whl", hash = "sha256:d65d26612454c4475d550fa84b087b7f8125ea789f8db93f7930ce9614c174fc"},
-    {file = "pymssql-2.2.10-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:5a1b6b856c276ecfeeab46608f1bda67e3b0687c8387dbd72a5e8a0c27817baf"},
-    {file = "pymssql-2.2.10-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:efadd0c4f9fb84711a73b6e33a0b34c9bcc8c32f2758c695d57861adb9ad9490"},
-    {file = "pymssql-2.2.10-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7c2e1e42000264c36d820014ef493b9a0b4435c24225d0c627c8bfe2df92c732"},
-    {file = "pymssql-2.2.10-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0875009d57d3df36eac751f47448cb8e1e7afb748ef00726766bb5e90e079725"},
-    {file = "pymssql-2.2.10-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a024b118aadbfb47bcd896c378a6992f16f57dd4f245790c041698b28c70b31f"},
-    {file = "pymssql-2.2.10-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:cf0f8f2e56211df67d3682ba2610ed587dc81253ef46dada40212b6115e4cbca"},
-    {file = "pymssql-2.2.10-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6c81ce53cdc5a51334edcff80833ae4dec5ae43d350c07074bb42164062b04f5"},
-    {file = "pymssql-2.2.10-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:0d15c78677e5fff925e6a6cb8172bbe80eb5fa2f81dec9ba2047a13e4cfcefe9"},
-    {file = "pymssql-2.2.10-cp39-cp39-win32.whl", hash = "sha256:309ea54d61ec9b46b3f0b28bb3ec66989d518d1fa56d487b95af539da8bf3ff8"},
-    {file = "pymssql-2.2.10-cp39-cp39-win_amd64.whl", hash = "sha256:08fb96a5f59216c07ff1c89975bfdfb5bf45b7bd2d2abe8b67a79dd1ad12f0e7"},
-    {file = "pymssql-2.2.10.tar.gz", hash = "sha256:a6b8ffc5cdfa38b3ba9b9c8d537a1058c7e3b64dc6a6d3c13ad8b663174bcf71"},
+    {file = "pymssql-2.2.11-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:692ab328ac290bd2031bc4dd6deae32665dfffda1b12aaa92928d3ebc667d5ad"},
+    {file = "pymssql-2.2.11-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:723a4612421027a01b51e42e786678a18c4a27613a3ccecf331c026e0cc41353"},
+    {file = "pymssql-2.2.11-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:34ab2373ca607174ad7244cfe955c07b6bc77a1e21d3c3143dbe934dec82c3a4"},
+    {file = "pymssql-2.2.11-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bc0ba19b4426c57509f065a03748d9ac230f1543ecdac57175e6ebd213a7bc0"},
+    {file = "pymssql-2.2.11-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e8d9d42a50f6e8e6b356e4e8b2fa1da725344ec0be6f8a6107b7196e5bd74906"},
+    {file = "pymssql-2.2.11-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aec64022a2419fad9f496f8e310522635e39d092970e1d55375ea0be86725174"},
+    {file = "pymssql-2.2.11-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:c389c8041c94d4058827faf5735df5f8e4c1c1eebdd051859536dc393925a667"},
+    {file = "pymssql-2.2.11-cp310-cp310-win32.whl", hash = "sha256:6452326cecd4dcee359a6f8878b827118a8c8523cd24de5b3a971a7a172e4275"},
+    {file = "pymssql-2.2.11-cp310-cp310-win_amd64.whl", hash = "sha256:c1bde266dbc91b100abd0311102a6585df09cc963599421cc12fd6b4cfa8e3d3"},
+    {file = "pymssql-2.2.11-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6ddaf0597138179517bdbf5b5aa3caffee65987316dc906359a5d0801d0847ee"},
+    {file = "pymssql-2.2.11-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c26af25991715431559cb5b37f243b8ff676540f504ed0317774dfc71827af1"},
+    {file = "pymssql-2.2.11-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:410e8c40b7c1b421e750cf80ccf2da8d802ed815575758ac9a78c5f6cd995723"},
+    {file = "pymssql-2.2.11-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa1767239ed45e1fa91d82fc0c63305750530787cd64089cabbe183eb538a35b"},
+    {file = "pymssql-2.2.11-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:9a644e4158fed30ae9f3846f2f1c74d36fa1610eb552de35b7f611d063fa3c85"},
+    {file = "pymssql-2.2.11-cp311-cp311-win32.whl", hash = "sha256:1956c111debe67f69a9c839b33ce420f0e8def1ef5ff9831c03d8ac840f82376"},
+    {file = "pymssql-2.2.11-cp311-cp311-win_amd64.whl", hash = "sha256:0bdd1fb49b0e331e47e83f39d4af784c857e230bfc73519654bab29285c51c63"},
+    {file = "pymssql-2.2.11-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:2609bbd3b715822bb4fa6d457b2985d32ad6ab9580fdb61ae6e0eee251791d24"},
+    {file = "pymssql-2.2.11-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c382aea9adaaee189f352d7a493e3f76c13f9337ec2b6aa40e76b114fa13ebac"},
+    {file = "pymssql-2.2.11-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5928324a09de7466368c15ece1de4ab5ea968d24943ceade758836f9fc7149f5"},
+    {file = "pymssql-2.2.11-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ee8b10f797d0bfec626b803891cf9e98480ee11f2e8459a7616cdb7e4e4bf2de"},
+    {file = "pymssql-2.2.11-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:1d5aa1a090b17f4ba75ffac3bb371f6c8c869692b653689396f9b470fde06981"},
+    {file = "pymssql-2.2.11-cp312-cp312-win32.whl", hash = "sha256:1f7ba71cf81af65c005173f279928bf86700d295f97e4965e169b5764bc6c4f2"},
+    {file = "pymssql-2.2.11-cp312-cp312-win_amd64.whl", hash = "sha256:a0ebb0e40c93f8f1e40aad80f512ae4aa89cb1ec8a96964b9afedcff1d5813fd"},
+    {file = "pymssql-2.2.11-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:e0ed115902956efaca9d9a20fa9b2b604e3e11d640416ca74900d215cdcbf3ab"},
+    {file = "pymssql-2.2.11-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1a75afa17746972bb61120fb6ea907657fc1ab68250bbbd8b21a00d0720ed0f4"},
+    {file = "pymssql-2.2.11-cp36-cp36m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d2ae69d8e46637a203cfb48e05439fc9e2ff7646fa1f5396aa3577ce52810031"},
+    {file = "pymssql-2.2.11-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f13710240457ace5b8c9cca7f4971504656f5703b702895a86386e87c7103801"},
+    {file = "pymssql-2.2.11-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d7234b0f61dd9ccb2304171b5fd7ed9db133b4ea7c835c9942c9dc5bfc00c1cb"},
+    {file = "pymssql-2.2.11-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0dcd76a8cc757c7cfe2d235f232a20d74ac8cebf9feabcdcbda5ef33157d14b1"},
+    {file = "pymssql-2.2.11-cp36-cp36m-manylinux_2_28_x86_64.whl", hash = "sha256:84aff3235ad1289c4079c548cfcdf7eaaf2475b9f81557351deb42e8f45a9c2d"},
+    {file = "pymssql-2.2.11-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5b081aa7b02911e3f299f7d1f68ce8ca585a5119d44601bf4483da0aae8c2181"},
+    {file = "pymssql-2.2.11-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:d315f08c106c884d6b42f70c9518e765a5bc23f6d3a587346bc4e6f198768c7a"},
+    {file = "pymssql-2.2.11-cp36-cp36m-win32.whl", hash = "sha256:c8b35b3d5e326729e5edb73d593103d2dbfb474bd36ee95b4e85e1f8271ba98a"},
+    {file = "pymssql-2.2.11-cp36-cp36m-win_amd64.whl", hash = "sha256:139c5032e0a2765764987803f1266132fcc5da572848ccc4d29cebba794a4260"},
+    {file = "pymssql-2.2.11-cp37-cp37m-macosx_11_0_x86_64.whl", hash = "sha256:7bac28aed1d625a002e0289e0c18d1808cecbdc12e2a1a3927dbbaff66e5fff3"},
+    {file = "pymssql-2.2.11-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:4eeaacc1dbbc678f4e80c6fd6fc279468021fdf2e486adc8631ec0de6b6c0e62"},
+    {file = "pymssql-2.2.11-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:428e32e53c554798bc2d0682a169fcb681df6b68544c4aedd1186018ea7e0447"},
+    {file = "pymssql-2.2.11-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2b621c5e32136dabc2fea25696beab0647ec336d25c04ab6d8eb8c8ee92f0e52"},
+    {file = "pymssql-2.2.11-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:658c85474ea01ca3a30de769df06f46681e882524b05c6994cd6fd985c485f27"},
+    {file = "pymssql-2.2.11-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:070181361ab94bdaeb14b591a35d853f327bc90c660b04047d474274fbb80357"},
+    {file = "pymssql-2.2.11-cp37-cp37m-manylinux_2_28_x86_64.whl", hash = "sha256:492e49616b58b2d6caf4a2598cb344572870171a7b65ba1ac61a5e248b6a8e1c"},
+    {file = "pymssql-2.2.11-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:803122aec31fbd52f5d65ef3b30b3bd2dc7b2a9e3a8223d16078a25805155c45"},
+    {file = "pymssql-2.2.11-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:09075e129655ab1178d2d60efb9b3fbf5cdb6da2338ecdb3a92c53a4ad7efa0c"},
+    {file = "pymssql-2.2.11-cp37-cp37m-win32.whl", hash = "sha256:b4a8377527702d746c490c2ce67d17f1c351d182b49b82fae6e67ae206bf9663"},
+    {file = "pymssql-2.2.11-cp37-cp37m-win_amd64.whl", hash = "sha256:167313d91606dc7a3c05b2ad60491a138b7408a8779599ab6430a48a67f133f0"},
+    {file = "pymssql-2.2.11-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:8d418f4dca245421242ed9df59d3bcda0cd081650df6deb1bef7f157b6a6f9dd"},
+    {file = "pymssql-2.2.11-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f0c44169df8d23c7ce172bd90ef5deb44caf19f15990e4db266e3193071988a4"},
+    {file = "pymssql-2.2.11-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b78032e45ea33c55d430b93e55370b900479ea324fae5d5d32486cc0fdc0fedd"},
+    {file = "pymssql-2.2.11-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:984d99ee6a2579f86c536b1b0354ad3dc9701e98a4b3953f1301b4695477cd2f"},
+    {file = "pymssql-2.2.11-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:287c8f79a7eca0c6787405797bac0f7c502d9be151f3f823aae12042235f8426"},
+    {file = "pymssql-2.2.11-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:85ea4ea296afcae34bc61e4e0ef2f503270fd4bb097b308a07a9194f1f063aa1"},
+    {file = "pymssql-2.2.11-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:a114633fa02b7eb5bc63520bf07954106c0ed0ce032449c871abb8b8c435a872"},
+    {file = "pymssql-2.2.11-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7332db36a537cbc16640a0c3473a2e419aa5bc1f9953cada3212e7b2587de658"},
+    {file = "pymssql-2.2.11-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:cd7292d872948c1f67c8cc12158f2c8ed9873d54368139ce1f67b2262ac34029"},
+    {file = "pymssql-2.2.11-cp38-cp38-win32.whl", hash = "sha256:fbca115e11685b5891755cc22b3db4348071b8d100a41e1ce93526d9c3dbf2d5"},
+    {file = "pymssql-2.2.11-cp38-cp38-win_amd64.whl", hash = "sha256:452b88a4ceca7efb934b5babb365851a3c52e723642092ebc92777397c2cacdb"},
+    {file = "pymssql-2.2.11-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:001242cedc73587cbb10aec4069de50febbff3c4c50f9908a215476496b3beab"},
+    {file = "pymssql-2.2.11-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:da492482b923b9cc9ad37f0f5592c776279299db2a89c0b7fc931aaefec652d4"},
+    {file = "pymssql-2.2.11-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:139a833e6e72a624e4f2cde803a34a616d5661dd9a5b2ae0402d9d8a597b2f1f"},
+    {file = "pymssql-2.2.11-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e57fbfad252434d64bdf4b6a935e4241616a4cf8df7af58b9772cd91fce9309a"},
+    {file = "pymssql-2.2.11-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a5308507c2c4e94ede7e5b164870c1ba2be55abab6daf795b5529e2da4e838b6"},
+    {file = "pymssql-2.2.11-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdca43c42d5f370358535b2107140ed550d74f9ef0fc95d2d7fa8c4e40ee48c2"},
+    {file = "pymssql-2.2.11-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:fe0cc975aac87b364fdb55cb89642435c3e859dcd99d7260f48af94111ba2673"},
+    {file = "pymssql-2.2.11-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4551f50c8a3b6ffbd71f794ee1c0c0134134c5d6414302c2fa28b67fe4470d07"},
+    {file = "pymssql-2.2.11-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:ae9818df40588d5a49e7476f05e31cc83dea630d607178d66762ca8cf32e9f77"},
+    {file = "pymssql-2.2.11-cp39-cp39-win32.whl", hash = "sha256:15257c7bd89c0283f70d6eaafd9b872201818572b8ba1e8576408ae23ef50c7c"},
+    {file = "pymssql-2.2.11-cp39-cp39-win_amd64.whl", hash = "sha256:65bb674c0ba35379bf93d1b2cf06fdc5e7ec56e1d0e9de525bdcf977190b2865"},
+    {file = "pymssql-2.2.11.tar.gz", hash = "sha256:15815bf1ff9edb475ec4ef567f23e23c4e828ce119ff5bf98a072b66b8d0ac1b"},
 ]
 
 [[package]]
@@ -3701,13 +3641,13 @@ rsa = ["oauthlib[signedtoken] (>=3.0.0)"]
 
 [[package]]
 name = "requests-toolbelt"
-version = "0.10.1"
+version = "1.0.0"
 description = "A utility belt for advanced users of python-requests"
 optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 files = [
-    {file = "requests-toolbelt-0.10.1.tar.gz", hash = "sha256:62e09f7ff5ccbda92772a29f394a49c3ad6cb181d568b1337626b2abb628a63d"},
-    {file = "requests_toolbelt-0.10.1-py2.py3-none-any.whl", hash = "sha256:18565aa58116d9951ac39baa288d3adb5b3ff975c4f25eee78555d89e8f247f7"},
+    {file = "requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6"},
+    {file = "requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06"},
 ]
 
 [package.dependencies]
@@ -3727,7 +3667,6 @@ files = [
 [package.dependencies]
 markdown-it-py = ">=2.2.0"
 pygments = ">=2.13.0,<3.0.0"
-typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.9\""}
 
 [package.extras]
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
@@ -4006,7 +3945,6 @@ requests = "<3.0.0"
 sortedcontainers = ">=2.4.0"
 tomlkit = "*"
 typing-extensions = ">=4.3,<5"
-urllib3 = {version = ">=1.21.1,<2.0.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
 development = ["Cython", "coverage", "more-itertools", "numpy (<1.27.0)", "pendulum (!=2.1.1)", "pexpect", "pytest (<7.5.0)", "pytest-cov", "pytest-rerunfailures", "pytest-timeout", "pytest-xdist", "pytzdata"]
@@ -4158,23 +4096,23 @@ pbr = ">=2.0.0,<2.1.0 || >2.1.0"
 
 [[package]]
 name = "tableauserverclient"
-version = "0.25"
+version = "0.28"
 description = "A Python module for working with the Tableau Server REST API."
 optional = true
 python-versions = ">=3.7"
 files = [
-    {file = "tableauserverclient-0.25-py3-none-any.whl", hash = "sha256:341cea1706c8fc4ce35d28e21f420e3874ec13812497e1629d37adb4dce4c74a"},
-    {file = "tableauserverclient-0.25.tar.gz", hash = "sha256:d354d16245c459a805ad207bcef3fa063e18bc8168695920ac89bf8125a420b6"},
+    {file = "tableauserverclient-0.28-py3-none-any.whl", hash = "sha256:dedee5c74de7b02617f6fb76c16252dbf2fcaf594929e22e6615cbf013515845"},
+    {file = "tableauserverclient-0.28.tar.gz", hash = "sha256:8d26e50d592eb81059ec698f2946238bcc2d4683d2ee0f2be987bd1299e3bca0"},
 ]
 
 [package.dependencies]
 defusedxml = ">=0.7.1"
-packaging = ">=22.0"
-requests = ">=2.28"
-urllib3 = ">=1.26.8,<1.27.0"
+packaging = ">=23.1"
+requests = ">=2.31"
+urllib3 = "2.0.6"
 
 [package.extras]
-test = ["argparse", "black", "mock", "mypy", "pytest (>=7.0)", "pytest-subtests", "requests-mock (>=1.0,<2.0)"]
+test = ["argparse", "black (==23.7)", "mock", "mypy (==1.4)", "pytest (>=7.0)", "pytest-cov", "pytest-subtests", "requests-mock (>=1.0,<2.0)"]
 
 [[package]]
 name = "testcontainers"
@@ -4288,7 +4226,6 @@ files = [
 ]
 
 [package.dependencies]
-"backports.zoneinfo" = {version = "*", markers = "python_version < \"3.9\""}
 python-dateutil = "*"
 pytz = "*"
 requests = ">=2.31.0"
@@ -4451,7 +4388,6 @@ files = [
 ]
 
 [package.dependencies]
-"backports.zoneinfo" = {version = "*", markers = "python_version < \"3.9\""}
 tzdata = {version = "*", markers = "platform_system == \"Windows\""}
 
 [package.extras]
@@ -4459,19 +4395,20 @@ devenv = ["check-manifest", "pytest (>=4.3)", "pytest-cov", "pytest-mock (>=3.3)
 
 [[package]]
 name = "urllib3"
-version = "1.26.18"
+version = "2.0.6"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+python-versions = ">=3.7"
 files = [
-    {file = "urllib3-1.26.18-py2.py3-none-any.whl", hash = "sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07"},
-    {file = "urllib3-1.26.18.tar.gz", hash = "sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0"},
+    {file = "urllib3-2.0.6-py3-none-any.whl", hash = "sha256:7a7c7003b000adf9e7ca2a377c9688bbc54ed41b985789ed576570342a375cd2"},
+    {file = "urllib3-2.0.6.tar.gz", hash = "sha256:b19e1a85d206b56d7df1d5e683df4a7725252a964e3993648dd0fb5a1c157564"},
 ]
 
 [package.extras]
-brotli = ["brotli (==1.0.9)", "brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
-secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
-socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
+secure = ["certifi", "cryptography (>=1.9)", "idna (>=2.0.0)", "pyopenssl (>=17.1.0)", "urllib3-secure-extra"]
+socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
+zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "websocket-client"
@@ -4675,7 +4612,7 @@ multidict = ">=4.0"
 name = "zipp"
 version = "3.17.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "zipp-3.17.0-py3-none-any.whl", hash = "sha256:0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31"},
@@ -4710,5 +4647,5 @@ unity-catalog = ["databricks-sdk", "databricks-sql-connector"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.8.1,<4.0"
-content-hash = "3e3da497343d20b128b19a6013415adb1516a1b3d8311a16b2cb056e344b43ae"
+python-versions = ">=3.10,<4.0"
+content-hash = "fd1fc14a70f18f1c73941e068cc08c5771281724412af61c6ab5c043796e28ec"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,19 +40,19 @@ msgraph-beta-sdk = { version = "1.0.0", optional = true }
 pyarrow = { version = "^14.0.1", extras = ["pandas"]}
 pycarlo = { version = "^0.8.1", optional = true }
 pydantic = { version = "2.5.1", extras = ["email"]}
-pymssql = { version = "^2.2.9", optional = true }
+pymssql = { version = "^2.2.11", optional = true }
 pymysql = { version = "^1.0.2", optional = true }
-python = ">=3.8.1,<4.0"
+python = ">=3.10,<4.0"
 python-dateutil = "^2.8.1"
 PyYAML = "^6.0"
 requests = "^2.28.1"
 setuptools = "^68.0.0"
 smart-open = "^6.3.0"
-snowflake-connector-python = { version = "^3.5.0", optional = true }
+snowflake-connector-python = { version = "^3.6.0", optional = true }
 SQLAlchemy = { version = "^1.4.46", optional = true}
 sql-metadata = { version = "^2.8.0", optional = true }
 sqllineage = { version = "~=1.3.8", optional = true }
-tableauserverclient = { version = "^0.25", optional = true }
+tableauserverclient = { version = "^0.28", optional = true }
 thoughtspot_rest_api_v1 = { version = "1.5.3", optional = true }
 trino = { version = "^0.327.0", optional = true }
 pathvalidate = "^3.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.93"
+version = "0.14.0"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,6 @@ import os
 import pytest
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def test_root_dir():
     return os.path.join(os.path.dirname(__file__))


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

`snowflake-connector-python` has a `urllib3` dependency that's stuck in v1.x, while some other libraries (e.g. tableuserverclient, minio for s3 crawler) depends on urllib3 v2.x.
In https://github.com/snowflakedb/snowflake-connector-python/issues/1743 they got rid of the urllib3 dependency altogether for python >= 3.10, so it makes sense to upgrade our minimum supported python version from 3.8 to 3.10 in order to be able to upgrade other libraries.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Change python minimum version in pyproject.toml from 3.8 to 3.10
- Fixed some incompatibilities between different versions
- Added guide to install mssql on apple silicon machines

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

- Unit tests are passing.
- Ran several connectors, all worked as intended.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
