### PR TITLE
[sc-26028] Override inherited system tags

### DIFF
--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -65,8 +65,9 @@ from metaphor.snowflake.utils import (
     DatasetInfo,
     QueryWithParam,
     SnowflakeTableType,
+    append_column_system_tag,
+    append_dataset_system_tag,
     check_access_history,
-    dedup_dataset_system_tags,
     exclude_username_clause,
     fetch_query_history_count,
     str_to_source_type,
@@ -165,10 +166,6 @@ class SnowflakeExtractor(BaseExtractor):
 
         datasets = list(self._datasets.values())
         tag_datasets(datasets, self._tag_matchers)
-
-        # Dedup system tags
-        for dataset in datasets:
-            dedup_dataset_system_tags(dataset)
 
         entities: List[ENTITY_TYPES] = []
         entities.extend(datasets)
@@ -502,57 +499,6 @@ class SnowflakeExtractor(BaseExtractor):
             )
         )
 
-    def _append_tag(
-        self, dataset_key: str, key: str, value: str, column_name: Optional[str]
-    ):
-        """
-        Appends a tag to the dataset. If column_name is provided, it is a column tag.
-        """
-        dataset = self._datasets.get(dataset_key)
-        tag = SnowflakeExtractor._build_tag_string(key, value)
-
-        if dataset is None or dataset.schema is None:
-            logger.error(f"Table {dataset_key} not found for tag {tag}")
-            return
-
-        if not column_name:
-            assert dataset.system_tags and dataset.system_tags.tags is not None
-            dataset.system_tags.tags.append(
-                SystemTag(
-                    key=key,
-                    system_tag_source=SystemTagSource.SNOWFLAKE,
-                    value=value,
-                )
-            )
-
-        # When we get here the fields should already be populated.
-        if dataset.schema.fields:
-            if column_name:
-                field = next(
-                    (
-                        fd
-                        for fd in dataset.schema.fields
-                        if fd.field_path
-                        and fd.field_path.upper() == column_name.upper()
-                    ),
-                    None,
-                )
-                if not field:
-                    logger.error(
-                        f"Field {column_name} not found in {dataset_key} for tag {tag}"
-                    )
-                    return
-                if not field.tags:
-                    field.tags = []
-                other_field_tags = [t for t in field.tags if t.split("=", 1)[0] != key]
-                field.tags = other_field_tags + [tag]
-
-            else:
-                for field in dataset.schema.fields:
-                    if not field.tags:
-                        field.tags = []
-                    field.tags.append(tag)
-
     def _fetch_tags(self, cursor: SnowflakeCursor) -> None:
         query = """
         SELECT TAG_NAME, TAG_VALUE, DOMAIN, OBJECT_DATABASE, OBJECT_SCHEMA, OBJECT_NAME, COLUMN_NAME
@@ -567,30 +513,65 @@ class SnowflakeExtractor(BaseExtractor):
         """
         cursor.execute(query)
 
-        for key, value, object_type, database, schema, object_name, column in cursor:
+        qq = list()
+        for (
+            key,
+            value,
+            object_type,
+            database,
+            schema,
+            object_name,
+            column_name,
+        ) in cursor:
+            qq.append(
+                (key, value, object_type, database, schema, object_name, column_name)
+            )
             if object_type in {"DATABASE", "SCHEMA"}:
                 self._add_hierarchy_system_tag(
                     database, object_name, object_type, key, value
                 )
 
-            if object_type == "DATABASE":
-                key_prefix = dataset_normalized_name(db=object_name)
-            elif object_type == "SCHEMA":
-                key_prefix = dataset_normalized_name(db=database, schema=object_name)
-            else:
-                key_prefix = dataset_normalized_name(
-                    db=database, schema=schema, table=object_name
-                )
+            system_tag = SystemTag(
+                key=key, value=value, system_tag_source=SystemTagSource.SNOWFLAKE
+            )
 
             if object_type in {"DATABASE", "SCHEMA"}:
+                db = object_name if object_type == "DATABASE" else database
+                sch = None if object_type == "DATABASE" else object_name
+                prefix = f"{dataset_normalized_name(db=db, schema=sch)}."
                 for dataset_key in self._datasets:
                     # Need to make sure key_prefix == `db`.`schema`
-                    if dataset_key.startswith(f"{key_prefix}."):
-                        self._append_tag(dataset_key, key, value, None)
-            else:
-                self._append_tag(
-                    key_prefix, key, value, column if object_type == "COLUMN" else None
+                    if dataset_key.startswith(prefix):
+                        append_dataset_system_tag(
+                            self._datasets[dataset_key], system_tag
+                        )
+
+            elif object_type == "TABLE":
+                dataset_key = dataset_normalized_name(
+                    db=database, schema=schema, table=object_name
                 )
+                if dataset_key not in self._datasets:
+                    logger.warning(
+                        f"Ignoring tag {system_tag} for excluded dataset {dataset_key}"
+                    )
+                else:
+                    append_dataset_system_tag(self._datasets[dataset_key], system_tag)
+
+            elif object_type == "COLUMN":
+                dataset_key = dataset_normalized_name(
+                    db=database, schema=schema, table=object_name
+                )
+                if dataset_key not in self._datasets:
+                    logger.warning(
+                        f"Ignoring tag {system_tag} for excluded dataset {dataset_key}"
+                    )
+                else:
+                    append_column_system_tag(
+                        self._datasets[dataset_key], system_tag, column_name
+                    )
+            else:
+                logger.error(f"Unknown object_type: {object_type}")
+        print("qq")
 
     def _fetch_query_logs(self) -> Iterator[QueryLog]:
         logger.info("Fetching Snowflake query logs")

--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -66,6 +66,7 @@ from metaphor.snowflake.utils import (
     QueryWithParam,
     SnowflakeTableType,
     check_access_history,
+    dedup_dataset_system_tags,
     exclude_username_clause,
     fetch_query_history_count,
     str_to_source_type,
@@ -167,8 +168,7 @@ class SnowflakeExtractor(BaseExtractor):
 
         # Dedup system tags
         for dataset in datasets:
-            assert dataset.system_tags and dataset.system_tags.tags is not None
-            dataset.system_tags.tags = list(set(dataset.system_tags.tags))
+            dedup_dataset_system_tags(dataset)
 
         entities: List[ENTITY_TYPES] = []
         entities.extend(datasets)

--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -513,7 +513,6 @@ class SnowflakeExtractor(BaseExtractor):
         """
         cursor.execute(query)
 
-        qq = list()
         for (
             key,
             value,
@@ -523,9 +522,6 @@ class SnowflakeExtractor(BaseExtractor):
             object_name,
             column_name,
         ) in cursor:
-            qq.append(
-                (key, value, object_type, database, schema, object_name, column_name)
-            )
             if object_type in {"DATABASE", "SCHEMA"}:
                 self._add_hierarchy_system_tag(
                     database, object_name, object_type, key, value
@@ -571,7 +567,6 @@ class SnowflakeExtractor(BaseExtractor):
                     )
             else:
                 logger.error(f"Unknown object_type: {object_type}")
-        print("qq")
 
     def _fetch_query_logs(self) -> Iterator[QueryLog]:
         logger.info("Fetching Snowflake query logs")

--- a/metaphor/snowflake/utils.py
+++ b/metaphor/snowflake/utils.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import time
 from concurrent import futures

--- a/metaphor/snowflake/utils.py
+++ b/metaphor/snowflake/utils.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import time
 from concurrent import futures
@@ -10,9 +11,11 @@ from snowflake.connector import SnowflakeConnection
 from snowflake.connector.cursor import SnowflakeCursor
 
 from metaphor.models.metadata_change_event import (
+    Dataset,
     MaterializationType,
     SnowflakeStreamSourceType,
     SnowflakeStreamType,
+    SystemTag,
 )
 
 logger = logging.getLogger(__name__)
@@ -220,3 +223,11 @@ def fetch_query_history_count(
     if result is not None:
         return result[0]
     return 0
+
+
+def dedup_dataset_system_tags(dataset: Dataset) -> None:
+    assert dataset.system_tags and dataset.system_tags.tags is not None
+    dataset.system_tags.tags = [
+        SystemTag.from_dict(json.loads(x))
+        for x in set(json.dumps(tag.to_dict()) for tag in dataset.system_tags.tags)
+    ]

--- a/metaphor/snowflake/utils.py
+++ b/metaphor/snowflake/utils.py
@@ -227,7 +227,11 @@ def fetch_query_history_count(
 
 def dedup_dataset_system_tags(dataset: Dataset) -> None:
     assert dataset.system_tags and dataset.system_tags.tags is not None
-    dataset.system_tags.tags = [
-        SystemTag.from_dict(json.loads(x))
-        for x in set(json.dumps(tag.to_dict()) for tag in dataset.system_tags.tags)
-    ]
+    deduped: List[SystemTag] = list()
+    for tag in dataset.system_tags.tags:
+        # Check if the tag is already in deduped, only append if it does not
+        if not next(
+            (x for x in deduped if x.key == tag.key and x.value == tag.value), None
+        ):
+            deduped.append(tag)
+    dataset.system_tags.tags = deduped

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.183"
+version = "0.13.184"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/snowflake/test_utils.py
+++ b/tests/snowflake/test_utils.py
@@ -1,54 +1,7 @@
-from metaphor.models.metadata_change_event import (
-    Dataset,
-    SystemTag,
-    SystemTags,
-    SystemTagSource,
-)
-from metaphor.snowflake.utils import dedup_dataset_system_tags, to_quoted_identifier
+from metaphor.snowflake.utils import to_quoted_identifier
 
 
 def test_to_quoted_identifier():
     assert to_quoted_identifier([None, "", "a", "b", "c"]) == '"a"."b"."c"'
 
     assert to_quoted_identifier(["db", "sc", 'ta"@BLE']) == '"db"."sc"."ta""@BLE"'
-
-
-def test_dedup_dataset_system_tags():
-    dataset = Dataset(
-        system_tags=SystemTags(
-            tags=[
-                SystemTag(
-                    key="a",
-                    system_tag_source=SystemTagSource.SNOWFLAKE,
-                    value="b",
-                ),
-                SystemTag(
-                    key="a",
-                    system_tag_source=SystemTagSource.SNOWFLAKE,
-                    value="b",
-                ),
-                SystemTag(
-                    key="aa",
-                    system_tag_source=SystemTagSource.SNOWFLAKE,
-                    value="bc",
-                ),
-                SystemTag(
-                    key="a",
-                    system_tag_source=SystemTagSource.SNOWFLAKE,
-                    value="b",
-                ),
-            ]
-        )
-    )
-
-    dedup_dataset_system_tags(dataset)
-    assert dataset.system_tags and dataset.system_tags.tags
-    assert len(dataset.system_tags.tags) == 2
-    assert (
-        SystemTag(key="a", system_tag_source=SystemTagSource.SNOWFLAKE, value="b")
-        in dataset.system_tags.tags
-    )
-    assert (
-        SystemTag(key="aa", system_tag_source=SystemTagSource.SNOWFLAKE, value="bc")
-        in dataset.system_tags.tags
-    )

--- a/tests/snowflake/test_utils.py
+++ b/tests/snowflake/test_utils.py
@@ -1,7 +1,54 @@
-from metaphor.snowflake.utils import to_quoted_identifier
+from metaphor.models.metadata_change_event import (
+    Dataset,
+    SystemTag,
+    SystemTags,
+    SystemTagSource,
+)
+from metaphor.snowflake.utils import dedup_dataset_system_tags, to_quoted_identifier
 
 
 def test_to_quoted_identifier():
     assert to_quoted_identifier([None, "", "a", "b", "c"]) == '"a"."b"."c"'
 
     assert to_quoted_identifier(["db", "sc", 'ta"@BLE']) == '"db"."sc"."ta""@BLE"'
+
+
+def test_dedup_dataset_system_tags():
+    dataset = Dataset(
+        system_tags=SystemTags(
+            tags=[
+                SystemTag(
+                    key="a",
+                    system_tag_source=SystemTagSource.SNOWFLAKE,
+                    value="b",
+                ),
+                SystemTag(
+                    key="a",
+                    system_tag_source=SystemTagSource.SNOWFLAKE,
+                    value="b",
+                ),
+                SystemTag(
+                    key="aa",
+                    system_tag_source=SystemTagSource.SNOWFLAKE,
+                    value="bc",
+                ),
+                SystemTag(
+                    key="a",
+                    system_tag_source=SystemTagSource.SNOWFLAKE,
+                    value="b",
+                ),
+            ]
+        )
+    )
+
+    dedup_dataset_system_tags(dataset)
+    assert dataset.system_tags and dataset.system_tags.tags
+    assert len(dataset.system_tags.tags) == 2
+    assert (
+        SystemTag(key="a", system_tag_source=SystemTagSource.SNOWFLAKE, value="b")
+        in dataset.system_tags.tags
+    )
+    assert (
+        SystemTag(key="aa", system_tag_source=SystemTagSource.SNOWFLAKE, value="bc")
+        in dataset.system_tags.tags
+    )


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Instead of deduping system tags, what we need to do is to properly override inherited system tags: 

>It is possible to override an inherited tag on a given object. For example, if a table column inherits the tag named cost_center with a string value called sales, the tag can be updated with a more specific tag string value such as sales_na, to specify the North America sales cost center. Additionally, a new tag can be applied to the table column. Use an [ALTER TABLE … ALTER COLUMN](https://docs.snowflake.com/en/sql-reference/sql/alter-table-column) statement to update the tag string value on the column and to set one or more additional tags on a column.

https://docs.snowflake.com/en/user-guide/object-tagging#tag-lineage

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Refactor
- Implement logic for overriding inherited system tags.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

- Added unit test.
- Tested on our Snowflake instance.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
