### PR TITLE
Add delimiter after key prefix when matching dataset keys

### DIFF
--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -519,7 +519,8 @@ class SnowflakeExtractor(BaseExtractor):
 
             if object_type in {"DATABASE", "SCHEMA"}:
                 for dataset_key in self._datasets:
-                    if dataset_key.startswith(key_prefix):
+                    # Need to make sure key_prefix == `db`.`schema`
+                    if dataset_key.startswith(f"{key_prefix}."):
                         self._append_tag(dataset_key, key, value, None)
             else:
                 self._append_tag(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.114"
+version = "0.13.115"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/snowflake/test_extractor.py
+++ b/tests/snowflake/test_extractor.py
@@ -285,6 +285,42 @@ def test_fetch_tags(mock_connect: MagicMock):
 
 
 @patch("metaphor.snowflake.auth.connect")
+def test_fetch_tags_for_similar_schema(mock_connect: MagicMock):
+    mock_cursor = MagicMock()
+
+    mock_cursor.__iter__.return_value = iter(
+        [
+            ("foo", "foo", "SCHEMA", "db", None, "foo", None),
+            ("foobar", "foo", "SCHEMA", "db", None, "foobar", None),
+            ("foobaz", "foo", "SCHEMA", "db", None, "foobaz", None),
+        ]
+    )
+
+    extractor = SnowflakeExtractor(make_snowflake_config())
+
+    for i, schema in enumerate(["foo", "foobar", "foobaz"]):
+        extractor._datasets[
+            dataset_normalized_name("db", schema, f"table{i}")
+        ] = extractor._init_dataset(
+            "db", schema, f"table{i}", table_type, "", None, None
+        )
+
+    extractor._fetch_tags(mock_cursor)
+
+    assert "db.foo.table0" in extractor._datasets
+    assert extractor._datasets["db.foo.table0"].schema
+    assert extractor._datasets["db.foo.table0"].schema.tags == ["foo=foo"]
+
+    assert "db.foobar.table1" in extractor._datasets
+    assert extractor._datasets["db.foobar.table1"].schema
+    assert extractor._datasets["db.foobar.table1"].schema.tags == ["foobar=foo"]
+
+    assert "db.foobaz.table2" in extractor._datasets
+    assert extractor._datasets["db.foobaz.table2"].schema
+    assert extractor._datasets["db.foobaz.table2"].schema.tags == ["foobaz=foo"]
+
+
+@patch("metaphor.snowflake.auth.connect")
 def test_fetch_hierarchy_system_tags(mock_connect: MagicMock):
     mock_cursor = MagicMock()
 
@@ -319,7 +355,7 @@ def test_fetch_hierarchy_system_tags(mock_connect: MagicMock):
 
     extractor._fetch_tags(mock_cursor)
 
-    assert dataset.schema.tags == ["bad=bad", "not=good"]
+    assert not dataset.schema.tags
     assert extractor._hierarchies.get(dataset_normalized_name(table_name)) is not None
     db_hierarchy = extractor._hierarchies[dataset_normalized_name(table_name)]
     assert db_hierarchy.logical_id == HierarchyLogicalID(


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Need to make sure the key prefix for tag is the entire name, i.e. if it's a database tag, then the tag's key prefix should represent the entire database name instead of a prefix of the name.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Fix the aforementioned bug.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Tested locally.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
