### PR TITLE
[sc-25976] Add `database_defaults` to Metabase crawler config

### DIFF
--- a/metaphor/metabase/README.md
+++ b/metaphor/metabase/README.md
@@ -32,7 +32,7 @@ Metabase's API does not provide information on the default schema used to execut
 ```yaml
 database_defaults:
     - id: <id of the database in Metabase>
-      default_schema: <default schema in the SQL platform>
+      default_schema: <default schema for the database>
 ```
 
 #### Output Destination

--- a/metaphor/metabase/README.md
+++ b/metaphor/metabase/README.md
@@ -27,7 +27,7 @@ password: <password>
 
 #### Database Defaults
 
-Metabase parses the SQL queries executed on Redshift, Snowflake and BigQuery, but it is unaware of a query's default schema during its execution. Metaphor's in-app SQL lineage parser will not be able to locate the correct dataset if the query's schema is not provided. To set the SQL platform's default schema, set the `database_defaults` configuration:
+Metabase's API does not provide information on the default schema used to execute [native queries](https://www.metabase.com/glossary/native_query). This makes it difficult to parse the lineage precisely. When this happens, use `database_defaults` to manually set the [database](https://www.metabase.com/docs/latest/databases/start)'s default schema:
 
 ```yaml
 database_defaults:

--- a/metaphor/metabase/README.md
+++ b/metaphor/metabase/README.md
@@ -25,6 +25,16 @@ password: <password>
 
 ### Optional Configurations
 
+#### Database Defaults
+
+Metabase parses the SQL queries executed on Redshift, Snowflake and BigQuery, but it is unaware of a query's default schema during its execution. Metaphor's in-app SQL lineage parser will not be able to locate the correct dataset if the query's schema is not provided. To set the SQL platform's default schema, set the `database_defaults` configuration:
+
+```yaml
+database_defaults:
+    - id: <id of the database in Metabase>
+      default_schema: <default schema in the SQL platform>
+```
+
 #### Output Destination
 
 See [Output Config](../common/docs/output.md) for more information.

--- a/metaphor/metabase/config.py
+++ b/metaphor/metabase/config.py
@@ -1,7 +1,16 @@
+from dataclasses import field
+from typing import List, Optional
+
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.base_config import BaseConfig
 from metaphor.common.dataclass import ConnectorConfig
+
+
+@dataclass
+class MetabaseDatabaseDefaults:
+    id: int
+    default_schema: Optional[str] = None
 
 
 @dataclass(config=ConnectorConfig)
@@ -9,3 +18,5 @@ class MetabaseRunConfig(BaseConfig):
     server_url: str
     username: str
     password: str
+
+    database_defaults: List[MetabaseDatabaseDefaults] = field(default_factory=list)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.181"
+version = "0.13.182"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/metabase/config.yml
+++ b/tests/metabase/config.yml
@@ -2,4 +2,9 @@
 server_url: https://metaphor.metabaseapp.com
 username: foo
 password: bar
+database_defaults:
+  - id: 1
+    default_schema: SCH
+  - id: 2
+    default_schema: SCH2
 output: {}

--- a/tests/metabase/test_config.py
+++ b/tests/metabase/test_config.py
@@ -1,5 +1,5 @@
 from metaphor.common.base_config import OutputConfig
-from metaphor.metabase.config import MetabaseRunConfig
+from metaphor.metabase.config import MetabaseDatabaseDefaults, MetabaseRunConfig
 
 
 def test_yaml_config(test_root_dir):
@@ -9,5 +9,15 @@ def test_yaml_config(test_root_dir):
         server_url="https://metaphor.metabaseapp.com",
         username="foo",
         password="bar",
+        database_defaults=[
+            MetabaseDatabaseDefaults(
+                id=1,
+                default_schema="SCH",
+            ),
+            MetabaseDatabaseDefaults(
+                id=2,
+                default_schema="SCH2",
+            ),
+        ],
         output=OutputConfig(),
     )

--- a/tests/metabase/test_extractor.py
+++ b/tests/metabase/test_extractor.py
@@ -56,3 +56,37 @@ async def test_extractor(
     events = [EventUtil.trim_event(e) for e in await extractor.extract()]
 
     assert events == load_json(f"{test_root_dir}/metabase/expected.json")
+
+
+def test_parse_database(test_root_dir: str):
+    config = MetabaseRunConfig.from_yaml_file(f"{test_root_dir}/metabase/config.yml")
+    extractor = MetabaseExtractor(config)
+    bq_database = {
+        "details": {
+            "project-id": "bq_db",
+        },
+        "id": 1,
+        "engine": "bigquery-cloud-sdk",
+    }
+
+    redshift_database = {
+        "details": {
+            "db": "redshift_db",
+        },
+        "id": 2,
+        "engine": "redshift",
+    }
+
+    snowflake_database = {
+        "details": {"db": "snowflake_db", "account": "john.doe@metaphor.io"},
+        "id": 3,
+        "engine": "snowflake",
+    }
+
+    for database in [bq_database, redshift_database, snowflake_database]:
+        extractor._parse_database(database)
+
+    assert len(extractor._databases) == 3
+    assert extractor._databases[1].schema == "SCH"
+    assert extractor._databases[2].schema == "SCH2"
+    assert not extractor._databases[3].schema


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Metabase does not know a SQL query's default schema on Snowflake, RedShift and BigQuery. This causes our lineage parser unable to locate the correct upstream dataset, and in some instances the lineage parser to straight up fail.

Since Metabase API does not provide us with the default schema, best we can do is to specify this in the configs.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Add config for `database_defaults`, which contains `default_schema`
- Use a database's `default_schema` when parsing database info from metabase api

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

- Unit test
- Tested locally

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
