### PR TITLE
Set user_id field in BigQuery query log for service accounts

### DIFF
--- a/metaphor/bigquery/extractor.py
+++ b/metaphor/bigquery/extractor.py
@@ -355,9 +355,9 @@ class BigQueryExtractor(BaseExtractor):
             else None
         )
 
-        # Assume service account always end in "gserviceaccount.com"
+        # Assume service accounts always end in ".gserviceaccount.com"
         # https://cloud.google.com/compute/docs/access/service-accounts
-        is_service_account = job_change.user_email.endswith("gserviceaccount.com")
+        is_service_account = job_change.user_email.endswith(".gserviceaccount.com")
 
         return QueryLog(
             id=f"{DataPlatform.BIGQUERY.name}:{job_change.job_name}",

--- a/metaphor/bigquery/extractor.py
+++ b/metaphor/bigquery/extractor.py
@@ -355,13 +355,18 @@ class BigQueryExtractor(BaseExtractor):
             else None
         )
 
+        # Assume service account always end in "gserviceaccount.com"
+        # https://cloud.google.com/compute/docs/access/service-accounts
+        is_service_account = job_change.user_email.endswith("gserviceaccount.com")
+
         return QueryLog(
             id=f"{DataPlatform.BIGQUERY.name}:{job_change.job_name}",
             query_id=job_change.job_name,
             platform=DataPlatform.BIGQUERY,
             start_time=job_change.start_time,
             duration=safe_float(elapsed_time),
-            email=job_change.user_email,
+            user_id=job_change.user_email if is_service_account else None,
+            email=job_change.user_email if not is_service_account else None,
             rows_written=float(job_change.output_rows)
             if job_change.output_rows
             else None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.134"
+version = "0.13.135"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/bigquery/query_logs.json
+++ b/tests/bigquery/query_logs.json
@@ -37,7 +37,7 @@
           "_id": "BIGQUERY:projects/metaphor-data/jobs/job_BSqXkGDLhaGKKQDJtesGJt3gjwG5",
           "bytesRead": 72.0,
           "duration": 0.376,
-          "email": "scott@metaphor.io",
+          "userId": "robot@iam.gserviceaccount.com",
           "platform": "BIGQUERY",
           "queryId": "projects/metaphor-data/jobs/job_BSqXkGDLhaGKKQDJtesGJt3gjwG5",
           "rowsWritten": 10.0,

--- a/tests/bigquery/sample_log.json
+++ b/tests/bigquery/sample_log.json
@@ -98,7 +98,7 @@
       "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
       "status": {},
       "authenticationInfo": {
-        "principalEmail": "scott@metaphor.io"
+        "principalEmail": "robot@iam.gserviceaccount.com"
       },
       "requestMetadata": {
         "callerIp": "1.1.1.1",


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

When encountering queries issued by a [GCP service account](https://cloud.google.com/compute/docs/access/service-accounts), we should identify it as such by setting the `user_id` field instead of `email`.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified against a production instance.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
