### PR TITLE
Output the correct data platform for Redshift profiler

### DIFF
--- a/metaphor/redshift/lineage/extractor.py
+++ b/metaphor/redshift/lineage/extractor.py
@@ -9,6 +9,7 @@ from metaphor.common.entity_id import to_dataset_entity_id
 from metaphor.common.event_util import ENTITY_TYPES
 from metaphor.common.logger import get_logger
 from metaphor.common.utils import unique_list
+from metaphor.models.crawler_run_metadata import Platform
 from metaphor.models.metadata_change_event import (
     DataPlatform,
     Dataset,
@@ -26,6 +27,8 @@ class RedshiftLineageExtractor(PostgreSQLExtractor):
     """Redshift lineage metadata extractor"""
 
     _description = "Redshift data lineage crawler"
+    _platform = Platform.REDSHIFT
+    _dataset_platform = DataPlatform.REDSHIFT
 
     @staticmethod
     def from_config_file(config_file: str) -> "RedshiftLineageExtractor":

--- a/metaphor/redshift/profile/extractor.py
+++ b/metaphor/redshift/profile/extractor.py
@@ -1,4 +1,6 @@
 from metaphor.common.logger import get_logger
+from metaphor.models.crawler_run_metadata import Platform
+from metaphor.models.metadata_change_event import DataPlatform
 from metaphor.postgresql.profile.extractor import PostgreSQLProfileExtractor
 from metaphor.redshift.profile.config import RedshiftProfileRunConfig
 from metaphor.redshift.utils import exclude_system_databases
@@ -10,6 +12,8 @@ class RedshiftProfileExtractor(PostgreSQLProfileExtractor):
     """Redshift data profile extractor"""
 
     _description = "Redshift data profile crawler"
+    _platform = Platform.REDSHIFT
+    _dataset_platform = DataPlatform.REDSHIFT
 
     @staticmethod
     def from_config_file(config_file: str) -> "RedshiftProfileExtractor":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.155"
+version = "0.13.156"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Similar to https://github.com/MetaphorData/connectors/pull/792, but for redshift profiler.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled. The changes to `redshift.lineage` connector aren't necessary but were still added just in case. 

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Manually verified the MCE output against a production instance.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
