### PR TITLE
bugfix: redshift profiler null count should be `COUNT(1) - COUNT(column)`

### DIFF
--- a/metaphor/postgresql/profile/extractor.py
+++ b/metaphor/postgresql/profile/extractor.py
@@ -121,7 +121,7 @@ class PostgreSQLProfileExtractor(PostgreSQLExtractor):
                 entities.append(f"COUNT(DISTINCT {column})")
 
             if nullable and column_statistics.null_count:
-                entities.append(f"COUNT({column})")
+                entities.append(f"COUNT(1) - COUNT({column})")
 
             if is_numeric:
                 if column_statistics.min_value:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.154"
+version = "0.13.155"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/postgresql/profile/test_extractor.py
+++ b/tests/postgresql/profile/test_extractor.py
@@ -52,8 +52,8 @@ def test_build_profiling_query():
     expected = [
         (
             'SELECT COUNT(1), COUNT(DISTINCT "id"), COUNT(DISTINCT "price"), '
-            'COUNT("price"), MIN("price"), MAX("price"), AVG("price"::double precision), '
-            'COUNT(DISTINCT "year"), COUNT("year"), MIN("year"), MAX("year"), AVG("year"::double precision) '
+            'COUNT(1) - COUNT("price"), MIN("price"), MAX("price"), AVG("price"::double precision), '
+            'COUNT(DISTINCT "year"), COUNT(1) - COUNT("year"), MIN("year"), MAX("year"), AVG("year"::double precision) '
             "FROM foo"
         )
     ]
@@ -93,18 +93,18 @@ def test_build_profiling_query_multiple_sql():
         (
             "SELECT "
             'COUNT(1), COUNT(DISTINCT "id"), COUNT(DISTINCT "price"), '
-            'COUNT("price"), MIN("price") '
+            'COUNT(1) - COUNT("price"), MIN("price") '
             "FROM foo"
         ),
         (
             "SELECT "
             'MAX("price"), AVG("price"::double precision), COUNT(DISTINCT "year"), '
-            'COUNT("year"), MIN("year") '
+            'COUNT(1) - COUNT("year"), MIN("year") '
             "FROM foo"
         ),
         (
             "SELECT "
-            'MAX("year"), AVG("year"::double precision), COUNT(DISTINCT "name"), COUNT("name") '
+            'MAX("year"), AVG("year"::double precision), COUNT(DISTINCT "name"), COUNT(1) - COUNT("name") '
             "FROM foo"
         ),
     ]
@@ -133,7 +133,7 @@ def test_build_profiling_query_with_sampling():
     expected = [
         (
             'SELECT COUNT(1), COUNT(DISTINCT "id"), COUNT(DISTINCT "price"), '
-            'COUNT("price"), MIN("price"), MAX("price"), AVG("price"::double precision) '
+            'COUNT(1) - COUNT("price"), MIN("price"), MAX("price"), AVG("price"::double precision) '
             "FROM foo WHERE random() < 0.01"
         )
     ]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Null count = `COUNT(1) - COUNT(column)`, not `COUNT(column)`.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Fix the above bug.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Tested locally.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
