### PR TITLE
[sc-26422] Use `DIRECT_OBJECTS_ACCESSED` instead of `BASE_OBJECTS_ACCESSED` in `ACCESS_HISTORY`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.4"
+version = "0.14.5"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

This is so that we don't collapse the views along the lineage. 

Also includes `STREAM` in the object domains filter.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Use `DIRECT_OBJECTS_ACCESSED` instead of `BASE_OBJECTS_ACCESSED` in `ACCESS_HISTORY`
- Includes `STREAM` in the object domains filter.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

- SnowflakeLineage crawler run locally
 
### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
