### PR TITLE
[sc-24788] Modify S3 crawler to not require endpoint url

### DIFF
--- a/metaphor/s3/README.md
+++ b/metaphor/s3/README.md
@@ -24,7 +24,6 @@ aws:
   assume_role_arn: <aws_role_arn>  # If using IAM role
   session_token: <aws_session_token>  # If using session token
   profile_name: <aws_profile_name>  # If using AWS profile
-endpoint_url: <endpoint_url>  # The URL for the S3 object storage
 path_specs:
   - <PATH_SPEC_1>
   - <PATH_SPEC_2>
@@ -136,6 +135,16 @@ The excluded URIs do not support labels.
 #### Output Destination
 
 See [Output Config](../common/docs/output.md) for more information.
+
+#### Endpoint URL
+
+If you're connecting to S3 compatible storage such as Minio, an endponint URL must be provided:
+
+```yaml
+endpoint_url: <endpoint_url>  # The URL for the S3 object storage
+```
+
+This is not needed for AWS S3.
 
 ## Testing
 

--- a/metaphor/s3/config.py
+++ b/metaphor/s3/config.py
@@ -1,6 +1,6 @@
 from dataclasses import field
 from functools import cached_property
-from typing import List, Union
+from typing import List, Optional, Union
 
 from pydantic.dataclasses import dataclass
 
@@ -23,7 +23,7 @@ logger = get_logger()
 @dataclass(config=ConnectorConfig)
 class S3RunConfig(BaseConfig):
     aws: AwsCredentials
-    endpoint_url: str
+    endpoint_url: Optional[str] = None
     path_specs: List[PathSpec] = field(default_factory=list)
     verify_ssl: Union[bool, str] = False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.129"
+version = "0.13.130"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Endpoint URL is not needed for AWS S3.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Moved `endpoint_url` config value to optional.
- Remove unnecessary `list_buckets` call.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Tested locallly.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
