### PR TITLE
Handle Snowflake SHOW STREAMS failures gracefully

### DIFF
--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -590,7 +590,7 @@ class SnowflakeExtractor(BaseExtractor):
             cursor.execute(f"SHOW STREAMS IN {schema}")
         except Exception as e:
             # Most likely due to a permission issue
-            logger.error(f"Failed to show streams in '{schema}'\n{e}")
+            logger.exception(f"Failed to show streams in '{schema}'")
             return
 
         count = 0

--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -586,8 +586,14 @@ class SnowflakeExtractor(BaseExtractor):
         return [schema[0] for schema in cursor]
 
     def _fetch_streams(self, cursor: SnowflakeCursor, database: str, schema: str):
+        try:
+            cursor.execute(f"SHOW STREAMS IN {schema}")
+        except Exception as e:
+            # Most likely due to a permission issue
+            logger.error(f"Failed to show streams in '{schema}'\n{e}")
+            return
+
         count = 0
-        cursor.execute(f"SHOW STREAMS IN {schema}")
         for entry in cursor:
             (
                 create_on,

--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -588,7 +588,7 @@ class SnowflakeExtractor(BaseExtractor):
     def _fetch_streams(self, cursor: SnowflakeCursor, database: str, schema: str):
         try:
             cursor.execute(f"SHOW STREAMS IN {schema}")
-        except Exception as e:
+        except Exception:
             # Most likely due to a permission issue
             logger.exception(f"Failed to show streams in '{schema}'")
             return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.126"
+version = "0.13.127"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

[SHOW STREMS](https://docs.snowflake.com/en/sql-reference/sql/show-streams) can throw the following exception and stops the entire connector if the user doesn't have the correct privilege:

```
SQL compilation error:
Schema '<redacted>' does not exist or not authorized.
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/metaphor/common/runner.py", line 51, in run_connector
    entities = connector.run_async()
  File "/usr/local/lib/python3.8/site-packages/metaphor/common/base_extractor.py", line 39, in run_async
    return asyncio.run(self.extract())
  File "/usr/local/lib/python3.8/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/local/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/usr/local/lib/python3.8/site-packages/metaphor/snowflake/extractor.py", line 154, in extract
    self._fetch_streams(cursor, database, schema)
  File "/usr/local/lib/python3.8/site-packages/metaphor/snowflake/extractor.py", line 590, in _fetch_streams
    cursor.execute(f"SHOW STREAMS IN {schema}")
  File "/usr/local/lib/python3.8/site-packages/snowflake/connector/cursor.py", line 1136, in execute
    Error.errorhandler_wrapper(self.connection, self, error_class, errvalue)
  File "/usr/local/lib/python3.8/site-packages/snowflake/connector/errors.py", line 290, in errorhandler_wrapper
    handed_over = Error.hand_to_other_handler(
  File "/usr/local/lib/python3.8/site-packages/snowflake/connector/errors.py", line 345, in hand_to_other_handler
    cursor.errorhandler(connection, cursor, error_class, error_value)
  File "/usr/local/lib/python3.8/site-packages/snowflake/connector/errors.py", line 221, in default_errorhandler
    raise error_class(
snowflake.connector.errors.ProgrammingError: 002003 (02000): SQL compilation error:
```

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Handle the exception gracefully and log the error without failing the whole connector. 

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified against a production instance.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
