### PR TITLE
bump models version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3106,13 +3106,13 @@ files = [
 
 [[package]]
 name = "metaphor-models"
-version = "0.33.5"
+version = "0.33.6"
 description = ""
 optional = false
 python-versions = "<4.0,>=3.8"
 files = [
-    {file = "metaphor_models-0.33.5-py3-none-any.whl", hash = "sha256:4db2ef94b2ac8ecdde4d2d16e1e9a9a46e6b5a53bfffb944c30f2dd7cb8ad2d2"},
-    {file = "metaphor_models-0.33.5.tar.gz", hash = "sha256:2e200c779c47dcc32ee58f82ca30518f600f20c5e251495d1f4d66fc66e697f5"},
+    {file = "metaphor_models-0.33.6-py3-none-any.whl", hash = "sha256:1612cafeea426adc5e8b9dec8411c85c5293edf7461259437aa92b42570fbe9d"},
+    {file = "metaphor_models-0.33.6.tar.gz", hash = "sha256:19e24616040b9e4dfcdcde29cd56b448187604422159ce848329ae107c82b3f1"},
 ]
 
 [[package]]
@@ -6318,4 +6318,4 @@ unity-catalog = ["databricks-sdk", "databricks-sql-connector"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.12"
-content-hash = "6cc6d8afd6847b4a58cc41b357fc2a43e00bacc07684c105b871fcd7e6833b62"
+content-hash = "ed1bf4b9a02457f7e315ff0e5a4baf72371de0c9aa0f43c1297b402eff6e3014"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.184"
+version = "0.13.185"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]
@@ -41,7 +41,7 @@ llama-index-readers-confluence = { version = "^0.1.4", optional = true }
 llama-index-readers-notion = { version = "^0.1.6", optional = true }
 looker-sdk = { version = "^24.2.0", optional = true }
 lxml = { version = "~=5.0.0", optional = true }
-metaphor-models = "0.33.5"
+metaphor-models = "0.33.6"
 more-itertools = { version = "^10.1.0", optional = true }
 msal = { version = "^1.28.0", optional = true }
 msgraph-beta-sdk = { version = "1.2.0", optional = true }


### PR DESCRIPTION
### 🤔 Why?

To prevent emitting `lookerView.query.referenecedView` field. The latest parser should have stopped using that field already.

### 🤓 What?

- bump metaphor-models version

### 🧪 Tested?

 unit tests pass

### ☑️ Checks


- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
