### PR TITLE
[sc-24626] Add query logs MCE count to CrawlerRunMetadata

### DIFF
--- a/metaphor/common/runner.py
+++ b/metaphor/common/runner.py
@@ -83,13 +83,15 @@ def run_connector(
     if file_sink_config is not None:
         file_sink = FileSink(file_sink_config)
         file_sink.write_events(events)
-        file_sink.write_metadata(run_metadata)
         file_sink.write_execution_logs()
 
         with file_sink.get_query_log_sink() as query_log_sink:
             for query_log in connector.collect_query_logs():
                 query_log_sink.write_query_log(query_log)
+            if run_metadata.entity_count is not None:
+                run_metadata.entity_count += float(query_log_sink.total_mces_wrote)
 
+        file_sink.write_metadata(run_metadata)
     return events, run_metadata
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.124"
+version = "0.13.125"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/common/test_runner.py
+++ b/tests/common/test_runner.py
@@ -1,14 +1,18 @@
-from typing import Collection, List
+import tempfile
+from typing import Collection, Iterator, List
 
 from metaphor.common.base_config import BaseConfig, OutputConfig
 from metaphor.common.base_extractor import BaseExtractor
 from metaphor.common.event_util import ENTITY_TYPES
+from metaphor.common.file_sink import FileSinkConfig
 from metaphor.common.runner import run_connector
+from metaphor.common.utils import md5_digest
 from metaphor.models.crawler_run_metadata import RunStatus
 from metaphor.models.metadata_change_event import (
     DataPlatform,
     Dataset,
     DatasetLogicalID,
+    QueryLog,
 )
 
 
@@ -36,9 +40,31 @@ def test_run_connector() -> None:
                     self.extend_errors(e)
             return entities
 
+        def collect_query_logs(self) -> Iterator[QueryLog]:
+            query_logs = [
+                QueryLog(
+                    id=f"{DataPlatform.SNOWFLAKE.name}:{query_id}",
+                    query_id=str(query_id),
+                    platform=DataPlatform.SNOWFLAKE,
+                    account="account",
+                    sql=query_text,
+                    sql_hash=md5_digest(query_text.encode("utf-8")),
+                )
+                for query_id, query_text in enumerate(
+                    f"this is query no. {x}" for x in range(5)
+                )
+            ]
+            for query_log in query_logs:
+                yield query_log
+
+    directory = tempfile.mkdtemp()
+    file_sink_config = FileSinkConfig(directory=directory, batch_size_bytes=1000000)
     dummy_connector = DummyConnector(BaseConfig(output=OutputConfig()))
     events, run_metadata = run_connector(
-        dummy_connector, "dummy_connector", "dummy connector"
+        dummy_connector,
+        "dummy_connector",
+        "dummy connector",
+        file_sink_config=file_sink_config,
     )
     assert run_metadata.status is RunStatus.FAILURE
     assert sorted(


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Since we've separated the query logs dump logic from the others, we need to also include the query log MCE count in `CrawlerRunMetadata`.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Added `total_mces_wrote` to `QueryLogSink`, and add that to `CrawlerRunMetadata.entity_count`.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Unit test.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
