### PR TITLE
Output the correct platform for redshift crawler

### DIFF
--- a/metaphor/redshift/extractor.py
+++ b/metaphor/redshift/extractor.py
@@ -23,7 +23,7 @@ class RedshiftExtractor(PostgreSQLExtractor):
 
     _description = "Redshift metadata crawler"
     _platform = Platform.REDSHIFT
-    _data_platform = DataPlatform.REDSHIFT
+    _dataset_platform = DataPlatform.REDSHIFT
 
     @staticmethod
     def from_config_file(config_file: str) -> "RedshiftExtractor":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.133"
+version = "0.13.134"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/redshift/test_extractor.py
+++ b/tests/redshift/test_extractor.py
@@ -6,6 +6,7 @@ import pytest
 
 from metaphor.common.base_config import OutputConfig
 from metaphor.common.event_util import EventUtil
+from metaphor.models.metadata_change_event import DataPlatform
 from metaphor.redshift.access_event import AccessEvent
 from metaphor.redshift.config import RedshiftRunConfig
 from metaphor.redshift.extractor import RedshiftExtractor
@@ -35,6 +36,11 @@ async def test_extractor(
 
     events = [EventUtil.trim_event(e) for e in await extractor.extract()]
     assert events == []
+
+
+def test_dataset_platform():
+    extractor = RedshiftExtractor(dummy_config())
+    assert extractor._dataset_platform == DataPlatform.REDSHIFT
 
 
 def test_collect_query_logs(test_root_dir: str) -> None:


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Redshift crawler is settings the output asset platform type to `POSTGRES` instead of `REDSHIFT`.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Fix the typo made in https://github.com/MetaphorData/connectors/pull/724 and add a rudimentary test to verify.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified against a production instance.

Before:
```
[{"dataset": {"logicalId": {"name": "metaphor.private.sample_sales_records2", "platform": "POSTGRESQL"}, ...]
```

After:
```
[{"dataset": {"logicalId": {"name": "metaphor.private.sample_sales_records2", "platform": "REDSHIFT"}, ...]
```

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [ ] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
