### PR TITLE
[sc-25548] Ignore duplicate snowflake tags

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.153"
+version = "0.13.154"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Turns out Snowflake's account usage table can have duplicate tags in them, so we need to weed out the duplicate ones when updating object tags.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Check if tag already exists in object's tag field (`systemTags` for datasets, `tags` for columns`), only insert new tag if it is not there.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

- Added new test case.
- Tested locally.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
