### PR TITLE
Make `output` optional in configuration

### DIFF
--- a/metaphor/common/base_config.py
+++ b/metaphor/common/base_config.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Optional, Type, TypeVar
 
 import yaml
@@ -27,10 +28,33 @@ class BaseConfig:
     All subclasses should add the @dataclass decorators
     """
 
-    output: OutputConfig
+    output: Optional[OutputConfig]
+    """
+    No default value here, otherwise dataclass inheritance would not work.
+
+    If this field is `None`, the connector will store the extracted data to
+    `PWD`/`timestamp`.
+
+    To disable storing data altogether, set this field to `OutputConfig()`.
+    """
 
     @classmethod
     def from_yaml_file(cls: Type[T], path: str) -> T:
         with open(path, encoding="utf8") as fin:
             obj = yaml.safe_load(fin.read())
+
+            # So that user can just ignore this field in their config file.
+            if "output" not in obj:
+                obj["output"] = None
+
             return TypeAdapter(cls).validate_python(variable_substitution(obj))
+
+    @property
+    def file_sink_config(self) -> Optional[FileSinkConfig]:
+        if self.output:
+            return self.output.file
+        return FileSinkConfig(
+            directory=Path.cwd()
+            .absolute()
+            .as_posix(),  # timestamp is added in file sink
+        )

--- a/metaphor/common/cli.py
+++ b/metaphor/common/cli.py
@@ -14,5 +14,5 @@ def cli_main(extractor_cls: Type[BaseExtractor], config_file: str):
         name=EventUtil.class_fqcn(extractor_cls),
         description=extractor_cls._description,
         platform=extractor_cls._platform,
-        file_sink_config=base_config.output.file,
+        file_sink_config=base_config.file_sink_config,
     )

--- a/metaphor/common/docs/output.md
+++ b/metaphor/common/docs/output.md
@@ -4,7 +4,9 @@ You can configure the connector to output to files or API.
 
 ## Output to Local Files
 
-File-based output is the preferred way as it enables decoupling between the connector and ingestion pipeline. Add the following fragment to your config file:
+File-based output is the preferred way as it enables decoupling between the connector and ingestion pipeline. By default, the connector will write to the directory `${pwd}/${CURRENT_TIMESTAMP}`.
+
+To write the extracted data to a specific location, add the following fragment to your config file:
 
 ```yaml
 output:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.110"
+version = "0.13.111"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/common/test_config.py
+++ b/tests/common/test_config.py
@@ -24,8 +24,9 @@ def test_yaml_config(test_root_dir):
 
 
 def test_yaml_config_with_missing_config(test_root_dir):
-    with pytest.raises(ValidationError):
-        BaseConfig.from_yaml_file(f"{test_root_dir}/common/configs/missing.yml")
+    missing = BaseConfig.from_yaml_file(f"{test_root_dir}/common/configs/missing.yml")
+    assert not missing.output
+    assert missing.file_sink_config and missing.file_sink_config.directory
 
 
 @dataclass(config=ConnectorConfig)
@@ -36,7 +37,8 @@ class AnotherBaseConfig(BaseConfig):
 def test_yaml_config_with_extra_config(test_root_dir):
     # BaseConfig allows extras
     config = BaseConfig.from_yaml_file(f"{test_root_dir}/common/configs/extend.yml")
-    assert config == BaseConfig(output={})
+    assert config == BaseConfig(output=OutputConfig())
+    assert not config.file_sink_config
 
     # AnotherBaseConfig does not allow extras
     with pytest.raises(ValidationError):
@@ -50,4 +52,4 @@ class ExtendConfig(BaseConfig):
 
 def test_extend_config(test_root_dir):
     config = ExtendConfig.from_yaml_file(f"{test_root_dir}/common/configs/extend.yml")
-    assert config == ExtendConfig(foo="bar", output={})
+    assert config == ExtendConfig(foo="bar", output=OutputConfig())


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

Provide a reasonable default output directory when the `output` field isn't provided. This hopefully creates a more seamless user experience.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Made `output` optional
- When config file does not have a `output` field, `from_yaml_file` method manually adds it.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Tested locally.
### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
