### PR TITLE
Handle no longer available Snowflake shared [sc-25949]

### DIFF
--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -222,7 +222,8 @@ class SnowflakeExtractor(BaseExtractor):
         try:
             cursor.execute("USE " + database_name)
         except ProgrammingError:
-            raise ValueError(f"Invalid or inaccessible database {database_name}")
+            logger.exception(f"Invalid or inaccessible database {database_name}")
+            return {}
 
         cursor.execute(self.FETCH_TABLE_QUERY)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -5339,37 +5339,37 @@ files = [
 
 [[package]]
 name = "snowflake-connector-python"
-version = "3.8.1"
+version = "3.9.1"
 description = "Snowflake Connector for Python"
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "snowflake-connector-python-3.8.1.tar.gz", hash = "sha256:9bcce1a0d9e212ceecf45edcea02d18e205a95f88cc0470ada4a8bacb54247d5"},
-    {file = "snowflake_connector_python-3.8.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6841c7b37213c1d3caea044b4a5f3f8486911aaa39f2a99a750c0a066df6b389"},
-    {file = "snowflake_connector_python-3.8.1-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:4de973d0d5a579f0eea82e0908123d72e27ee89bd743f39630ee6e92de0c2d8c"},
-    {file = "snowflake_connector_python-3.8.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:67f3608833854427f5611017ba4d7a46eed198b0481ffcaf058155c9cb4e576c"},
-    {file = "snowflake_connector_python-3.8.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e7aebc0ea91d6f387d06b033302628b27aa5a5841aa41a3910343654ae8b318"},
-    {file = "snowflake_connector_python-3.8.1-cp310-cp310-win_amd64.whl", hash = "sha256:50a47e863a278d3716ae3fd7abbfcacc3fa6b855a2e0b3039157c06e2f0ea7d8"},
-    {file = "snowflake_connector_python-3.8.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:76844277162b84aefd3dcf345eb0bf62aab24b1b8a8cd774eb40478b7c9533c0"},
-    {file = "snowflake_connector_python-3.8.1-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:646cb614d41f3285d5636ececff628495f21e9b50a1310e17ac8c90ea63c139a"},
-    {file = "snowflake_connector_python-3.8.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:56c12c079a9fff235fe6fbfd905af7999180b051f8f414a4887c7752bc4961c0"},
-    {file = "snowflake_connector_python-3.8.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0ddadb2e0e854c5737ba883b5b1cc29153792224b7f357e772388995e6b2f382"},
-    {file = "snowflake_connector_python-3.8.1-cp311-cp311-win_amd64.whl", hash = "sha256:56b6b5c09f305022abb9964ca31430f7ce1be8883259d3fdade7d7bd40419656"},
-    {file = "snowflake_connector_python-3.8.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b09da3ab1d7e3be5552dabacacabd9cfcdd4c620828aacf6077d1c408971512c"},
-    {file = "snowflake_connector_python-3.8.1-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:3a53ecf180c23cb1f7c988277c2a76579bfbc5b35d60c3ea6f909bbac5f83c3f"},
-    {file = "snowflake_connector_python-3.8.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29a37c3b1a059cb6320792badfb1d1f131d8a4eb799fb4733fde5c90745af390"},
-    {file = "snowflake_connector_python-3.8.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ac25dc4866700e1a2b47620540a4e40f469bcf718226fc3585199f85228f5b5"},
-    {file = "snowflake_connector_python-3.8.1-cp312-cp312-win_amd64.whl", hash = "sha256:103fce3b03b155d727607b620de64c5fbf94539fb45ca2653b768aab0ecf36f1"},
-    {file = "snowflake_connector_python-3.8.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:63152ac063ddcd9f5dc9ce5fd4c72d9514bc1250b852c3d18504aa9b2b24d5e9"},
-    {file = "snowflake_connector_python-3.8.1-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:322b899861cf104a3548e42a44a548de9a7e21510fdd1849da9e3e96641f9b90"},
-    {file = "snowflake_connector_python-3.8.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d3347743fd902c801e9e2dbd1d3727228c2fe7dcf6945ed9f48c961589c24102"},
-    {file = "snowflake_connector_python-3.8.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c5ffc3a81f7ee240f42ca118d9d42738929fc196c40b8df35c7b698f94148254"},
-    {file = "snowflake_connector_python-3.8.1-cp38-cp38-win_amd64.whl", hash = "sha256:3d7aa9c3637a519f493fd470bc03f1eb0164b0438f9ccb9d5e98ef9a48fe4036"},
-    {file = "snowflake_connector_python-3.8.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:167abcbed9f9e33b28ca47cee7397183cb06dc54bae616466e7854a903607370"},
-    {file = "snowflake_connector_python-3.8.1-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:97ae86e35886de231e5adf303549995b7a0a7e11fe992d5bdb5e5c42fbbecb6d"},
-    {file = "snowflake_connector_python-3.8.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0e2340f382578edc3a281527e399b2be24e0417f6980a785cef6b33d505433a6"},
-    {file = "snowflake_connector_python-3.8.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9610fd750ee0b24249b8c28eff81491af1d0bfc7d82e71f47568dca0f12572cc"},
-    {file = "snowflake_connector_python-3.8.1-cp39-cp39-win_amd64.whl", hash = "sha256:b8d8ca8dc832a87d361ad3816e313a7f3fdeaa62e00070ffe55528b19bb49c0b"},
+    {file = "snowflake_connector_python-3.9.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:48b22f847964b41362010035f778e7e6184ff8de8767961ba93e58be9a9d7467"},
+    {file = "snowflake_connector_python-3.9.1-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:76ea3ed0a3492e64ac5cf081a68d8e9efaa464d59c4f5d0d67857c9040a4580b"},
+    {file = "snowflake_connector_python-3.9.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5da41e3998495cd663a6b7aa2b26c8be684aa84d094c6d03f286c73576480210"},
+    {file = "snowflake_connector_python-3.9.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e7c2000b30d3d6fafab341d81001746084d8c23473dfa1b749470fd9e888018b"},
+    {file = "snowflake_connector_python-3.9.1-cp310-cp310-win_amd64.whl", hash = "sha256:9b2a82f46c7b28134c9012ff342319775e70b491600847a41e40998ae9feb3f8"},
+    {file = "snowflake_connector_python-3.9.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5fc37cd66382833d8474333caf55493ef1ced7a01e5877265263fb0d1faecbe2"},
+    {file = "snowflake_connector_python-3.9.1-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:13bd92a798092717312a616ea8f481157232e32c847650a44e96f4826b223341"},
+    {file = "snowflake_connector_python-3.9.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d166dae704f850c84bff089a48efe7f24f8894247cd9138cf2bde71e5ef77c2"},
+    {file = "snowflake_connector_python-3.9.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c979e19faccd6f05ec75b646333e99f9565f72a7a22c933ae6f61c7331f92fa1"},
+    {file = "snowflake_connector_python-3.9.1-cp311-cp311-win_amd64.whl", hash = "sha256:3494509128df8edcf8cea8f6f81848ae4f9f3356cf0474cee596a66201aaf771"},
+    {file = "snowflake_connector_python-3.9.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:efe732a8ddc94a72dea89b4d39a6f42804fe88db8e3a35dcc023e5dbde418b98"},
+    {file = "snowflake_connector_python-3.9.1-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:0d0b7a2f5c85859c3ddb8774907fc9e3200429256afcfb9805a395e5f4c3f15a"},
+    {file = "snowflake_connector_python-3.9.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3621415c128adc8efd29c84d1002ef5aba25a0ad048c2c45d4da0635ad84b204"},
+    {file = "snowflake_connector_python-3.9.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e9ffe6fc5baec2babaf3af8cae95997ec9b9c6519740ddb52b19b9c7b51b50e"},
+    {file = "snowflake_connector_python-3.9.1-cp312-cp312-win_amd64.whl", hash = "sha256:a46adb25a8fb4ef0e95baa125d5a54e539d1066d5ffad9b4713410d5e842df47"},
+    {file = "snowflake_connector_python-3.9.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:903ed5c69d2b5b4d9206d67fd24daf7767c1aa84783a6ba1c8034a3e2c71c5a2"},
+    {file = "snowflake_connector_python-3.9.1-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:a4f416f4c3f083c4732df05c8abd0fe53f55fbf1712ad2b8eb8a7b0ea80aba93"},
+    {file = "snowflake_connector_python-3.9.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afbc045703a0c4e995fa48414c8f4c80dd78fc1d5ee0a5a07aa3b317024744d0"},
+    {file = "snowflake_connector_python-3.9.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d6f9d20e6602339fbb89c2612b5b9706384fa8356be5e24afacbe39a47ca7631"},
+    {file = "snowflake_connector_python-3.9.1-cp38-cp38-win_amd64.whl", hash = "sha256:6fce744024914fa4bad54d1a31253e39877ba2b069cbdac166bdcb3d61112f11"},
+    {file = "snowflake_connector_python-3.9.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:139a71711a48c373bc517ce890e1fc93844513358105d748194091fd817a3eef"},
+    {file = "snowflake_connector_python-3.9.1-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:e91339f3e651f3c236a5d002495d5fb1221c2c71bda8f560cf395fd25d152c12"},
+    {file = "snowflake_connector_python-3.9.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:be03395718ff4779340c03b3fe3cd2e964501c54fa171aae1c0a5a054652c249"},
+    {file = "snowflake_connector_python-3.9.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ac5c1364d84dd83a8f1c3eebe908fc2458f5d29f2e9f02b6ed6266049f3bf68"},
+    {file = "snowflake_connector_python-3.9.1-cp39-cp39-win_amd64.whl", hash = "sha256:662abbae94891a8181b73153586fad74b0a65b55ba8c214687fe4bd6e8d038c2"},
+    {file = "snowflake_connector_python-3.9.1.tar.gz", hash = "sha256:381dcfd7ce1a658d69e54260dc9bdf8f47bd0baf1d6bd1fccc62ebf25f797a1c"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.13.185"
+version = "0.13.186"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
### 🤔 Why?

Sometimes shared DB are no longer accessible to the user, resulting in SQL query errors. Didn't find a good way of knowing the accessibility of a database before query.

### 🤓 What?

- Log the SQL exception instead of the throwing errors

### 🧪 Tested?

tested against metaphor snowflake, will verify the effect after deployment to customer

### ☑️ Checks


- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
