### PR TITLE
Output log.zip for invalid connector configs

### DIFF
--- a/metaphor/common/runner.py
+++ b/metaphor/common/runner.py
@@ -69,10 +69,10 @@ def run_connector(
     file_sink = None
     if file_sink_config is not None:
         file_sink = FileSink(file_sink_config)
+        file_sink.write_execution_logs()
 
     if file_sink and connector:
         file_sink.write_events(events)
-        file_sink.write_execution_logs()
 
         # Query logs are only collected when we have a destination to write to.
         query_log_sink = file_sink.get_query_log_sink()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.152"
+version = "0.13.153"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Currently no `log.zip` file is generated when an invalid crawler config is supplied. 

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Fix the bug introduced in https://github.com/MetaphorData/connectors/pull/794.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified that log.zip is generated for invalid configs:

<img width="729" alt="Screenshot 2024-03-28 at 3 35 11 PM" src="https://github.com/MetaphorData/connectors/assets/24240669/3bccd01f-c47c-490c-a3b3-cfdb3028e139">

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
