### PR TITLE
Missing Metabase to Redshift lineage [sc-25155]

### DIFF
--- a/metaphor/metabase/extractor.py
+++ b/metaphor/metabase/extractor.py
@@ -41,7 +41,7 @@ class DatabaseInfo:
 
 
 class MetabaseExtractor(BaseExtractor):
-    """Tableau metadata extractor"""
+    """Metabase metadata extractor"""
 
     _description = "Metabase metadata crawler"
     _platform = Platform.METABASE
@@ -186,7 +186,7 @@ class MetabaseExtractor(BaseExtractor):
         dashboard_details = self._fetch_asset("dashboard", dashboard_id)
         name = dashboard_details["name"]
 
-        cards = dashboard_details.get("ordered_cards", [])
+        cards = dashboard_details.get("dashcards", [])
         charts, upstream_datasets = [], set()
         for card in cards:
             card_id = card.get("card_id")

--- a/poetry.lock
+++ b/poetry.lock
@@ -6120,4 +6120,4 @@ unity-catalog = ["databricks-sdk", "databricks-sql-connector"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.12"
-content-hash = "c3e2ecd4398db7e8760c7ca2f8c9e9830d9346abcfecdc832511c0558c26fa6e"
+content-hash = "dbfa0dc73ebf7e91459e004c3ca014a37e83fcadbdb16a3b9c1f17e2d825a43f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.141"
+version = "0.13.142"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]
@@ -61,7 +61,7 @@ setuptools = "^69.2.0"
 smart-open = "^7.0.1"
 snowflake-connector-python = { version = "^3.7.1", optional = true }
 SQLAlchemy = { version = "^1.4.46", optional = true}
-sql-metadata = { version = "^2.8.0", optional = true }
+sql-metadata = { version = "^2.10.0", optional = true }
 sqllineage = { version = "~=1.3.8", optional = true }
 tableauserverclient = { version = "^0.25", optional = true }
 thoughtspot_rest_api_v1 = { version = "1.5.3", optional = true }

--- a/tests/metabase/data/dashboard101.json
+++ b/tests/metabase/data/dashboard101.json
@@ -2,7 +2,7 @@
   "description": "This is Metabase dashboard for clean rides",
   "archived": false,
   "collection_position": null,
-  "ordered_cards": [
+  "dashcards": [
     {
       "size_x": 4,
       "series": [],


### PR DESCRIPTION
### 🤔 Why?

The Metabase API respones structure for the dashboard has changed.

### 🤓 What?

- use `dashcards` field instead of `ordered_cards` field in a dashboard to get cards

### 🧪 Tested?

tested against metaphor metabase instance and verified the MCE

### ☑️ Checks


- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
