### PR TITLE
Skip parsing tests that reference inactive models

### DIFF
--- a/metaphor/dbt/artifact_parser.py
+++ b/metaphor/dbt/artifact_parser.py
@@ -515,6 +515,13 @@ class ArtifactParser:
         if not model_unique_id.startswith("model."):
             return
 
+        # Skip test if it references an non-existing (most likely disabled) model
+        if model_unique_id not in self._virtual_views:
+            logger.warn(
+                f"Test {test.unique_id} references non-active model {model_unique_id}"
+            )
+            return
+
         columns = []
         if test.columns:
             columns = list(test.columns.keys())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.108"
+version = "0.13.109"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

The dbt connector fails with the following error when encountering tests that reference inactive (disabled) dbt models:

```
2024-01-18 10:13:38:ERROR:metaphor:Failed to parse artifacts for run ID = <reacted>, project ID = <reacted>, job ID = <reacted>
Traceback (most recent call last):
  File "/Users/marslan/Metaphor/connectors/metaphor/dbt/cloud/extractor.py", line 91, in _extract_last_run
    entities = await DbtExtractor(
  File "/Users/marslan/Metaphor/connectors/metaphor/dbt/extractor.py", line 71, in extract
    artifact_parser.parse(manifest_json, run_results_json)
  File "/Users/marslan/Metaphor/connectors/metaphor/dbt/artifact_parser.py", line 364, in parse
    self.parse_manifest(manifest_json, run_results)
  File "/Users/marslan/Metaphor/connectors/metaphor/dbt/artifact_parser.py", line 497, in parse_manifest
    self._parse_test(test, run_results, models)
  File "/Users/marslan/Metaphor/connectors/metaphor/dbt/artifact_parser.py", line 538, in _parse_test
    init_dbt_tests(self._virtual_views, model_unique_id).append(dbt_test)
  File "/Users/marslan/Metaphor/connectors/metaphor/dbt/util.py", line 165, in init_dbt_tests
    assert dbt_model_unique_id in virtual_views
AssertionError
```

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Skip processing tests that reference inactive dbt models.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified against a production instance.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
