### PR TITLE
Exceptions thrown in crawler constructors not handled gracefully

### DIFF
--- a/examples/custom_dashboard.py
+++ b/examples/custom_dashboard.py
@@ -81,7 +81,7 @@ class CustomDashboardConnector(BaseExtractor):
 connector_name = "custom_dashboard_connector"
 tenant_name = "<tenant>"
 run_connector(
-    connector=CustomDashboardConnector.from_config_file(""),
+    make_connector=lambda: CustomDashboardConnector.from_config_file(""),
     name=connector_name,
     platform=Platform.CUSTOM_DASHBOARD,
     description="This is a custom connector made by Acme, Inc.",

--- a/examples/custom_dq.py
+++ b/examples/custom_dq.py
@@ -56,7 +56,7 @@ class CustomDQConnector(BaseExtractor):
 connector_name = "custom_dq_connector"
 tenant_name = "tenant"
 run_connector(
-    connector=CustomDQConnector.from_config_file(""),
+    make_connector=lambda: CustomDQConnector.from_config_file(""),
     name=connector_name,
     platform=Platform.BIGQUERY,
     description="This is a custom connector made by Acme, Inc.",

--- a/examples/custom_lineage.py
+++ b/examples/custom_lineage.py
@@ -66,7 +66,7 @@ class CustomLineageConnector(BaseExtractor):
 connector_name = "custom_lineage_connector"
 tenant_name = "tenant"
 run_connector(
-    connector=CustomLineageConnector.from_config_file(""),
+    make_connector=lambda: CustomLineageConnector.from_config_file(""),
     name=connector_name,
     platform=Platform.BIGQUERY,
     description="This is a custom connector made by Acme, Inc.",

--- a/metaphor/common/cli.py
+++ b/metaphor/common/cli.py
@@ -9,7 +9,7 @@ from metaphor.common.runner import run_connector
 def cli_main(extractor_cls: Type[BaseExtractor], config_file: str):
     base_config = BaseConfig.from_yaml_file(config_file)
 
-    def connector_func():
+    def make_connector():
         """
         Function to create the actual connector
         """
@@ -17,7 +17,7 @@ def cli_main(extractor_cls: Type[BaseExtractor], config_file: str):
 
     return run_connector(
         # We can't pass the connector instance here or we won't catch any error in connector.__init__
-        connector_func=connector_func,
+        make_connector=make_connector,
         name=EventUtil.class_fqcn(extractor_cls),
         description=extractor_cls._description,
         platform=extractor_cls._platform,

--- a/metaphor/common/cli.py
+++ b/metaphor/common/cli.py
@@ -9,8 +9,15 @@ from metaphor.common.runner import run_connector
 def cli_main(extractor_cls: Type[BaseExtractor], config_file: str):
     base_config = BaseConfig.from_yaml_file(config_file)
 
+    def connector_func():
+        """
+        Function to create the actual connector
+        """
+        return extractor_cls.from_config_file(config_file)
+
     return run_connector(
-        connector=extractor_cls.from_config_file(config_file),
+        # We can't pass the connector instance here or we won't catch any error in connector.__init__
+        connector_func=connector_func,
         name=EventUtil.class_fqcn(extractor_cls),
         description=extractor_cls._description,
         platform=extractor_cls._platform,

--- a/metaphor/common/runner.py
+++ b/metaphor/common/runner.py
@@ -24,7 +24,7 @@ def run_connector(
     Parameters
     ----------
     connector_func : Callable[[], Collection[ENTITY_TYPES]]
-        The function to create the instance of connector and exec run_async
+        The function to create and return an instance of connector
     name : str
         Name of the connector
     description : str

--- a/metaphor/common/runner.py
+++ b/metaphor/common/runner.py
@@ -13,7 +13,7 @@ logger = get_logger()
 
 
 def run_connector(
-    connector_func: Callable[[], BaseExtractor],
+    make_connector: Callable[[], BaseExtractor],
     name: str,
     description: str,
     platform: Optional[Platform] = None,
@@ -23,7 +23,7 @@ def run_connector(
 
     Parameters
     ----------
-    connector_func : Callable[[], BaseExtractor]
+    make_connector : Callable[[], BaseExtractor]
         The function to create and return an instance of connector
     name : str
         Name of the connector
@@ -49,7 +49,7 @@ def run_connector(
     entities: Collection[ENTITY_TYPES] = []
     connector: Optional[BaseExtractor] = None
     try:
-        connector = connector_func()
+        connector = make_connector()
         entities = connector.run_async()
         if connector.status is RunStatus.FAILURE:
             logger.warning(f"Some of {name}'s entities cannot be parsed!")

--- a/metaphor/common/runner.py
+++ b/metaphor/common/runner.py
@@ -23,7 +23,7 @@ def run_connector(
 
     Parameters
     ----------
-    connector_func : Callable[[], Collection[ENTITY_TYPES]]
+    connector_func : Callable[[], BaseExtractor]
         The function to create and return an instance of connector
     name : str
         Name of the connector

--- a/metaphor/common/runner.py
+++ b/metaphor/common/runner.py
@@ -1,6 +1,6 @@
 import traceback
 from datetime import datetime
-from typing import Collection, List, Optional, Tuple
+from typing import Callable, Collection, List, Optional, Tuple
 
 from metaphor.common.base_extractor import BaseExtractor
 from metaphor.common.event_util import ENTITY_TYPES, EventUtil
@@ -13,7 +13,7 @@ logger = get_logger()
 
 
 def run_connector(
-    connector: BaseExtractor,
+    connector_func: Callable[[], BaseExtractor],
     name: str,
     description: str,
     platform: Optional[Platform] = None,
@@ -23,8 +23,8 @@ def run_connector(
 
     Parameters
     ----------
-    connector: BaseExtractor
-        The connector instance to run
+    connector_func : Callable[[], Collection[ENTITY_TYPES]]
+        The function to create the instance of connector and exec run_async
     name : str
         Name of the connector
     description : str
@@ -47,7 +47,9 @@ def run_connector(
     stacktrace = None
 
     entities: Collection[ENTITY_TYPES] = []
+    connector: Optional[BaseExtractor] = None
     try:
+        connector = connector_func()
         entities = connector.run_async()
         if connector.status is RunStatus.FAILURE:
             logger.warning(f"Some of {name}'s entities cannot be parsed!")
@@ -68,7 +70,7 @@ def run_connector(
     if file_sink_config is not None:
         file_sink = FileSink(file_sink_config)
 
-    if file_sink:
+    if file_sink and connector:
         file_sink.write_events(events)
         file_sink.write_execution_logs()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.136"
+version = "0.13.137"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/common/test_runner.py
+++ b/tests/common/test_runner.py
@@ -61,7 +61,7 @@ def test_run_connector() -> None:
     file_sink_config = FileSinkConfig(directory=directory, batch_size_bytes=1000000)
     dummy_connector = DummyConnector(BaseConfig(output=OutputConfig()))
     events, run_metadata = run_connector(
-        dummy_connector,
+        lambda: dummy_connector,
         "dummy_connector",
         "dummy connector",
         file_sink_config=file_sink_config,


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

We can't initialize the class before entering `run_cli` or we can't catch the exceptions

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

- Revert the change to passing a function to `run_cli`

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

- Add unit tests
- Modify snowflake connector to throw exception locally and able to get the output files

<!--
  Describe how the change was tested end-to-end.
-->

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
