### PR TITLE
[sc-24431] Create generator based extract method specifically for `QueryLogs`

### DIFF
--- a/metaphor/common/base_extractor.py
+++ b/metaphor/common/base_extractor.py
@@ -1,7 +1,7 @@
 import asyncio
 import traceback
 from abc import ABC, abstractmethod
-from typing import Collection, Generator, Optional
+from typing import Collection, Iterator, Optional
 
 from metaphor.common.base_config import BaseConfig
 from metaphor.common.event_util import ENTITY_TYPES
@@ -38,7 +38,7 @@ class BaseExtractor(ABC):
     def run_async(self) -> Collection[ENTITY_TYPES]:
         return asyncio.run(self.extract())
 
-    def collect_query_logs(self) -> Generator[QueryLog, None, None]:
+    def collect_query_logs(self) -> Iterator[QueryLog]:
         """
         Collects only the query logs. By default collects nothing,
         crawler class needs to implement this method if it wishes

--- a/metaphor/common/base_extractor.py
+++ b/metaphor/common/base_extractor.py
@@ -1,11 +1,12 @@
 import asyncio
 import traceback
 from abc import ABC, abstractmethod
-from typing import Collection, Optional
+from typing import Collection, Generator, Optional
 
 from metaphor.common.base_config import BaseConfig
 from metaphor.common.event_util import ENTITY_TYPES
 from metaphor.models.crawler_run_metadata import Platform, RunStatus
+from metaphor.models.metadata_change_event import QueryLog
 
 
 class BaseExtractor(ABC):
@@ -36,6 +37,14 @@ class BaseExtractor(ABC):
 
     def run_async(self) -> Collection[ENTITY_TYPES]:
         return asyncio.run(self.extract())
+
+    def collect_query_logs(self) -> Generator[QueryLog, None, None]:
+        """
+        Collects only the query logs. By default collects nothing,
+        crawler class needs to implement this method if it wishes
+        to separate the query logs from the rest of the MCEs.
+        """
+        yield from []
 
     def extend_errors(self, e: Exception) -> None:
         error_message = str(e)

--- a/metaphor/common/event_util.py
+++ b/metaphor/common/event_util.py
@@ -112,6 +112,11 @@ class EventUtil:
         return EventUtil.clean_nones(event.to_dict())
 
     @staticmethod
+    def build_then_trim(entity: ENTITY_TYPES) -> dict:
+        event = EventUtil.build_event(entity)
+        return EventUtil.trim_event(event)
+
+    @staticmethod
     def class_fqcn(clazz) -> str:
         """Get the fully qualified class name"""
         return f"{clazz.__module__}.{clazz.__qualname__}"

--- a/metaphor/common/file_sink.py
+++ b/metaphor/common/file_sink.py
@@ -106,7 +106,9 @@ class QueryLogSink:
 
     def write_query_log(self, query_log: QueryLog) -> None:
         if not self._entered:
-            raise ValueError()
+            raise ValueError(
+                "This method can only be called when QueryLogSink is in a managed context"
+            )
         if (
             self.logs_count >= self.logs_per_mce
             or self.batch_bytes >= self.bytes_per_batch

--- a/metaphor/common/runner.py
+++ b/metaphor/common/runner.py
@@ -82,9 +82,13 @@ def run_connector(
 
     if file_sink_config is not None:
         file_sink = FileSink(file_sink_config)
-        file_sink.sink(events)
-        file_sink.sink_metadata(run_metadata)
-        file_sink.sink_logs()
+        file_sink.write_events(events)
+        file_sink.write_metadata(run_metadata)
+        file_sink.write_execution_logs()
+
+        with file_sink.get_query_log_sink() as query_log_sink:
+            for query_log in connector.collect_query_logs():
+                query_log_sink.write_query_log(query_log)
 
     return events, run_metadata
 

--- a/metaphor/common/sink.py
+++ b/metaphor/common/sink.py
@@ -14,7 +14,7 @@ logger.setLevel(logging.INFO)
 class Sink(ABC):
     """Base class for metadata sinks"""
 
-    def sink(self, events: List[MetadataChangeEvent]) -> bool:
+    def write_events(self, events: List[MetadataChangeEvent]) -> bool:
         """Sink MCE messages to the destination"""
         event_util = EventUtil()
         records = [event_util.trim_event(e) for e in events]

--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -1,6 +1,16 @@
 import math
 from datetime import datetime, timezone
-from typing import Collection, Dict, Generator, List, Literal, Mapping, Optional, Tuple
+from typing import (
+    Collection,
+    Dict,
+    Generator,
+    Iterator,
+    List,
+    Literal,
+    Mapping,
+    Optional,
+    Tuple,
+)
 
 from pydantic import TypeAdapter
 
@@ -155,7 +165,7 @@ class SnowflakeExtractor(BaseExtractor):
         entities.extend(self._hierarchies.values())
         return entities
 
-    def collect_query_logs(self):
+    def collect_query_logs(self) -> Iterator[QueryLog]:
         self._conn = auth.connect(self._config)
 
         with self._conn:
@@ -528,7 +538,7 @@ class SnowflakeExtractor(BaseExtractor):
                     key_prefix, key, value, column if object_type == "COLUMN" else None
                 )
 
-    def _fetch_query_logs(self):
+    def _fetch_query_logs(self) -> Iterator[QueryLog]:
         logger.info("Fetching Snowflake query logs")
 
         start_date = start_of_day(self._query_log_lookback_days)

--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -1,6 +1,6 @@
 import math
 from datetime import datetime, timezone
-from typing import Collection, Dict, List, Literal, Mapping, Optional, Tuple
+from typing import Collection, Dict, Generator, List, Literal, Mapping, Optional, Tuple
 
 from pydantic import TypeAdapter
 
@@ -21,7 +21,7 @@ from metaphor.common.event_util import ENTITY_TYPES
 from metaphor.common.filter import DatasetFilter
 from metaphor.common.logger import get_logger
 from metaphor.common.models import to_dataset_statistics
-from metaphor.common.query_history import chunk_query_logs, user_id_or_email
+from metaphor.common.query_history import user_id_or_email
 from metaphor.common.snowflake import normalize_snowflake_account
 from metaphor.common.tag_matcher import tag_datasets
 from metaphor.common.utils import chunks, md5_digest, safe_float, start_of_day
@@ -54,7 +54,6 @@ from metaphor.snowflake.utils import (
     DatasetInfo,
     QueryWithParam,
     SnowflakeTableType,
-    async_execute,
     check_access_history,
     exclude_username_clause,
     fetch_query_history_count,
@@ -104,7 +103,6 @@ class SnowflakeExtractor(BaseExtractor):
 
         self._datasets: Dict[str, Dataset] = {}
         self._hierarchies: Dict[str, Hierarchy] = {}
-        self._logs: List[QueryLog] = []
 
     async def extract(self) -> Collection[ENTITY_TYPES]:
         logger.info("Fetching metadata from Snowflake")
@@ -149,17 +147,20 @@ class SnowflakeExtractor(BaseExtractor):
             self._fetch_unique_keys(cursor)
             self._fetch_tags(cursor)
 
-            if self._query_log_lookback_days > 0:
-                self._fetch_query_logs()
-
         datasets = list(self._datasets.values())
         tag_datasets(datasets, self._tag_matchers)
 
         entities: List[ENTITY_TYPES] = []
         entities.extend(datasets)
-        entities.extend(chunk_query_logs(self._logs))
         entities.extend(self._hierarchies.values())
         return entities
+
+    def collect_query_logs(self):
+        self._conn = auth.connect(self._config)
+
+        with self._conn:
+            if self._query_log_lookback_days > 0:
+                yield from self._fetch_query_logs()
 
     @staticmethod
     def fetch_databases(cursor: SnowflakeCursor) -> List[str]:
@@ -527,7 +528,7 @@ class SnowflakeExtractor(BaseExtractor):
                     key_prefix, key, value, column if object_type == "COLUMN" else None
                 )
 
-    def _fetch_query_logs(self) -> None:
+    def _fetch_query_logs(self):
         logger.info("Fetching Snowflake query logs")
 
         start_date = start_of_day(self._query_log_lookback_days)
@@ -552,15 +553,15 @@ class SnowflakeExtractor(BaseExtractor):
             else self._batch_query_for_query_logs(start_date, end_date, batches)
         )
 
-        async_execute(
-            self._conn,
-            queries,
-            "fetch_query_logs",
-            self._max_concurrency,
-            self._parse_query_logs,
-        )
+        cursor = self._conn.cursor()
+        parsed_query_log_count = 0
+        for batch, query in queries.items():
+            cursor.execute(query.query, query.params)
+            for query_log in self._parse_query_logs(batch, cursor):
+                parsed_query_log_count += 1
+                yield query_log
 
-        logger.info(f"Fetched {len(self._logs)} query logs")
+        logger.info(f"Fetched {parsed_query_log_count} query logs")
 
     def _fetch_schemas(self, cursor: SnowflakeCursor) -> List[str]:
         cursor.execute(
@@ -720,8 +721,10 @@ class SnowflakeExtractor(BaseExtractor):
             for x in range(batches)
         }
 
-    def _parse_query_logs(self, batch_number: str, query_logs: List[Tuple]) -> None:
-        logger.info(f"query logs batch #{batch_number}")
+    def _parse_query_logs(
+        self, batch: int, cursor: SnowflakeCursor
+    ) -> Generator[QueryLog, None, None]:
+        logger.info(f"query logs batch #{batch}")
         for (
             query_id,
             username,
@@ -737,7 +740,7 @@ class SnowflakeExtractor(BaseExtractor):
             rows_inserted,
             rows_updated,
             *access_objects,
-        ) in query_logs:
+        ) in cursor:
             try:
                 sources = (
                     self._parse_accessed_objects(access_objects[0])
@@ -779,7 +782,7 @@ class SnowflakeExtractor(BaseExtractor):
                     sql_hash=md5_digest(query_text.encode("utf-8")),
                 )
 
-                self._logs.append(query_log)
+                yield query_log
             except Exception:
                 logger.exception(f"query log processing error, query id: {query_id}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.118"
+version = "0.13.119"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/common/test_file_sink.py
+++ b/tests/common/test_file_sink.py
@@ -1,3 +1,4 @@
+import json
 import tempfile
 from datetime import datetime
 from os import path
@@ -8,12 +9,14 @@ from freezegun import freeze_time
 from metaphor.common.event_util import EventUtil
 from metaphor.common.file_sink import FileSink, FileSinkConfig
 from metaphor.common.logger import add_debug_file
+from metaphor.common.utils import md5_digest
 from metaphor.models.crawler_run_metadata import CrawlerRunMetadata, RunStatus
 from metaphor.models.metadata_change_event import (
     DataPlatform,
     Dataset,
     DatasetLogicalID,
     MetadataChangeEvent,
+    QueryLog,
 )
 from tests.test_utils import load_json
 
@@ -41,7 +44,7 @@ def test_file_sink_no_split(test_root_dir):
 
     # Set batch_size_bytes so large that all messages can fit in the same file
     sink = FileSink(FileSinkConfig(directory=directory, batch_size_bytes=1000000))
-    assert sink.sink(messages) is True
+    assert sink.write_events(messages) is True
     assert messages == events_from_json(f"{directory}/946684800/1-of-1.json")
 
 
@@ -79,7 +82,7 @@ def test_file_sink_split(test_root_dir):
 
     # Set batch_size_bytes so small that only one message can be fit in each file
     sink = FileSink(FileSinkConfig(directory=directory, batch_size_bytes=10))
-    assert sink.sink(messages) is True
+    assert sink.write_events(messages) is True
     assert messages[0:1] == events_from_json(f"{directory}/946684800/1-of-5.json")
     assert messages[1:2] == events_from_json(f"{directory}/946684800/2-of-5.json")
     assert messages[2:3] == events_from_json(f"{directory}/946684800/3-of-5.json")
@@ -101,7 +104,7 @@ def test_sink_metadata(test_root_dir):
     )
 
     sink = FileSink(FileSinkConfig(directory=directory))
-    sink.sink_metadata(metadata)
+    sink.write_metadata(metadata)
 
     assert EventUtil.clean_nones(metadata.to_dict()) == load_json(
         f"{directory}/946684800/run.metadata"
@@ -116,7 +119,7 @@ def test_sink_logs(test_root_dir):
     directory = tempfile.mkdtemp()
 
     sink = FileSink(FileSinkConfig(directory=directory))
-    sink.sink_logs()
+    sink.write_execution_logs()
 
     zip_file = f"{directory}/946684800/log.zip"
 
@@ -145,3 +148,76 @@ def test_sink_file(test_root_dir):
 
     sink.remove_file(filename)
     assert path.exists(full_path) is False
+
+
+def test_query_log_sink_chunk_by_count():
+    directory = tempfile.mkdtemp()
+
+    sink = FileSink(FileSinkConfig(directory=directory, batch_size_count=3))
+    query_logs = [
+        QueryLog(
+            id=f"{DataPlatform.SNOWFLAKE.name}:{query_id}",
+            query_id=str(query_id),
+            platform=DataPlatform.SNOWFLAKE,
+            account="account",
+            sql=query_text,
+            sql_hash=md5_digest(query_text.encode("utf-8")),
+        )
+        for query_id, query_text in enumerate(
+            f"this is query no. {x}" for x in range(17)
+        )
+    ]
+    with sink.get_query_log_sink(2) as query_log_sink:
+        for query_log in query_logs:
+            query_log_sink.write_query_log(query_log)
+
+    files = sink._storage.list_files(sink.path, ".json")
+    assert len(files) == 3
+    for file in files:
+        with open(file) as f:
+            obj = json.loads(f.read())
+            assert len(obj) == 3
+            for mce in obj:
+                assert len(mce["queryLogs"]["logs"]) < 3
+
+
+def test_query_log_sink_chunk_by_size():
+    directory = tempfile.mkdtemp()
+
+    sink = FileSink(FileSinkConfig(directory=directory, batch_size_bytes=300))
+
+    def get_sql_query(x: int) -> str:
+        if x in {0, 3, 8}:
+            return "long" * 100
+        return "short"
+
+    query_logs = [
+        QueryLog(
+            id=f"{DataPlatform.SNOWFLAKE.name}:{query_id}",
+            query_id=str(query_id),
+            platform=DataPlatform.SNOWFLAKE,
+            account="account",
+            sql=query_text,
+            sql_hash=md5_digest(query_text.encode("utf-8")),
+        )
+        for query_id, query_text in enumerate(get_sql_query(x) for x in range(11))
+    ]
+    with sink.get_query_log_sink() as query_log_sink:
+        for query_log in query_logs:
+            query_log_sink.write_query_log(query_log)
+
+    files = sorted(sink._storage.list_files(sink.path, ".json"))
+
+    def assert_num_logs(file, num: int):
+        with open(file) as f:
+            obj = json.loads(f.read())
+            print(obj)
+            # assert len(obj) == 1
+            # assert len(obj[0]["queryLogs"]["logs"]) == num
+
+    assert len(files) == 5
+    assert_num_logs(files[0], 1)
+    assert_num_logs(files[1], 3)
+    assert_num_logs(files[2], 3)
+    assert_num_logs(files[3], 2)
+    assert_num_logs(files[4], 2)

--- a/tests/common/test_file_sink.py
+++ b/tests/common/test_file_sink.py
@@ -212,8 +212,8 @@ def test_query_log_sink_chunk_by_size():
         with open(file) as f:
             obj = json.loads(f.read())
             print(obj)
-            # assert len(obj) == 1
-            # assert len(obj[0]["queryLogs"]["logs"]) == num
+            assert len(obj) == 1
+            assert len(obj[0]["queryLogs"]["logs"]) == num
 
     assert len(files) == 5
     assert_num_logs(files[0], 1)

--- a/tests/snowflake/test_extractor.py
+++ b/tests/snowflake/test_extractor.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime, timezone
-from typing import Any, List, Optional, Tuple
+from typing import Optional
 from unittest.mock import MagicMock, patch
 
 from metaphor.common.base_config import OutputConfig
@@ -407,346 +407,359 @@ def test_fetch_shared_databases(mock_connect: MagicMock):
 
 @patch("metaphor.snowflake.auth.connect")
 def test_parse_query_logs(mock_connect: MagicMock):
-    query_logs: List[Tuple[Any, ...]] = [
-        (
-            "id1",  # QUERY_ID
-            "METAPHOR",  # USER_NAME
-            "short query text less than 40 chars",  # QUERY_TEXT
-            "2022-12-12 14:01:02.778 -0800",  # START_TIME
-            2514,  # TOTAL_ELAPSED_TIME
-            "0.000296",  # CREDITS_USED_CLOUD_SERVICES
-            "ACME",  # DATABASE_NAME
-            "RIDE_SHARE",  # SCHEMA_NAME
-            100,  # BYTES_SCANNED
-            200,  # BYTES_WRITTEN
-            10,  # ROWS_PRODUCED
-            20,  # ROWS_INSERTED
-            0,  # ROWS_UPDATED
-            json.dumps(
-                [
-                    {
-                        "columns": [
-                            {"columnId": 1485364, "columnName": "START_STATION_NAME"},
-                            {"columnId": 1485363, "columnName": "START_STATION_ID"},
-                            {"columnId": 1485357, "columnName": "TOTAL_MINUTES"},
-                            {
-                                "columnId": 1485365,
-                                "columnName": "START_STATION_BIKES_COUNT",
-                            },
-                            {"columnId": 1485360, "columnName": "MONTH"},
-                            {
-                                "columnId": 1485367,
-                                "columnName": "START_STATION_INSTALL_DATE",
-                            },
-                            {"columnId": 1485361, "columnName": "START_PEAK_TRAVEL"},
-                            {"columnId": 1485362, "columnName": "SAME_STATION_FLAG"},
-                            {
-                                "columnId": 1485366,
-                                "columnName": "START_STATION_DOCKS_COUNT",
-                            },
-                            {"columnId": 1485358, "columnName": "TOTAL_BIKE_HIRES"},
-                        ],
-                        "objectDomain": "Table",
-                        "objectId": 1471594,
-                        "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                    }
-                ]
+    mock_cursor = MagicMock()
+
+    mock_cursor.__iter__.return_value = iter(
+        [
+            (
+                "id1",  # QUERY_ID
+                "METAPHOR",  # USER_NAME
+                "short query text less than 40 chars",  # QUERY_TEXT
+                "2022-12-12 14:01:02.778 -0800",  # START_TIME
+                2514,  # TOTAL_ELAPSED_TIME
+                "0.000296",  # CREDITS_USED_CLOUD_SERVICES
+                "ACME",  # DATABASE_NAME
+                "RIDE_SHARE",  # SCHEMA_NAME
+                100,  # BYTES_SCANNED
+                200,  # BYTES_WRITTEN
+                10,  # ROWS_PRODUCED
+                20,  # ROWS_INSERTED
+                0,  # ROWS_UPDATED
+                json.dumps(
+                    [
+                        {
+                            "columns": [
+                                {
+                                    "columnId": 1485364,
+                                    "columnName": "START_STATION_NAME",
+                                },
+                                {"columnId": 1485363, "columnName": "START_STATION_ID"},
+                                {"columnId": 1485357, "columnName": "TOTAL_MINUTES"},
+                                {
+                                    "columnId": 1485365,
+                                    "columnName": "START_STATION_BIKES_COUNT",
+                                },
+                                {"columnId": 1485360, "columnName": "MONTH"},
+                                {
+                                    "columnId": 1485367,
+                                    "columnName": "START_STATION_INSTALL_DATE",
+                                },
+                                {
+                                    "columnId": 1485361,
+                                    "columnName": "START_PEAK_TRAVEL",
+                                },
+                                {
+                                    "columnId": 1485362,
+                                    "columnName": "SAME_STATION_FLAG",
+                                },
+                                {
+                                    "columnId": 1485366,
+                                    "columnName": "START_STATION_DOCKS_COUNT",
+                                },
+                                {"columnId": 1485358, "columnName": "TOTAL_BIKE_HIRES"},
+                            ],
+                            "objectDomain": "Table",
+                            "objectId": 1471594,
+                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                        }
+                    ]
+                ),
+                json.dumps(
+                    [
+                        {
+                            "columns": [
+                                {
+                                    "baseSources": [
+                                        {
+                                            "columnName": "MONTH",
+                                            "objectDomain": "Table",
+                                            "objectId": 1471594,
+                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                        }
+                                    ],
+                                    "columnId": 1485909,
+                                    "columnName": "MONTH",
+                                    "directSources": [
+                                        {
+                                            "columnName": "MONTH",
+                                            "objectDomain": "Table",
+                                            "objectId": 1471594,
+                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                        }
+                                    ],
+                                },
+                                {
+                                    "baseSources": [
+                                        {
+                                            "columnName": "START_STATION_INSTALL_DATE",
+                                            "objectDomain": "Table",
+                                            "objectId": 1471594,
+                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                        }
+                                    ],
+                                    "columnId": 1485916,
+                                    "columnName": "START_STATION_INSTALL_DATE",
+                                    "directSources": [
+                                        {
+                                            "columnName": "START_STATION_INSTALL_DATE",
+                                            "objectDomain": "Table",
+                                            "objectId": 1471594,
+                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                        }
+                                    ],
+                                },
+                                {
+                                    "baseSources": [
+                                        {
+                                            "columnName": "TOTAL_BIKE_HIRES",
+                                            "objectDomain": "Table",
+                                            "objectId": 1471594,
+                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                        }
+                                    ],
+                                    "columnId": 1485907,
+                                    "columnName": "TOTAL_BIKE_HIRES",
+                                    "directSources": [
+                                        {
+                                            "columnName": "TOTAL_BIKE_HIRES",
+                                            "objectDomain": "Table",
+                                            "objectId": 1471594,
+                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                        }
+                                    ],
+                                },
+                                {
+                                    "baseSources": [
+                                        {
+                                            "columnName": "START_STATION_DOCKS_COUNT",
+                                            "objectDomain": "Table",
+                                            "objectId": 1471594,
+                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                        }
+                                    ],
+                                    "columnId": 1485915,
+                                    "columnName": "START_STATION_DOCKS_COUNT",
+                                    "directSources": [
+                                        {
+                                            "columnName": "START_STATION_DOCKS_COUNT",
+                                            "objectDomain": "Table",
+                                            "objectId": 1471594,
+                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                        }
+                                    ],
+                                },
+                                {
+                                    "baseSources": [
+                                        {
+                                            "columnName": "START_STATION_NAME",
+                                            "objectDomain": "Table",
+                                            "objectId": 1471594,
+                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                        }
+                                    ],
+                                    "columnId": 1485913,
+                                    "columnName": "START_STATION_NAME",
+                                    "directSources": [
+                                        {
+                                            "columnName": "START_STATION_NAME",
+                                            "objectDomain": "Table",
+                                            "objectId": 1471594,
+                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                        }
+                                    ],
+                                },
+                                {
+                                    "baseSources": [
+                                        {
+                                            "columnName": "START_STATION_ID",
+                                            "objectDomain": "Table",
+                                            "objectId": 1471594,
+                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                        }
+                                    ],
+                                    "columnId": 1485912,
+                                    "columnName": "START_STATION_ID",
+                                    "directSources": [
+                                        {
+                                            "columnName": "START_STATION_ID",
+                                            "objectDomain": "Table",
+                                            "objectId": 1471594,
+                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                        }
+                                    ],
+                                },
+                                {
+                                    "baseSources": [
+                                        {
+                                            "columnName": "TOTAL_BIKE_HIRES",
+                                            "objectDomain": "Table",
+                                            "objectId": 1471594,
+                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                        },
+                                        {
+                                            "columnName": "TOTAL_MINUTES",
+                                            "objectDomain": "Table",
+                                            "objectId": 1471594,
+                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                        },
+                                    ],
+                                    "columnId": 1485908,
+                                    "columnName": "AVERAGE_DURATION_IN_MINUTES",
+                                    "directSources": [
+                                        {
+                                            "columnName": "TOTAL_BIKE_HIRES",
+                                            "objectDomain": "Table",
+                                            "objectId": 1471594,
+                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                        },
+                                        {
+                                            "columnName": "TOTAL_MINUTES",
+                                            "objectDomain": "Table",
+                                            "objectId": 1471594,
+                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                        },
+                                    ],
+                                },
+                                {
+                                    "baseSources": [
+                                        {
+                                            "columnName": "START_STATION_BIKES_COUNT",
+                                            "objectDomain": "Table",
+                                            "objectId": 1471594,
+                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                        }
+                                    ],
+                                    "columnId": 1485914,
+                                    "columnName": "START_STATION_BIKES_COUNT",
+                                    "directSources": [
+                                        {
+                                            "columnName": "START_STATION_BIKES_COUNT",
+                                            "objectDomain": "Table",
+                                            "objectId": 1471594,
+                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                        }
+                                    ],
+                                },
+                                {
+                                    "baseSources": [
+                                        {
+                                            "columnName": "SAME_STATION_FLAG",
+                                            "objectDomain": "Table",
+                                            "objectId": 1471594,
+                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                        }
+                                    ],
+                                    "columnId": 1485911,
+                                    "columnName": "SAME_STATION_FLAG",
+                                    "directSources": [
+                                        {
+                                            "columnName": "SAME_STATION_FLAG",
+                                            "objectDomain": "Table",
+                                            "objectId": 1471594,
+                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                        }
+                                    ],
+                                },
+                                {
+                                    "baseSources": [
+                                        {
+                                            "columnName": "START_PEAK_TRAVEL",
+                                            "objectDomain": "Table",
+                                            "objectId": 1471594,
+                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                        }
+                                    ],
+                                    "columnId": 1485910,
+                                    "columnName": "START_PEAK_TRAVEL",
+                                    "directSources": [
+                                        {
+                                            "columnName": "START_PEAK_TRAVEL",
+                                            "objectDomain": "Table",
+                                            "objectId": 1471594,
+                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                        }
+                                    ],
+                                },
+                                {
+                                    "baseSources": [
+                                        {
+                                            "columnName": "TOTAL_MINUTES",
+                                            "objectDomain": "Table",
+                                            "objectId": 1471594,
+                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                        }
+                                    ],
+                                    "columnId": 1485906,
+                                    "columnName": "TOTAL_HOURS",
+                                    "directSources": [
+                                        {
+                                            "columnName": "TOTAL_MINUTES",
+                                            "objectDomain": "Table",
+                                            "objectId": 1471594,
+                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                        }
+                                    ],
+                                },
+                                {
+                                    "baseSources": [
+                                        {
+                                            "columnName": "TOTAL_MINUTES",
+                                            "objectDomain": "Table",
+                                            "objectId": 1471594,
+                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                        }
+                                    ],
+                                    "columnId": 1485905,
+                                    "columnName": "TOTAL_MINUTES",
+                                    "directSources": [
+                                        {
+                                            "columnName": "TOTAL_MINUTES",
+                                            "objectDomain": "Table",
+                                            "objectId": 1471594,
+                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                        }
+                                    ],
+                                },
+                            ],
+                            "objectDomain": "Table",
+                            "objectId": 1472528,
+                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_START_STATION_2017",
+                        },
+                        {
+                            "objectDomain": "Table",
+                            "objectId": 14725280,
+                            "objectName": "ACME.RIDE_SHARE.FOO.BAR",
+                        },
+                    ]
+                ),
             ),
-            json.dumps(
-                [
-                    {
-                        "columns": [
-                            {
-                                "baseSources": [
-                                    {
-                                        "columnName": "MONTH",
-                                        "objectDomain": "Table",
-                                        "objectId": 1471594,
-                                        "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                    }
-                                ],
-                                "columnId": 1485909,
-                                "columnName": "MONTH",
-                                "directSources": [
-                                    {
-                                        "columnName": "MONTH",
-                                        "objectDomain": "Table",
-                                        "objectId": 1471594,
-                                        "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                    }
-                                ],
-                            },
-                            {
-                                "baseSources": [
-                                    {
-                                        "columnName": "START_STATION_INSTALL_DATE",
-                                        "objectDomain": "Table",
-                                        "objectId": 1471594,
-                                        "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                    }
-                                ],
-                                "columnId": 1485916,
-                                "columnName": "START_STATION_INSTALL_DATE",
-                                "directSources": [
-                                    {
-                                        "columnName": "START_STATION_INSTALL_DATE",
-                                        "objectDomain": "Table",
-                                        "objectId": 1471594,
-                                        "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                    }
-                                ],
-                            },
-                            {
-                                "baseSources": [
-                                    {
-                                        "columnName": "TOTAL_BIKE_HIRES",
-                                        "objectDomain": "Table",
-                                        "objectId": 1471594,
-                                        "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                    }
-                                ],
-                                "columnId": 1485907,
-                                "columnName": "TOTAL_BIKE_HIRES",
-                                "directSources": [
-                                    {
-                                        "columnName": "TOTAL_BIKE_HIRES",
-                                        "objectDomain": "Table",
-                                        "objectId": 1471594,
-                                        "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                    }
-                                ],
-                            },
-                            {
-                                "baseSources": [
-                                    {
-                                        "columnName": "START_STATION_DOCKS_COUNT",
-                                        "objectDomain": "Table",
-                                        "objectId": 1471594,
-                                        "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                    }
-                                ],
-                                "columnId": 1485915,
-                                "columnName": "START_STATION_DOCKS_COUNT",
-                                "directSources": [
-                                    {
-                                        "columnName": "START_STATION_DOCKS_COUNT",
-                                        "objectDomain": "Table",
-                                        "objectId": 1471594,
-                                        "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                    }
-                                ],
-                            },
-                            {
-                                "baseSources": [
-                                    {
-                                        "columnName": "START_STATION_NAME",
-                                        "objectDomain": "Table",
-                                        "objectId": 1471594,
-                                        "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                    }
-                                ],
-                                "columnId": 1485913,
-                                "columnName": "START_STATION_NAME",
-                                "directSources": [
-                                    {
-                                        "columnName": "START_STATION_NAME",
-                                        "objectDomain": "Table",
-                                        "objectId": 1471594,
-                                        "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                    }
-                                ],
-                            },
-                            {
-                                "baseSources": [
-                                    {
-                                        "columnName": "START_STATION_ID",
-                                        "objectDomain": "Table",
-                                        "objectId": 1471594,
-                                        "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                    }
-                                ],
-                                "columnId": 1485912,
-                                "columnName": "START_STATION_ID",
-                                "directSources": [
-                                    {
-                                        "columnName": "START_STATION_ID",
-                                        "objectDomain": "Table",
-                                        "objectId": 1471594,
-                                        "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                    }
-                                ],
-                            },
-                            {
-                                "baseSources": [
-                                    {
-                                        "columnName": "TOTAL_BIKE_HIRES",
-                                        "objectDomain": "Table",
-                                        "objectId": 1471594,
-                                        "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                    },
-                                    {
-                                        "columnName": "TOTAL_MINUTES",
-                                        "objectDomain": "Table",
-                                        "objectId": 1471594,
-                                        "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                    },
-                                ],
-                                "columnId": 1485908,
-                                "columnName": "AVERAGE_DURATION_IN_MINUTES",
-                                "directSources": [
-                                    {
-                                        "columnName": "TOTAL_BIKE_HIRES",
-                                        "objectDomain": "Table",
-                                        "objectId": 1471594,
-                                        "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                    },
-                                    {
-                                        "columnName": "TOTAL_MINUTES",
-                                        "objectDomain": "Table",
-                                        "objectId": 1471594,
-                                        "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                    },
-                                ],
-                            },
-                            {
-                                "baseSources": [
-                                    {
-                                        "columnName": "START_STATION_BIKES_COUNT",
-                                        "objectDomain": "Table",
-                                        "objectId": 1471594,
-                                        "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                    }
-                                ],
-                                "columnId": 1485914,
-                                "columnName": "START_STATION_BIKES_COUNT",
-                                "directSources": [
-                                    {
-                                        "columnName": "START_STATION_BIKES_COUNT",
-                                        "objectDomain": "Table",
-                                        "objectId": 1471594,
-                                        "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                    }
-                                ],
-                            },
-                            {
-                                "baseSources": [
-                                    {
-                                        "columnName": "SAME_STATION_FLAG",
-                                        "objectDomain": "Table",
-                                        "objectId": 1471594,
-                                        "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                    }
-                                ],
-                                "columnId": 1485911,
-                                "columnName": "SAME_STATION_FLAG",
-                                "directSources": [
-                                    {
-                                        "columnName": "SAME_STATION_FLAG",
-                                        "objectDomain": "Table",
-                                        "objectId": 1471594,
-                                        "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                    }
-                                ],
-                            },
-                            {
-                                "baseSources": [
-                                    {
-                                        "columnName": "START_PEAK_TRAVEL",
-                                        "objectDomain": "Table",
-                                        "objectId": 1471594,
-                                        "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                    }
-                                ],
-                                "columnId": 1485910,
-                                "columnName": "START_PEAK_TRAVEL",
-                                "directSources": [
-                                    {
-                                        "columnName": "START_PEAK_TRAVEL",
-                                        "objectDomain": "Table",
-                                        "objectId": 1471594,
-                                        "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                    }
-                                ],
-                            },
-                            {
-                                "baseSources": [
-                                    {
-                                        "columnName": "TOTAL_MINUTES",
-                                        "objectDomain": "Table",
-                                        "objectId": 1471594,
-                                        "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                    }
-                                ],
-                                "columnId": 1485906,
-                                "columnName": "TOTAL_HOURS",
-                                "directSources": [
-                                    {
-                                        "columnName": "TOTAL_MINUTES",
-                                        "objectDomain": "Table",
-                                        "objectId": 1471594,
-                                        "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                    }
-                                ],
-                            },
-                            {
-                                "baseSources": [
-                                    {
-                                        "columnName": "TOTAL_MINUTES",
-                                        "objectDomain": "Table",
-                                        "objectId": 1471594,
-                                        "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                    }
-                                ],
-                                "columnId": 1485905,
-                                "columnName": "TOTAL_MINUTES",
-                                "directSources": [
-                                    {
-                                        "columnName": "TOTAL_MINUTES",
-                                        "objectDomain": "Table",
-                                        "objectId": 1471594,
-                                        "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                    }
-                                ],
-                            },
-                        ],
-                        "objectDomain": "Table",
-                        "objectId": 1472528,
-                        "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_START_STATION_2017",
-                    },
-                    {
-                        "objectDomain": "Table",
-                        "objectId": 14725280,
-                        "objectName": "ACME.RIDE_SHARE.FOO.BAR",
-                    },
-                ]
+            (
+                # Large query - expected to be ignored
+                "id1",  # QUERY_ID
+                "METAPHOR",  # USER_NAME
+                "a very very long query that exceeds 40 chars",  # QUERY_TEXT
+                "2022-12-12 14:01:02.778 -0800",  # START_TIME
+                2514,  # TOTAL_ELAPSED_TIME
+                "0.000296",  # CREDITS_USED_CLOUD_SERVICES
+                "ACME",  # DATABASE_NAME
+                "RIDE_SHARE",  # SCHEMA_NAME
+                100,  # BYTES_SCANNED
+                200,  # BYTES_WRITTEN
+                10,  # ROWS_PRODUCED
+                20,  # ROWS_INSERTED
+                0,  # ROWS_UPDATED
             ),
-        ),
-        (
-            # Large query - expected to be ignored
-            "id1",  # QUERY_ID
-            "METAPHOR",  # USER_NAME
-            "a very very long query that exceeds 40 chars",  # QUERY_TEXT
-            "2022-12-12 14:01:02.778 -0800",  # START_TIME
-            2514,  # TOTAL_ELAPSED_TIME
-            "0.000296",  # CREDITS_USED_CLOUD_SERVICES
-            "ACME",  # DATABASE_NAME
-            "RIDE_SHARE",  # SCHEMA_NAME
-            100,  # BYTES_SCANNED
-            200,  # BYTES_WRITTEN
-            10,  # ROWS_PRODUCED
-            20,  # ROWS_INSERTED
-            0,  # ROWS_UPDATED
-        ),
-    ]
+        ]
+    )
 
     config = make_snowflake_config()
     config.query_log = SnowflakeQueryLogConfig(max_query_size=40)
 
     extractor = SnowflakeExtractor(config)
-    extractor._parse_query_logs("1", query_logs)
+    query_logs = list(extractor._parse_query_logs(1, mock_cursor))
 
-    assert len(extractor._logs) == 1
-    log0 = extractor._logs[0]
+    assert len(query_logs) == 1
+    log0 = query_logs[0]
     assert log0.query_id == "id1"
     assert log0.bytes_read == 100
     assert log0.bytes_written == 200

--- a/tests/snowflake/test_extractor.py
+++ b/tests/snowflake/test_extractor.py
@@ -405,358 +405,381 @@ def test_fetch_shared_databases(mock_connect: MagicMock):
     assert results == [database]
 
 
+@patch("metaphor.snowflake.extractor.check_access_history")
+@patch("metaphor.snowflake.extractor.fetch_query_history_count")
 @patch("metaphor.snowflake.auth.connect")
-def test_parse_query_logs(mock_connect: MagicMock):
-    mock_cursor = MagicMock()
+def test_collect_query_logs(
+    mock_connect: MagicMock,
+    mock_fetch_query_history_count: MagicMock,
+    mock_check_access_history: MagicMock,
+):
+    mock_check_access_history.return_value = True
+    mock_fetch_query_history_count.return_value = 1
 
-    mock_cursor.__iter__.return_value = iter(
-        [
-            (
-                "id1",  # QUERY_ID
-                "METAPHOR",  # USER_NAME
-                "short query text less than 40 chars",  # QUERY_TEXT
-                "2022-12-12 14:01:02.778 -0800",  # START_TIME
-                2514,  # TOTAL_ELAPSED_TIME
-                "0.000296",  # CREDITS_USED_CLOUD_SERVICES
-                "ACME",  # DATABASE_NAME
-                "RIDE_SHARE",  # SCHEMA_NAME
-                100,  # BYTES_SCANNED
-                200,  # BYTES_WRITTEN
-                10,  # ROWS_PRODUCED
-                20,  # ROWS_INSERTED
-                0,  # ROWS_UPDATED
-                json.dumps(
-                    [
-                        {
-                            "columns": [
-                                {
-                                    "columnId": 1485364,
-                                    "columnName": "START_STATION_NAME",
-                                },
-                                {"columnId": 1485363, "columnName": "START_STATION_ID"},
-                                {"columnId": 1485357, "columnName": "TOTAL_MINUTES"},
-                                {
-                                    "columnId": 1485365,
-                                    "columnName": "START_STATION_BIKES_COUNT",
-                                },
-                                {"columnId": 1485360, "columnName": "MONTH"},
-                                {
-                                    "columnId": 1485367,
-                                    "columnName": "START_STATION_INSTALL_DATE",
-                                },
-                                {
-                                    "columnId": 1485361,
-                                    "columnName": "START_PEAK_TRAVEL",
-                                },
-                                {
-                                    "columnId": 1485362,
-                                    "columnName": "SAME_STATION_FLAG",
-                                },
-                                {
-                                    "columnId": 1485366,
-                                    "columnName": "START_STATION_DOCKS_COUNT",
-                                },
-                                {"columnId": 1485358, "columnName": "TOTAL_BIKE_HIRES"},
-                            ],
-                            "objectDomain": "Table",
-                            "objectId": 1471594,
-                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                        }
-                    ]
+    class MockCursor:
+        def execute(self, _query, _params):
+            pass
+
+        def __iter__(self):
+            for obj in [
+                (
+                    "id1",  # QUERY_ID
+                    "METAPHOR",  # USER_NAME
+                    "short query text less than 40 chars",  # QUERY_TEXT
+                    "2022-12-12 14:01:02.778 -0800",  # START_TIME
+                    2514,  # TOTAL_ELAPSED_TIME
+                    "0.000296",  # CREDITS_USED_CLOUD_SERVICES
+                    "ACME",  # DATABASE_NAME
+                    "RIDE_SHARE",  # SCHEMA_NAME
+                    100,  # BYTES_SCANNED
+                    200,  # BYTES_WRITTEN
+                    10,  # ROWS_PRODUCED
+                    20,  # ROWS_INSERTED
+                    0,  # ROWS_UPDATED
+                    json.dumps(
+                        [
+                            {
+                                "columns": [
+                                    {
+                                        "columnId": 1485364,
+                                        "columnName": "START_STATION_NAME",
+                                    },
+                                    {
+                                        "columnId": 1485363,
+                                        "columnName": "START_STATION_ID",
+                                    },
+                                    {
+                                        "columnId": 1485357,
+                                        "columnName": "TOTAL_MINUTES",
+                                    },
+                                    {
+                                        "columnId": 1485365,
+                                        "columnName": "START_STATION_BIKES_COUNT",
+                                    },
+                                    {"columnId": 1485360, "columnName": "MONTH"},
+                                    {
+                                        "columnId": 1485367,
+                                        "columnName": "START_STATION_INSTALL_DATE",
+                                    },
+                                    {
+                                        "columnId": 1485361,
+                                        "columnName": "START_PEAK_TRAVEL",
+                                    },
+                                    {
+                                        "columnId": 1485362,
+                                        "columnName": "SAME_STATION_FLAG",
+                                    },
+                                    {
+                                        "columnId": 1485366,
+                                        "columnName": "START_STATION_DOCKS_COUNT",
+                                    },
+                                    {
+                                        "columnId": 1485358,
+                                        "columnName": "TOTAL_BIKE_HIRES",
+                                    },
+                                ],
+                                "objectDomain": "Table",
+                                "objectId": 1471594,
+                                "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                            }
+                        ]
+                    ),
+                    json.dumps(
+                        [
+                            {
+                                "columns": [
+                                    {
+                                        "baseSources": [
+                                            {
+                                                "columnName": "MONTH",
+                                                "objectDomain": "Table",
+                                                "objectId": 1471594,
+                                                "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                            }
+                                        ],
+                                        "columnId": 1485909,
+                                        "columnName": "MONTH",
+                                        "directSources": [
+                                            {
+                                                "columnName": "MONTH",
+                                                "objectDomain": "Table",
+                                                "objectId": 1471594,
+                                                "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                            }
+                                        ],
+                                    },
+                                    {
+                                        "baseSources": [
+                                            {
+                                                "columnName": "START_STATION_INSTALL_DATE",
+                                                "objectDomain": "Table",
+                                                "objectId": 1471594,
+                                                "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                            }
+                                        ],
+                                        "columnId": 1485916,
+                                        "columnName": "START_STATION_INSTALL_DATE",
+                                        "directSources": [
+                                            {
+                                                "columnName": "START_STATION_INSTALL_DATE",
+                                                "objectDomain": "Table",
+                                                "objectId": 1471594,
+                                                "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                            }
+                                        ],
+                                    },
+                                    {
+                                        "baseSources": [
+                                            {
+                                                "columnName": "TOTAL_BIKE_HIRES",
+                                                "objectDomain": "Table",
+                                                "objectId": 1471594,
+                                                "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                            }
+                                        ],
+                                        "columnId": 1485907,
+                                        "columnName": "TOTAL_BIKE_HIRES",
+                                        "directSources": [
+                                            {
+                                                "columnName": "TOTAL_BIKE_HIRES",
+                                                "objectDomain": "Table",
+                                                "objectId": 1471594,
+                                                "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                            }
+                                        ],
+                                    },
+                                    {
+                                        "baseSources": [
+                                            {
+                                                "columnName": "START_STATION_DOCKS_COUNT",
+                                                "objectDomain": "Table",
+                                                "objectId": 1471594,
+                                                "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                            }
+                                        ],
+                                        "columnId": 1485915,
+                                        "columnName": "START_STATION_DOCKS_COUNT",
+                                        "directSources": [
+                                            {
+                                                "columnName": "START_STATION_DOCKS_COUNT",
+                                                "objectDomain": "Table",
+                                                "objectId": 1471594,
+                                                "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                            }
+                                        ],
+                                    },
+                                    {
+                                        "baseSources": [
+                                            {
+                                                "columnName": "START_STATION_NAME",
+                                                "objectDomain": "Table",
+                                                "objectId": 1471594,
+                                                "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                            }
+                                        ],
+                                        "columnId": 1485913,
+                                        "columnName": "START_STATION_NAME",
+                                        "directSources": [
+                                            {
+                                                "columnName": "START_STATION_NAME",
+                                                "objectDomain": "Table",
+                                                "objectId": 1471594,
+                                                "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                            }
+                                        ],
+                                    },
+                                    {
+                                        "baseSources": [
+                                            {
+                                                "columnName": "START_STATION_ID",
+                                                "objectDomain": "Table",
+                                                "objectId": 1471594,
+                                                "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                            }
+                                        ],
+                                        "columnId": 1485912,
+                                        "columnName": "START_STATION_ID",
+                                        "directSources": [
+                                            {
+                                                "columnName": "START_STATION_ID",
+                                                "objectDomain": "Table",
+                                                "objectId": 1471594,
+                                                "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                            }
+                                        ],
+                                    },
+                                    {
+                                        "baseSources": [
+                                            {
+                                                "columnName": "TOTAL_BIKE_HIRES",
+                                                "objectDomain": "Table",
+                                                "objectId": 1471594,
+                                                "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                            },
+                                            {
+                                                "columnName": "TOTAL_MINUTES",
+                                                "objectDomain": "Table",
+                                                "objectId": 1471594,
+                                                "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                            },
+                                        ],
+                                        "columnId": 1485908,
+                                        "columnName": "AVERAGE_DURATION_IN_MINUTES",
+                                        "directSources": [
+                                            {
+                                                "columnName": "TOTAL_BIKE_HIRES",
+                                                "objectDomain": "Table",
+                                                "objectId": 1471594,
+                                                "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                            },
+                                            {
+                                                "columnName": "TOTAL_MINUTES",
+                                                "objectDomain": "Table",
+                                                "objectId": 1471594,
+                                                "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                            },
+                                        ],
+                                    },
+                                    {
+                                        "baseSources": [
+                                            {
+                                                "columnName": "START_STATION_BIKES_COUNT",
+                                                "objectDomain": "Table",
+                                                "objectId": 1471594,
+                                                "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                            }
+                                        ],
+                                        "columnId": 1485914,
+                                        "columnName": "START_STATION_BIKES_COUNT",
+                                        "directSources": [
+                                            {
+                                                "columnName": "START_STATION_BIKES_COUNT",
+                                                "objectDomain": "Table",
+                                                "objectId": 1471594,
+                                                "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                            }
+                                        ],
+                                    },
+                                    {
+                                        "baseSources": [
+                                            {
+                                                "columnName": "SAME_STATION_FLAG",
+                                                "objectDomain": "Table",
+                                                "objectId": 1471594,
+                                                "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                            }
+                                        ],
+                                        "columnId": 1485911,
+                                        "columnName": "SAME_STATION_FLAG",
+                                        "directSources": [
+                                            {
+                                                "columnName": "SAME_STATION_FLAG",
+                                                "objectDomain": "Table",
+                                                "objectId": 1471594,
+                                                "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                            }
+                                        ],
+                                    },
+                                    {
+                                        "baseSources": [
+                                            {
+                                                "columnName": "START_PEAK_TRAVEL",
+                                                "objectDomain": "Table",
+                                                "objectId": 1471594,
+                                                "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                            }
+                                        ],
+                                        "columnId": 1485910,
+                                        "columnName": "START_PEAK_TRAVEL",
+                                        "directSources": [
+                                            {
+                                                "columnName": "START_PEAK_TRAVEL",
+                                                "objectDomain": "Table",
+                                                "objectId": 1471594,
+                                                "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                            }
+                                        ],
+                                    },
+                                    {
+                                        "baseSources": [
+                                            {
+                                                "columnName": "TOTAL_MINUTES",
+                                                "objectDomain": "Table",
+                                                "objectId": 1471594,
+                                                "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                            }
+                                        ],
+                                        "columnId": 1485906,
+                                        "columnName": "TOTAL_HOURS",
+                                        "directSources": [
+                                            {
+                                                "columnName": "TOTAL_MINUTES",
+                                                "objectDomain": "Table",
+                                                "objectId": 1471594,
+                                                "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                            }
+                                        ],
+                                    },
+                                    {
+                                        "baseSources": [
+                                            {
+                                                "columnName": "TOTAL_MINUTES",
+                                                "objectDomain": "Table",
+                                                "objectId": 1471594,
+                                                "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                            }
+                                        ],
+                                        "columnId": 1485905,
+                                        "columnName": "TOTAL_MINUTES",
+                                        "directSources": [
+                                            {
+                                                "columnName": "TOTAL_MINUTES",
+                                                "objectDomain": "Table",
+                                                "objectId": 1471594,
+                                                "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
+                                            }
+                                        ],
+                                    },
+                                ],
+                                "objectDomain": "Table",
+                                "objectId": 1472528,
+                                "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_START_STATION_2017",
+                            },
+                            {
+                                "objectDomain": "Table",
+                                "objectId": 14725280,
+                                "objectName": "ACME.RIDE_SHARE.FOO.BAR",
+                            },
+                        ]
+                    ),
                 ),
-                json.dumps(
-                    [
-                        {
-                            "columns": [
-                                {
-                                    "baseSources": [
-                                        {
-                                            "columnName": "MONTH",
-                                            "objectDomain": "Table",
-                                            "objectId": 1471594,
-                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                        }
-                                    ],
-                                    "columnId": 1485909,
-                                    "columnName": "MONTH",
-                                    "directSources": [
-                                        {
-                                            "columnName": "MONTH",
-                                            "objectDomain": "Table",
-                                            "objectId": 1471594,
-                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                        }
-                                    ],
-                                },
-                                {
-                                    "baseSources": [
-                                        {
-                                            "columnName": "START_STATION_INSTALL_DATE",
-                                            "objectDomain": "Table",
-                                            "objectId": 1471594,
-                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                        }
-                                    ],
-                                    "columnId": 1485916,
-                                    "columnName": "START_STATION_INSTALL_DATE",
-                                    "directSources": [
-                                        {
-                                            "columnName": "START_STATION_INSTALL_DATE",
-                                            "objectDomain": "Table",
-                                            "objectId": 1471594,
-                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                        }
-                                    ],
-                                },
-                                {
-                                    "baseSources": [
-                                        {
-                                            "columnName": "TOTAL_BIKE_HIRES",
-                                            "objectDomain": "Table",
-                                            "objectId": 1471594,
-                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                        }
-                                    ],
-                                    "columnId": 1485907,
-                                    "columnName": "TOTAL_BIKE_HIRES",
-                                    "directSources": [
-                                        {
-                                            "columnName": "TOTAL_BIKE_HIRES",
-                                            "objectDomain": "Table",
-                                            "objectId": 1471594,
-                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                        }
-                                    ],
-                                },
-                                {
-                                    "baseSources": [
-                                        {
-                                            "columnName": "START_STATION_DOCKS_COUNT",
-                                            "objectDomain": "Table",
-                                            "objectId": 1471594,
-                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                        }
-                                    ],
-                                    "columnId": 1485915,
-                                    "columnName": "START_STATION_DOCKS_COUNT",
-                                    "directSources": [
-                                        {
-                                            "columnName": "START_STATION_DOCKS_COUNT",
-                                            "objectDomain": "Table",
-                                            "objectId": 1471594,
-                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                        }
-                                    ],
-                                },
-                                {
-                                    "baseSources": [
-                                        {
-                                            "columnName": "START_STATION_NAME",
-                                            "objectDomain": "Table",
-                                            "objectId": 1471594,
-                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                        }
-                                    ],
-                                    "columnId": 1485913,
-                                    "columnName": "START_STATION_NAME",
-                                    "directSources": [
-                                        {
-                                            "columnName": "START_STATION_NAME",
-                                            "objectDomain": "Table",
-                                            "objectId": 1471594,
-                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                        }
-                                    ],
-                                },
-                                {
-                                    "baseSources": [
-                                        {
-                                            "columnName": "START_STATION_ID",
-                                            "objectDomain": "Table",
-                                            "objectId": 1471594,
-                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                        }
-                                    ],
-                                    "columnId": 1485912,
-                                    "columnName": "START_STATION_ID",
-                                    "directSources": [
-                                        {
-                                            "columnName": "START_STATION_ID",
-                                            "objectDomain": "Table",
-                                            "objectId": 1471594,
-                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                        }
-                                    ],
-                                },
-                                {
-                                    "baseSources": [
-                                        {
-                                            "columnName": "TOTAL_BIKE_HIRES",
-                                            "objectDomain": "Table",
-                                            "objectId": 1471594,
-                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                        },
-                                        {
-                                            "columnName": "TOTAL_MINUTES",
-                                            "objectDomain": "Table",
-                                            "objectId": 1471594,
-                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                        },
-                                    ],
-                                    "columnId": 1485908,
-                                    "columnName": "AVERAGE_DURATION_IN_MINUTES",
-                                    "directSources": [
-                                        {
-                                            "columnName": "TOTAL_BIKE_HIRES",
-                                            "objectDomain": "Table",
-                                            "objectId": 1471594,
-                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                        },
-                                        {
-                                            "columnName": "TOTAL_MINUTES",
-                                            "objectDomain": "Table",
-                                            "objectId": 1471594,
-                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                        },
-                                    ],
-                                },
-                                {
-                                    "baseSources": [
-                                        {
-                                            "columnName": "START_STATION_BIKES_COUNT",
-                                            "objectDomain": "Table",
-                                            "objectId": 1471594,
-                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                        }
-                                    ],
-                                    "columnId": 1485914,
-                                    "columnName": "START_STATION_BIKES_COUNT",
-                                    "directSources": [
-                                        {
-                                            "columnName": "START_STATION_BIKES_COUNT",
-                                            "objectDomain": "Table",
-                                            "objectId": 1471594,
-                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                        }
-                                    ],
-                                },
-                                {
-                                    "baseSources": [
-                                        {
-                                            "columnName": "SAME_STATION_FLAG",
-                                            "objectDomain": "Table",
-                                            "objectId": 1471594,
-                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                        }
-                                    ],
-                                    "columnId": 1485911,
-                                    "columnName": "SAME_STATION_FLAG",
-                                    "directSources": [
-                                        {
-                                            "columnName": "SAME_STATION_FLAG",
-                                            "objectDomain": "Table",
-                                            "objectId": 1471594,
-                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                        }
-                                    ],
-                                },
-                                {
-                                    "baseSources": [
-                                        {
-                                            "columnName": "START_PEAK_TRAVEL",
-                                            "objectDomain": "Table",
-                                            "objectId": 1471594,
-                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                        }
-                                    ],
-                                    "columnId": 1485910,
-                                    "columnName": "START_PEAK_TRAVEL",
-                                    "directSources": [
-                                        {
-                                            "columnName": "START_PEAK_TRAVEL",
-                                            "objectDomain": "Table",
-                                            "objectId": 1471594,
-                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                        }
-                                    ],
-                                },
-                                {
-                                    "baseSources": [
-                                        {
-                                            "columnName": "TOTAL_MINUTES",
-                                            "objectDomain": "Table",
-                                            "objectId": 1471594,
-                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                        }
-                                    ],
-                                    "columnId": 1485906,
-                                    "columnName": "TOTAL_HOURS",
-                                    "directSources": [
-                                        {
-                                            "columnName": "TOTAL_MINUTES",
-                                            "objectDomain": "Table",
-                                            "objectId": 1471594,
-                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                        }
-                                    ],
-                                },
-                                {
-                                    "baseSources": [
-                                        {
-                                            "columnName": "TOTAL_MINUTES",
-                                            "objectDomain": "Table",
-                                            "objectId": 1471594,
-                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                        }
-                                    ],
-                                    "columnId": 1485905,
-                                    "columnName": "TOTAL_MINUTES",
-                                    "directSources": [
-                                        {
-                                            "columnName": "TOTAL_MINUTES",
-                                            "objectDomain": "Table",
-                                            "objectId": 1471594,
-                                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_2017",
-                                        }
-                                    ],
-                                },
-                            ],
-                            "objectDomain": "Table",
-                            "objectId": 1472528,
-                            "objectName": "ACME.RIDE_SHARE.RIDES_BY_MONTH_START_STATION_2017",
-                        },
-                        {
-                            "objectDomain": "Table",
-                            "objectId": 14725280,
-                            "objectName": "ACME.RIDE_SHARE.FOO.BAR",
-                        },
-                    ]
+                (
+                    # Large query - expected to be ignored
+                    "id1",  # QUERY_ID
+                    "METAPHOR",  # USER_NAME
+                    "a very very long query that exceeds 40 chars",  # QUERY_TEXT
+                    "2022-12-12 14:01:02.778 -0800",  # START_TIME
+                    2514,  # TOTAL_ELAPSED_TIME
+                    "0.000296",  # CREDITS_USED_CLOUD_SERVICES
+                    "ACME",  # DATABASE_NAME
+                    "RIDE_SHARE",  # SCHEMA_NAME
+                    100,  # BYTES_SCANNED
+                    200,  # BYTES_WRITTEN
+                    10,  # ROWS_PRODUCED
+                    20,  # ROWS_INSERTED
+                    0,  # ROWS_UPDATED
                 ),
-            ),
-            (
-                # Large query - expected to be ignored
-                "id1",  # QUERY_ID
-                "METAPHOR",  # USER_NAME
-                "a very very long query that exceeds 40 chars",  # QUERY_TEXT
-                "2022-12-12 14:01:02.778 -0800",  # START_TIME
-                2514,  # TOTAL_ELAPSED_TIME
-                "0.000296",  # CREDITS_USED_CLOUD_SERVICES
-                "ACME",  # DATABASE_NAME
-                "RIDE_SHARE",  # SCHEMA_NAME
-                100,  # BYTES_SCANNED
-                200,  # BYTES_WRITTEN
-                10,  # ROWS_PRODUCED
-                20,  # ROWS_INSERTED
-                0,  # ROWS_UPDATED
-            ),
-        ]
-    )
+            ]:
+                yield obj
 
     config = make_snowflake_config()
     config.query_log = SnowflakeQueryLogConfig(max_query_size=40)
 
     extractor = SnowflakeExtractor(config)
-    query_logs = list(extractor._parse_query_logs(1, mock_cursor))
+    conn_instance = MagicMock()
+    conn_instance.cursor.return_value = MockCursor()
+    mock_connect.return_value = conn_instance
+    query_logs = list(extractor.collect_query_logs())
 
     assert len(query_logs) == 1
     log0 = query_logs[0]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

It is possible for large amount of query logs to exhaust crawler's memory in the serverless instance. To mitigate this issue, I created a route for connectors to extract query logs as an iterator, and the corresponding method in `FileSink` to export those parsed query logs one by one. The chunking is taken care of in `FileSink`.

Note: the boundary check for `batch_size_bytes` is not 100% precise, but should be close enough.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Implemented `collect_query_logs` method in `BaseExtractor` and `SnowflakeExtractor`
- Implemented `QueryLogSink` in `file_sink.py` to support piping an iterator of `QueryLog` to files.
- Modified unit test.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Tested on personal dev env with Snowflake crawler:

crawler output:
<img width="1192" alt="截圖 2024-02-03 凌晨3 39 48" src="https://github.com/MetaphorData/connectors/assets/6112039/5a1da40e-ffad-44ca-b472-6772d2d428d6">
ingestion logs:
<img width="1370" alt="截圖 2024-02-03 凌晨3 43 21" src="https://github.com/MetaphorData/connectors/assets/6112039/14d43804-1cb1-4e8a-a888-c699d2db8fe0">

Notice the `query_logs-0.json` is correctly ingested.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
