### PR TITLE
User get notifications when dbt crawler run

### DIFF
--- a/metaphor/dbt/extractor.py
+++ b/metaphor/dbt/extractor.py
@@ -75,13 +75,9 @@ class DbtExtractor(BaseExtractor):
         entities: List[ENTITY_TYPES] = []
         entities.extend(self._datasets.values())
         entities.extend(
-            map(
-                lambda item: item[1],
-                filter(
-                    lambda item: item[0] not in self._referenced_virtual_views,
-                    self._virtual_views.items(),
-                ),
-            )
+            v
+            for k, v in self._virtual_views.items()
+            if k not in self._referenced_virtual_views
         )
         entities.extend(self._metrics.values())
         return entities

--- a/metaphor/dbt/extractor.py
+++ b/metaphor/dbt/extractor.py
@@ -1,5 +1,5 @@
 import json
-from typing import Collection, Dict, List
+from typing import Collection, Dict, List, Set
 
 from metaphor.common.base_extractor import BaseExtractor
 from metaphor.common.event_util import ENTITY_TYPES
@@ -40,6 +40,7 @@ class DbtExtractor(BaseExtractor):
         self._datasets: Dict[str, Dataset] = {}
         self._virtual_views: Dict[str, VirtualView] = {}
         self._metrics: Dict[str, Metric] = {}
+        self._referenced_virtual_views: Set[str] = set()
 
         add_debug_file(config.manifest)
         if config.run_results:
@@ -67,11 +68,20 @@ class DbtExtractor(BaseExtractor):
             self._datasets,
             self._virtual_views,
             self._metrics,
+            self._referenced_virtual_views,
         )
         artifact_parser.parse(manifest_json, run_results_json)
 
         entities: List[ENTITY_TYPES] = []
         entities.extend(self._datasets.values())
-        entities.extend(self._virtual_views.values())
+        entities.extend(
+            map(
+                lambda item: item[1],
+                filter(
+                    lambda item: item[0] not in self._referenced_virtual_views,
+                    self._virtual_views.items(),
+                ),
+            )
+        )
         entities.extend(self._metrics.values())
         return entities

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.165"
+version = "0.13.166"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/dbt/data/ride_share/manifest.json
+++ b/tests/dbt/data/ride_share/manifest.json
@@ -616,6 +616,96 @@
       "latest_version": null,
       "deprecation_date": null
     },
+    "model.london_bike_analysis.reference_model": {
+      "database": "DEMO_DB",
+      "schema": "METAPHOR",
+      "name": "reference_model",
+      "resource_type": "model",
+      "package_name": "other_project",
+      "path": "",
+      "original_file_path": "",
+      "unique_id": "model.london_bike_analysis.reference_model",
+      "fqn": [
+        "london_bike_analysis",
+        "rides",
+        "reference_model"
+      ],
+      "alias": "reference_model",
+      "checksum": {
+        "name": "sha256",
+        "checksum": "f2fddc3c490d40e45314567be849c98f9db701319fe3c60c43a2bc442557925f"
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": null,
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "group": null,
+        "materialized": "view",
+        "incremental_strategy": null,
+        "persist_docs": {},
+        "post-hook": [],
+        "pre-hook": [],
+        "quoting": {},
+        "column_types": {},
+        "full_refresh": null,
+        "unique_key": null,
+        "on_schema_change": "ignore",
+        "on_configuration_change": "apply",
+        "grants": {},
+        "packages": [],
+        "docs": {
+          "show": true,
+          "node_color": null
+        },
+        "contract": {
+          "enforced": false,
+          "alias_types": true
+        },
+        "access": "protected"
+      },
+      "tags": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "group": null,
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "build_path": null,
+      "deferred": false,
+      "unrendered_config": {
+        "alias": "",
+        "schema": "",
+        "database": ""
+      },
+      "created_at": 1713186099.1519442,
+      "relation_name": "",
+      "raw_code": "",
+      "language": "sql",
+      "refs": [],
+      "sources": [],
+      "metrics": [],
+      "depends_on": {
+        "macros": [],
+        "nodes": []
+      },
+      "compiled_path": null,
+      "contract": {
+        "enforced": false,
+        "alias_types": true,
+        "checksum": null
+      },
+      "access": "public",
+      "constraints": [],
+      "version": null,
+      "latest_version": null,
+      "deprecation_date": null
+    },
     "snapshot.london_bike_analysis.cycle_hire_snapshot": {
       "database": "DEMO_DB",
       "schema": "snapshots",


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

Some dbt models are imported using [project-dependencies](https://docs.getdbt.com/docs/collaborate/govern/project-dependencies). That means the dbt crawler may generate two entities with the same logical ID but we should not generate the imported one.

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

- Filter models the `package_name` is not equal to `project_name` if `project_name` is set.

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

Add test case.

<!--
  Describe how the change was tested end-to-end.
-->

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
