### PR TITLE
refresh time missing for snowflake tables

### DIFF
--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -203,7 +203,7 @@ class SnowflakeExtractor(BaseExtractor):
         for database, schema, table, is_secure in cursor:
             if not is_secure:
                 continue
-            fullname = to_quoted_identifier([database, schema, table])
+            fullname = f"{database}.{schema}.{table}".lower()
             set_of_secure_views.add(fullname)
         return set_of_secure_views
 
@@ -345,7 +345,7 @@ class SnowflakeExtractor(BaseExtractor):
             if (
                 table.type == SnowflakeTableType.BASE_TABLE.value
                 and not is_shared_database
-                and fullname not in secure_views
+                and normalized_name not in secure_views
             ):
                 queries.append(
                     f'SYSTEM$LAST_CHANGE_COMMIT_TIME(%s) as "UPDATED_{normalized_name}"'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.133"
+version = "0.13.134"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/snowflake/test_extractor.py
+++ b/tests/snowflake/test_extractor.py
@@ -180,7 +180,7 @@ def test_fetch_table_info(mock_connect: MagicMock):
     )
     extractor._datasets[normalized_name] = dataset
 
-    extractor._fetch_table_info({normalized_name: table_info}, False)
+    extractor._fetch_table_info({normalized_name: table_info}, False, set())
 
     assert dataset.schema.sql_schema.table_schema == "ddl"
     assert dataset.statistics.last_updated == datetime.utcfromtimestamp(0).replace(

--- a/tests/snowflake/test_extractor.py
+++ b/tests/snowflake/test_extractor.py
@@ -444,12 +444,30 @@ def test_fetch_hierarchy_system_tags(mock_connect: MagicMock):
 def test_fetch_shared_databases(mock_connect: MagicMock):
     mock_cursor = MagicMock()
 
-    mock_cursor.__iter__.return_value = iter([(None, "INBOUND", None, database)])
+    mock_cursor.__iter__.side_effect = [
+        iter(
+            [
+                (
+                    None,
+                    "INBOUND",
+                    None,
+                    "shared_1",
+                ),
+                (
+                    None,
+                    "UNKNOWN",
+                    None,
+                    "shared_2",
+                ),
+            ]
+        ),
+        iter([("shared_3",)]),
+    ]
 
     extractor = SnowflakeExtractor(make_snowflake_config())
     results = extractor._fetch_shared_databases(mock_cursor)
 
-    assert results == [database]
+    assert results == ["shared_1", "shared_3"]
 
 
 @patch("metaphor.snowflake.extractor.check_access_history")


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

Some of the Snowflake tables are missing refresh time because the loop to get table info stops iterating if there is an error in `get_table_info`.

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

- Reduce query compilation error ( skip secure view )
- Add try-catch in the for loop
- Partition table by schema because it's likely we can't get table information under a certain schema.

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

- Add tests


<!--
  Describe how the change was tested end-to-end.
-->

### ☑️ Checks

Run crawler against testing Snowflake account

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
