### PR TITLE
Ingestion of crawler run metadata fail

### DIFF
--- a/metaphor/common/runner.py
+++ b/metaphor/common/runner.py
@@ -76,8 +76,8 @@ def run_connector(
         end_time=end_time,
         status=run_status,
         entity_count=float(entity_count),
-        error_message=error_message,
-        stack_trace=stacktrace,
+        error_message=error_message if error_message else None,
+        stack_trace=stacktrace if stacktrace else None,
     )
 
     if file_sink_config is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.102"
+version = "0.13.103"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

It's possible to generate invalid `crawlerRunMetadata` now.

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

- Check these two field is empty string or not.

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

Unit test
<!--
  Describe how the change was tested end-to-end.
-->

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
