### PR TITLE
Fix CD by giving it the correct permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -88,6 +88,8 @@ jobs:
     name: Publish to PyPI
     runs-on: ubuntu-latest
     needs: version
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

https://github.com/MetaphorData/connectors/pull/770 locked down the token permission and led to the following [error](https://github.com/MetaphorData/connectors/actions/runs/7706967646/job/21003381772):

```
RequestError [HttpError]: Resource not accessible by integration
    at /home/runner/work/_actions/actions/github-script/v5/dist/index.js:4560:21
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  status: 403,
```
