### PR TITLE
Not use SHOW SHARES [sc-25711]

### DIFF
--- a/metaphor/snowflake/README.md
+++ b/metaphor/snowflake/README.md
@@ -28,12 +28,9 @@ grant usage on warehouse identifier($warehouse) to role identifier($role);
 
 -- Grant privilege to access Snowflake Account Usage views:
 grant imported privileges on database snowflake to role identifier($role);
-
--- (Optional) Grant privilege to "show shares" for inbound shared databases
-grant import share on account to identifier($role);
 ```
 
-For each database, run the following statements to grant the required privileges:
+For each database, including the inbound shared databases, run the following statements to grant the required privileges:
 
 ```sql
 set db = '<database>';

--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -186,13 +186,10 @@ class SnowflakeExtractor(BaseExtractor):
 
     @staticmethod
     def _fetch_shared_databases(cursor: SnowflakeCursor) -> List[str]:
-        cursor.execute("SHOW SHARES")
-        shared_database = [db[4].lower() for db in cursor if db[1] == "INBOUND"]
         cursor.execute(
             "SELECT database_name FROM information_schema.databases WHERE type = 'IMPORTED DATABASE' ORDER BY database_name"
         )
-        shared_database += [db[0].lower() for db in cursor]
-        return list(set(shared_database))
+        return [db[0].lower() for db in cursor]
 
     @staticmethod
     def _fetch_secure_views(cursor: SnowflakeCursor) -> Set[str]:

--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -179,8 +179,11 @@ class SnowflakeExtractor(BaseExtractor):
 
     @staticmethod
     def fetch_databases(cursor: SnowflakeCursor) -> List[str]:
+        """
+        Fetch all databases from Snowflake, including shared/imported databases.
+        """
         cursor.execute(
-            "SELECT database_name FROM information_schema.databases WHERE type != 'IMPORTED DATABASE' ORDER BY database_name"
+            "SELECT database_name FROM information_schema.databases ORDER BY database_name"
         )
         return [db[0].lower() for db in cursor]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.168"
+version = "0.13.169"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/snowflake/test_extractor.py
+++ b/tests/snowflake/test_extractor.py
@@ -476,31 +476,13 @@ def test_fetch_shared_databases(mock_connect: MagicMock):
     mock_cursor = MagicMock()
 
     mock_cursor.__iter__.side_effect = [
-        iter(
-            [
-                (
-                    None,
-                    "INBOUND",
-                    None,
-                    None,
-                    "shared_1",
-                ),
-                (
-                    None,
-                    "UNKNOWN",
-                    None,
-                    None,
-                    "shared_2",
-                ),
-            ]
-        ),
         iter([("shared_1",), ("shared_3",)]),
     ]
 
     extractor = SnowflakeExtractor(make_snowflake_config())
     results = extractor._fetch_shared_databases(mock_cursor)
 
-    assert set(results) == {"shared_1", "shared_3"}
+    assert results == ["shared_1", "shared_3"]
 
 
 @patch("metaphor.snowflake.extractor.check_access_history")


### PR DESCRIPTION
### 🤔 Why?

The `SHOW SHARES` will return all inbound/outbound shared databases, also including the inbound shared databases that have not been accepted by the receiver.

### 🤓 What?

- Not use `SHOW SHARES`, and use only `information_schema` instead. This does require the access to the imported databases to be granted to the metaphor role.

### 🧪 Tested?

tested on metaphor snowflake instance.

### ☑️ Checks


- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
