### PR TITLE
Optimize queries used in Snowflake lineage connector

### DIFF
--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -743,8 +743,8 @@ class SnowflakeExtractor(BaseExtractor):
                 JOIN SNOWFLAKE.ACCOUNT_USAGE.ACCESS_HISTORY a
                   ON a.QUERY_ID = q.QUERY_ID
                 WHERE EXECUTION_STATUS = 'SUCCESS'
-                  AND START_TIME > %s AND START_TIME <= %s
-                  AND QUERY_START_TIME > %s AND QUERY_START_TIME <= %s
+                  AND q.START_TIME > %s AND q.START_TIME <= %s
+                  AND a.QUERY_START_TIME > %s AND a.QUERY_START_TIME <= %s
                   {exclude_username_clause(self._query_log_excluded_usernames)}
                 ORDER BY q.QUERY_ID
                 LIMIT {self._query_log_fetch_size} OFFSET %s

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.138"
+version = "0.13.139"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

It takes an exceedingly long time (> 1.5 hours) to run the Snowflake lineage crawler against large `Snowflake.AccountUnage.QUERY_HISTORY` views.

Turns out that [similar to `ACCESS_HISTORY`](https://docs.snowflake.com/en/user-guide/access-history#querying-the-access-history-view), we must also specify a filter against `START_TIME` in order to query `QUERY_HISTORY` efficiently. 

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Specify the `START_TIME` filter for `QUERY_HISTORY` and use inner JOIN when joining with  `ACCESS_HISTORY` in Snowflake lineage connector
- Qualify the filters in the base Snowflake connector to avoid confusion.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified that the MCEs before & after the changes are identical. Observed an order of magnitude improvement in performance:

Before:
```
Ended running with RunStatus.SUCCESS at 2024-03-14 08:54:28.949943, fetched 78 entities, took 217.1s
```

After:
```
Ended running with RunStatus.SUCCESS at 2024-03-14 08:47:54.532785, fetched 78 entities, took 27.6s
```

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
