### PR TITLE
Fix dbt 1.8 manifest parsing errors

### DIFF
--- a/metaphor/dbt/artifact_parser.py
+++ b/metaphor/dbt/artifact_parser.py
@@ -124,11 +124,11 @@ from .generated.dbt_manifest_v11 import SnapshotNode as SnapshotNodeV11
 from .generated.dbt_manifest_v11 import SourceDefinition as SourceDefinitionV11
 from .generated.dbt_manifest_v11 import WritableManifest as DbtManifestV11
 from .generated.dbt_manifest_v12 import DependsOn as DependsOnV12
-from .generated.dbt_manifest_v12 import GenericTestNode as GenericTestNodeV12
+from .generated.dbt_manifest_v12 import GenericTest as GenericTestNodeV12
 from .generated.dbt_manifest_v12 import Macro as MacroV12
 from .generated.dbt_manifest_v12 import Metric as MetricV12
-from .generated.dbt_manifest_v12 import ModelNode as ModelNodeV12
-from .generated.dbt_manifest_v12 import SnapshotNode as SnapshotNodeV12
+from .generated.dbt_manifest_v12 import Model as ModelNodeV12
+from .generated.dbt_manifest_v12 import Snapshot as SnapshotNodeV12
 from .generated.dbt_manifest_v12 import SourceDefinition as SourceDefinitionV12
 from .generated.dbt_manifest_v12 import WritableManifest as DbtManifestV12
 from .generated.dbt_run_results_v4 import DbtRunResults as DbtRunResultsV4

--- a/metaphor/dbt/generated/dbt_manifest_v12.py
+++ b/metaphor/dbt/generated/dbt_manifest_v12.py
@@ -17,7 +17,7 @@ class ManifestMetadata(BaseModel):
         extra='forbid',
     )
     dbt_schema_version: Optional[str] = None
-    dbt_version: Optional[str] = '1.8.0a1'
+    dbt_version: Optional[str] = '1.9.0a1'
     generated_at: Optional[str] = None
     invocation_id: Optional[str] = None
     env: Optional[Dict[str, str]] = None
@@ -70,6 +70,69 @@ class ContractConfig(BaseModel):
     alias_types: Optional[bool] = True
 
 
+class SeedConfig(BaseModel):
+    model_config = ConfigDict(
+        extra='allow',
+    )
+    field_extra: Optional[Dict[str, Any]] = Field(None, alias='_extra')
+    enabled: Optional[bool] = True
+    alias: Optional[str] = None
+    schema_: Optional[str] = Field(None, alias='schema')
+    database: Optional[str] = None
+    tags: Optional[Union[List[str], str]] = None
+    meta: Optional[Dict[str, Any]] = None
+    group: Optional[str] = None
+    materialized: Optional[str] = 'seed'
+    incremental_strategy: Optional[str] = None
+    persist_docs: Optional[Dict[str, Any]] = None
+    post_hook: Optional[List[Hook]] = Field(None, alias='post-hook')
+    pre_hook: Optional[List[Hook]] = Field(None, alias='pre-hook')
+    quoting: Optional[Dict[str, Any]] = None
+    column_types: Optional[Dict[str, Any]] = None
+    full_refresh: Optional[bool] = None
+    unique_key: Optional[Union[str, List[str]]] = None
+    on_schema_change: Optional[str] = 'ignore'
+    on_configuration_change: Optional[Literal['apply', 'continue', 'fail']] = None
+    grants: Optional[Dict[str, Any]] = None
+    packages: Optional[List[str]] = None
+    docs: Optional[Docs] = Field(None, title='Docs')
+    contract: Optional[ContractConfig] = Field(None, title='ContractConfig')
+    delimiter: Optional[str] = ','
+    quote_columns: Optional[bool] = None
+
+
+class ColumnLevelConstraint(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    type: Literal['check', 'not_null', 'unique', 'primary_key', 'foreign_key', 'custom']
+    name: Optional[str] = None
+    expression: Optional[str] = None
+    warn_unenforced: Optional[bool] = True
+    warn_unsupported: Optional[bool] = True
+
+
+class ColumnInfo(BaseModel):
+    model_config = ConfigDict(
+        extra='allow',
+    )
+    name: str
+    description: Optional[str] = ''
+    meta: Optional[Dict[str, Any]] = None
+    data_type: Optional[str] = None
+    constraints: Optional[List[ColumnLevelConstraint]] = None
+    quote: Optional[bool] = None
+    tags: Optional[List[str]] = None
+    field_extra: Optional[Dict[str, Any]] = Field(None, alias='_extra')
+
+
+class MacroDependsOn(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    macros: Optional[List[str]] = None
+
+
 class NodeConfig(BaseModel):
     model_config = ConfigDict(
         extra='allow',
@@ -99,29 +162,82 @@ class NodeConfig(BaseModel):
     contract: Optional[ContractConfig] = Field(None, title='ContractConfig')
 
 
-class ColumnLevelConstraint(BaseModel):
+class DeferRelation(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    type: Literal['check', 'not_null', 'unique', 'primary_key', 'foreign_key', 'custom']
-    name: Optional[str] = None
-    expression: Optional[str] = None
-    warn_unenforced: Optional[bool] = True
-    warn_unsupported: Optional[bool] = True
-
-
-class ColumnInfo(BaseModel):
-    model_config = ConfigDict(
-        extra='allow',
-    )
+    database: Optional[str] = None
+    schema_: str = Field(..., alias='schema')
+    alias: str
+    relation_name: Optional[str] = None
+    resource_type: Literal[
+        'model',
+        'analysis',
+        'test',
+        'snapshot',
+        'operation',
+        'seed',
+        'rpc',
+        'sql_operation',
+        'doc',
+        'source',
+        'macro',
+        'exposure',
+        'metric',
+        'group',
+        'saved_query',
+        'semantic_model',
+        'unit_test',
+        'fixture',
+    ]
     name: str
-    description: Optional[str] = ''
-    meta: Optional[Dict[str, Any]] = None
-    data_type: Optional[str] = None
-    constraints: Optional[List[ColumnLevelConstraint]] = None
-    quote: Optional[bool] = None
+    description: str
+    compiled_code: Optional[str] = None
+    meta: Dict[str, Any]
+    tags: List[str]
+    config: Optional[NodeConfig] = None
+
+
+class Seed(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    database: Optional[str] = None
+    schema_: str = Field(..., alias='schema')
+    name: str
+    resource_type: Literal['seed']
+    package_name: str
+    path: str
+    original_file_path: str
+    unique_id: str
+    fqn: List[str]
+    alias: str
+    checksum: FileHash = Field(..., title='FileHash')
+    config: Optional[SeedConfig] = Field(None, title='SeedConfig')
     tags: Optional[List[str]] = None
-    field_extra: Optional[Dict[str, Any]] = Field(None, alias='_extra')
+    description: Optional[str] = ''
+    columns: Optional[Dict[str, ColumnInfo]] = None
+    meta: Optional[Dict[str, Any]] = None
+    group: Optional[str] = None
+    docs: Optional[Docs] = Field(None, title='Docs')
+    patch_path: Optional[str] = None
+    build_path: Optional[str] = None
+    unrendered_config: Optional[Dict[str, Any]] = None
+    created_at: Optional[float] = None
+    config_call_dict: Optional[Dict[str, Any]] = None
+    relation_name: Optional[str] = None
+    raw_code: Optional[str] = ''
+    root_path: Optional[str] = None
+    depends_on: Optional[MacroDependsOn] = Field(None, title='MacroDependsOn')
+    defer_relation: Optional[DeferRelation] = None
+
+
+class NodeConfig1(NodeConfig):
+    pass
+
+
+class ColumnInfo1(ColumnInfo):
+    pass
 
 
 class RefArgs(BaseModel):
@@ -158,7 +274,7 @@ class Contract(BaseModel):
     checksum: Optional[str] = None
 
 
-class AnalysisNode(BaseModel):
+class Analysis(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
@@ -173,17 +289,15 @@ class AnalysisNode(BaseModel):
     fqn: List[str]
     alias: str
     checksum: FileHash = Field(..., title='FileHash')
-    config: Optional[NodeConfig] = Field(None, title='NodeConfig')
-    field_event_status: Optional[Dict[str, Any]] = Field(None, alias='_event_status')
+    config: Optional[NodeConfig1] = Field(None, title='NodeConfig')
     tags: Optional[List[str]] = None
     description: Optional[str] = ''
-    columns: Optional[Dict[str, ColumnInfo]] = None
+    columns: Optional[Dict[str, ColumnInfo1]] = None
     meta: Optional[Dict[str, Any]] = None
     group: Optional[str] = None
     docs: Optional[Docs] = Field(None, title='Docs')
     patch_path: Optional[str] = None
     build_path: Optional[str] = None
-    deferred: Optional[bool] = False
     unrendered_config: Optional[Dict[str, Any]] = None
     created_at: Optional[float] = None
     config_call_dict: Optional[Dict[str, Any]] = None
@@ -228,11 +342,11 @@ class TestConfig(BaseModel):
     error_if: Optional[str] = '!= 0'
 
 
-class ColumnInfo1(ColumnInfo):
+class ColumnInfo2(ColumnInfo):
     pass
 
 
-class SingularTestNode(BaseModel):
+class SingularTest(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
@@ -248,16 +362,14 @@ class SingularTestNode(BaseModel):
     alias: str
     checksum: FileHash = Field(..., title='FileHash')
     config: Optional[TestConfig] = Field(None, title='TestConfig')
-    field_event_status: Optional[Dict[str, Any]] = Field(None, alias='_event_status')
     tags: Optional[List[str]] = None
     description: Optional[str] = ''
-    columns: Optional[Dict[str, ColumnInfo1]] = None
+    columns: Optional[Dict[str, ColumnInfo2]] = None
     meta: Optional[Dict[str, Any]] = None
     group: Optional[str] = None
     docs: Optional[Docs] = Field(None, title='Docs')
     patch_path: Optional[str] = None
     build_path: Optional[str] = None
-    deferred: Optional[bool] = False
     unrendered_config: Optional[Dict[str, Any]] = None
     created_at: Optional[float] = None
     config_call_dict: Optional[Dict[str, Any]] = None
@@ -277,11 +389,11 @@ class SingularTestNode(BaseModel):
     contract: Optional[Contract] = Field(None, title='Contract')
 
 
-class NodeConfig1(NodeConfig):
+class NodeConfig2(NodeConfig):
     pass
 
 
-class ColumnInfo2(ColumnInfo):
+class ColumnInfo3(ColumnInfo):
     pass
 
 
@@ -300,17 +412,15 @@ class HookNode(BaseModel):
     fqn: List[str]
     alias: str
     checksum: FileHash = Field(..., title='FileHash')
-    config: Optional[NodeConfig1] = Field(None, title='NodeConfig')
-    field_event_status: Optional[Dict[str, Any]] = Field(None, alias='_event_status')
+    config: Optional[NodeConfig2] = Field(None, title='NodeConfig')
     tags: Optional[List[str]] = None
     description: Optional[str] = ''
-    columns: Optional[Dict[str, ColumnInfo2]] = None
+    columns: Optional[Dict[str, ColumnInfo3]] = None
     meta: Optional[Dict[str, Any]] = None
     group: Optional[str] = None
     docs: Optional[Docs] = Field(None, title='Docs')
     patch_path: Optional[str] = None
     build_path: Optional[str] = None
-    deferred: Optional[bool] = False
     unrendered_config: Optional[Dict[str, Any]] = None
     created_at: Optional[float] = None
     config_call_dict: Optional[Dict[str, Any]] = None
@@ -361,7 +471,7 @@ class ModelConfig(BaseModel):
     access: Optional[Literal['private', 'protected', 'public']] = 'protected'
 
 
-class ColumnInfo3(ColumnInfo):
+class ColumnInfo4(ColumnInfo):
     pass
 
 
@@ -377,7 +487,11 @@ class ModelLevelConstraint(BaseModel):
     columns: Optional[List[str]] = None
 
 
-class DeferRelation(BaseModel):
+class NodeConfig3(NodeConfig):
+    pass
+
+
+class DeferRelation1(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
@@ -385,9 +499,35 @@ class DeferRelation(BaseModel):
     schema_: str = Field(..., alias='schema')
     alias: str
     relation_name: Optional[str] = None
+    resource_type: Literal[
+        'model',
+        'analysis',
+        'test',
+        'snapshot',
+        'operation',
+        'seed',
+        'rpc',
+        'sql_operation',
+        'doc',
+        'source',
+        'macro',
+        'exposure',
+        'metric',
+        'group',
+        'saved_query',
+        'semantic_model',
+        'unit_test',
+        'fixture',
+    ]
+    name: str
+    description: str
+    compiled_code: Optional[str] = None
+    meta: Dict[str, Any]
+    tags: List[str]
+    config: Optional[NodeConfig3] = None
 
 
-class ModelNode(BaseModel):
+class Model(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
@@ -403,16 +543,14 @@ class ModelNode(BaseModel):
     alias: str
     checksum: FileHash = Field(..., title='FileHash')
     config: Optional[ModelConfig] = Field(None, title='ModelConfig')
-    field_event_status: Optional[Dict[str, Any]] = Field(None, alias='_event_status')
     tags: Optional[List[str]] = None
     description: Optional[str] = ''
-    columns: Optional[Dict[str, ColumnInfo3]] = None
+    columns: Optional[Dict[str, ColumnInfo4]] = None
     meta: Optional[Dict[str, Any]] = None
     group: Optional[str] = None
     docs: Optional[Docs] = Field(None, title='Docs')
     patch_path: Optional[str] = None
     build_path: Optional[str] = None
-    deferred: Optional[bool] = False
     unrendered_config: Optional[Dict[str, Any]] = None
     created_at: Optional[float] = None
     config_call_dict: Optional[Dict[str, Any]] = None
@@ -435,63 +573,11 @@ class ModelNode(BaseModel):
     version: Optional[Union[str, float]] = None
     latest_version: Optional[Union[str, float]] = None
     deprecation_date: Optional[str] = None
-    defer_relation: Optional[DeferRelation] = None
+    defer_relation: Optional[DeferRelation1] = None
+    primary_key: Optional[List[str]] = None
 
 
-class NodeConfig2(NodeConfig):
-    pass
-
-
-class ColumnInfo4(ColumnInfo):
-    pass
-
-
-class RPCNode(BaseModel):
-    model_config = ConfigDict(
-        extra='forbid',
-    )
-    database: Optional[str] = None
-    schema_: str = Field(..., alias='schema')
-    name: str
-    resource_type: Literal['rpc']
-    package_name: str
-    path: str
-    original_file_path: str
-    unique_id: str
-    fqn: List[str]
-    alias: str
-    checksum: FileHash = Field(..., title='FileHash')
-    config: Optional[NodeConfig2] = Field(None, title='NodeConfig')
-    field_event_status: Optional[Dict[str, Any]] = Field(None, alias='_event_status')
-    tags: Optional[List[str]] = None
-    description: Optional[str] = ''
-    columns: Optional[Dict[str, ColumnInfo4]] = None
-    meta: Optional[Dict[str, Any]] = None
-    group: Optional[str] = None
-    docs: Optional[Docs] = Field(None, title='Docs')
-    patch_path: Optional[str] = None
-    build_path: Optional[str] = None
-    deferred: Optional[bool] = False
-    unrendered_config: Optional[Dict[str, Any]] = None
-    created_at: Optional[float] = None
-    config_call_dict: Optional[Dict[str, Any]] = None
-    relation_name: Optional[str] = None
-    raw_code: Optional[str] = ''
-    language: Optional[str] = 'sql'
-    refs: Optional[List[RefArgs]] = None
-    sources: Optional[List[List[str]]] = None
-    metrics: Optional[List[List[str]]] = None
-    depends_on: Optional[DependsOn] = Field(None, title='DependsOn')
-    compiled_path: Optional[str] = None
-    compiled: Optional[bool] = False
-    compiled_code: Optional[str] = None
-    extra_ctes_injected: Optional[bool] = False
-    extra_ctes: Optional[List[InjectedCTE]] = None
-    field_pre_injected_sql: Optional[str] = Field(None, alias='_pre_injected_sql')
-    contract: Optional[Contract] = Field(None, title='Contract')
-
-
-class NodeConfig3(NodeConfig):
+class NodeConfig4(NodeConfig):
     pass
 
 
@@ -499,7 +585,7 @@ class ColumnInfo5(ColumnInfo):
     pass
 
 
-class SqlNode(BaseModel):
+class SqlOperation(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
@@ -514,8 +600,7 @@ class SqlNode(BaseModel):
     fqn: List[str]
     alias: str
     checksum: FileHash = Field(..., title='FileHash')
-    config: Optional[NodeConfig3] = Field(None, title='NodeConfig')
-    field_event_status: Optional[Dict[str, Any]] = Field(None, alias='_event_status')
+    config: Optional[NodeConfig4] = Field(None, title='NodeConfig')
     tags: Optional[List[str]] = None
     description: Optional[str] = ''
     columns: Optional[Dict[str, ColumnInfo5]] = None
@@ -524,7 +609,6 @@ class SqlNode(BaseModel):
     docs: Optional[Docs] = Field(None, title='Docs')
     patch_path: Optional[str] = None
     build_path: Optional[str] = None
-    deferred: Optional[bool] = False
     unrendered_config: Optional[Dict[str, Any]] = None
     created_at: Optional[float] = None
     config_call_dict: Optional[Dict[str, Any]] = None
@@ -544,24 +628,23 @@ class SqlNode(BaseModel):
     contract: Optional[Contract] = Field(None, title='Contract')
 
 
-class TestMetadata(BaseModel):
-    model_config = ConfigDict(
-        extra='forbid',
-    )
-    name: str
-    kwargs: Optional[Dict[str, Any]] = None
-    namespace: Optional[str] = None
-
-
 class ColumnInfo6(ColumnInfo):
     pass
 
 
-class GenericTestNode(BaseModel):
+class TestMetadata(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    test_metadata: TestMetadata = Field(..., title='TestMetadata')
+    name: Optional[str] = 'test'
+    kwargs: Optional[Dict[str, Any]] = None
+    namespace: Optional[str] = None
+
+
+class GenericTest(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
     name: str
@@ -574,7 +657,6 @@ class GenericTestNode(BaseModel):
     alias: str
     checksum: FileHash = Field(..., title='FileHash')
     config: Optional[TestConfig] = Field(None, title='TestConfig')
-    field_event_status: Optional[Dict[str, Any]] = Field(None, alias='_event_status')
     tags: Optional[List[str]] = None
     description: Optional[str] = ''
     columns: Optional[Dict[str, ColumnInfo6]] = None
@@ -583,7 +665,6 @@ class GenericTestNode(BaseModel):
     docs: Optional[Docs] = Field(None, title='Docs')
     patch_path: Optional[str] = None
     build_path: Optional[str] = None
-    deferred: Optional[bool] = False
     unrendered_config: Optional[Dict[str, Any]] = None
     created_at: Optional[float] = None
     config_call_dict: Optional[Dict[str, Any]] = None
@@ -604,6 +685,7 @@ class GenericTestNode(BaseModel):
     column_name: Optional[str] = None
     file_key_name: Optional[str] = None
     attached_node: Optional[str] = None
+    test_metadata: Optional[TestMetadata] = Field(None, title='TestMetadata')
 
 
 class SnapshotConfig(BaseModel):
@@ -644,7 +726,47 @@ class ColumnInfo7(ColumnInfo):
     pass
 
 
-class SnapshotNode(BaseModel):
+class NodeConfig5(NodeConfig):
+    pass
+
+
+class DeferRelation2(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    database: Optional[str] = None
+    schema_: str = Field(..., alias='schema')
+    alias: str
+    relation_name: Optional[str] = None
+    resource_type: Literal[
+        'model',
+        'analysis',
+        'test',
+        'snapshot',
+        'operation',
+        'seed',
+        'rpc',
+        'sql_operation',
+        'doc',
+        'source',
+        'macro',
+        'exposure',
+        'metric',
+        'group',
+        'saved_query',
+        'semantic_model',
+        'unit_test',
+        'fixture',
+    ]
+    name: str
+    description: str
+    compiled_code: Optional[str] = None
+    meta: Dict[str, Any]
+    tags: List[str]
+    config: Optional[NodeConfig5] = None
+
+
+class Snapshot(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
@@ -660,7 +782,6 @@ class SnapshotNode(BaseModel):
     alias: str
     checksum: FileHash = Field(..., title='FileHash')
     config: SnapshotConfig = Field(..., title='SnapshotConfig')
-    field_event_status: Optional[Dict[str, Any]] = Field(None, alias='_event_status')
     tags: Optional[List[str]] = None
     description: Optional[str] = ''
     columns: Optional[Dict[str, ColumnInfo7]] = None
@@ -669,7 +790,6 @@ class SnapshotNode(BaseModel):
     docs: Optional[Docs] = Field(None, title='Docs')
     patch_path: Optional[str] = None
     build_path: Optional[str] = None
-    deferred: Optional[bool] = False
     unrendered_config: Optional[Dict[str, Any]] = None
     created_at: Optional[float] = None
     config_call_dict: Optional[Dict[str, Any]] = None
@@ -687,176 +807,7 @@ class SnapshotNode(BaseModel):
     extra_ctes: Optional[List[InjectedCTE]] = None
     field_pre_injected_sql: Optional[str] = Field(None, alias='_pre_injected_sql')
     contract: Optional[Contract] = Field(None, title='Contract')
-    defer_relation: Optional[DeferRelation] = None
-
-
-class UnitTestNodeConfig(BaseModel):
-    model_config = ConfigDict(
-        extra='allow',
-    )
-    field_extra: Optional[Dict[str, Any]] = Field(None, alias='_extra')
-    enabled: Optional[bool] = True
-    alias: Optional[str] = None
-    schema_: Optional[str] = Field(None, alias='schema')
-    database: Optional[str] = None
-    tags: Optional[Union[List[str], str]] = None
-    meta: Optional[Dict[str, Any]] = None
-    group: Optional[str] = None
-    materialized: Optional[str] = 'view'
-    incremental_strategy: Optional[str] = None
-    persist_docs: Optional[Dict[str, Any]] = None
-    post_hook: Optional[List[Hook]] = Field(None, alias='post-hook')
-    pre_hook: Optional[List[Hook]] = Field(None, alias='pre-hook')
-    quoting: Optional[Dict[str, Any]] = None
-    column_types: Optional[Dict[str, Any]] = None
-    full_refresh: Optional[bool] = None
-    unique_key: Optional[Union[str, List[str]]] = None
-    on_schema_change: Optional[str] = 'ignore'
-    on_configuration_change: Optional[Literal['apply', 'continue', 'fail']] = None
-    grants: Optional[Dict[str, Any]] = None
-    packages: Optional[List[str]] = None
-    docs: Optional[Docs] = Field(None, title='Docs')
-    contract: Optional[ContractConfig] = Field(None, title='ContractConfig')
-    expected_rows: Optional[List[Dict[str, Any]]] = None
-
-
-class ColumnInfo8(ColumnInfo):
-    pass
-
-
-class UnitTestOverrides(BaseModel):
-    model_config = ConfigDict(
-        extra='forbid',
-    )
-    macros: Optional[Dict[str, Any]] = None
-    vars: Optional[Dict[str, Any]] = None
-    env_vars: Optional[Dict[str, Any]] = None
-
-
-class UnitTestNode(BaseModel):
-    model_config = ConfigDict(
-        extra='forbid',
-    )
-    database: Optional[str] = None
-    schema_: str = Field(..., alias='schema')
-    name: str
-    resource_type: Literal['unit_test']
-    package_name: str
-    path: str
-    original_file_path: str
-    unique_id: str
-    fqn: List[str]
-    alias: str
-    checksum: FileHash = Field(..., title='FileHash')
-    config: Optional[UnitTestNodeConfig] = Field(None, title='UnitTestNodeConfig')
-    field_event_status: Optional[Dict[str, Any]] = Field(None, alias='_event_status')
-    tags: Optional[List[str]] = None
-    description: Optional[str] = ''
-    columns: Optional[Dict[str, ColumnInfo8]] = None
-    meta: Optional[Dict[str, Any]] = None
-    group: Optional[str] = None
-    docs: Optional[Docs] = Field(None, title='Docs')
-    patch_path: Optional[str] = None
-    build_path: Optional[str] = None
-    deferred: Optional[bool] = False
-    unrendered_config: Optional[Dict[str, Any]] = None
-    created_at: Optional[float] = None
-    config_call_dict: Optional[Dict[str, Any]] = None
-    relation_name: Optional[str] = None
-    raw_code: Optional[str] = ''
-    language: Optional[str] = 'sql'
-    refs: Optional[List[RefArgs]] = None
-    sources: Optional[List[List[str]]] = None
-    metrics: Optional[List[List[str]]] = None
-    depends_on: Optional[DependsOn] = Field(None, title='DependsOn')
-    compiled_path: Optional[str] = None
-    compiled: Optional[bool] = False
-    compiled_code: Optional[str] = None
-    extra_ctes_injected: Optional[bool] = False
-    extra_ctes: Optional[List[InjectedCTE]] = None
-    field_pre_injected_sql: Optional[str] = Field(None, alias='_pre_injected_sql')
-    contract: Optional[Contract] = Field(None, title='Contract')
-    tested_node_unique_id: Optional[str] = None
-    this_input_node_unique_id: Optional[str] = None
-    overrides: Optional[UnitTestOverrides] = None
-
-
-class SeedConfig(BaseModel):
-    model_config = ConfigDict(
-        extra='allow',
-    )
-    field_extra: Optional[Dict[str, Any]] = Field(None, alias='_extra')
-    enabled: Optional[bool] = True
-    alias: Optional[str] = None
-    schema_: Optional[str] = Field(None, alias='schema')
-    database: Optional[str] = None
-    tags: Optional[Union[List[str], str]] = None
-    meta: Optional[Dict[str, Any]] = None
-    group: Optional[str] = None
-    materialized: Optional[str] = 'seed'
-    incremental_strategy: Optional[str] = None
-    persist_docs: Optional[Dict[str, Any]] = None
-    post_hook: Optional[List[Hook]] = Field(None, alias='post-hook')
-    pre_hook: Optional[List[Hook]] = Field(None, alias='pre-hook')
-    quoting: Optional[Dict[str, Any]] = None
-    column_types: Optional[Dict[str, Any]] = None
-    full_refresh: Optional[bool] = None
-    unique_key: Optional[Union[str, List[str]]] = None
-    on_schema_change: Optional[str] = 'ignore'
-    on_configuration_change: Optional[Literal['apply', 'continue', 'fail']] = None
-    grants: Optional[Dict[str, Any]] = None
-    packages: Optional[List[str]] = None
-    docs: Optional[Docs] = Field(None, title='Docs')
-    contract: Optional[ContractConfig] = Field(None, title='ContractConfig')
-    delimiter: Optional[str] = ','
-    quote_columns: Optional[bool] = None
-
-
-class ColumnInfo9(ColumnInfo):
-    pass
-
-
-class MacroDependsOn(BaseModel):
-    model_config = ConfigDict(
-        extra='forbid',
-    )
-    macros: Optional[List[str]] = None
-
-
-class SeedNode(BaseModel):
-    model_config = ConfigDict(
-        extra='forbid',
-    )
-    database: Optional[str] = None
-    schema_: str = Field(..., alias='schema')
-    name: str
-    resource_type: Literal['seed']
-    package_name: str
-    path: str
-    original_file_path: str
-    unique_id: str
-    fqn: List[str]
-    alias: str
-    checksum: FileHash = Field(..., title='FileHash')
-    config: Optional[SeedConfig] = Field(None, title='SeedConfig')
-    field_event_status: Optional[Dict[str, Any]] = Field(None, alias='_event_status')
-    tags: Optional[List[str]] = None
-    description: Optional[str] = ''
-    columns: Optional[Dict[str, ColumnInfo9]] = None
-    meta: Optional[Dict[str, Any]] = None
-    group: Optional[str] = None
-    docs: Optional[Docs] = Field(None, title='Docs')
-    patch_path: Optional[str] = None
-    build_path: Optional[str] = None
-    deferred: Optional[bool] = False
-    unrendered_config: Optional[Dict[str, Any]] = None
-    created_at: Optional[float] = None
-    config_call_dict: Optional[Dict[str, Any]] = None
-    relation_name: Optional[str] = None
-    raw_code: Optional[str] = ''
-    root_path: Optional[str] = None
-    depends_on: Optional[MacroDependsOn] = Field(None, title='MacroDependsOn')
-    defer_relation: Optional[DeferRelation] = None
+    defer_relation: Optional[DeferRelation2] = None
 
 
 class Quoting(BaseModel):
@@ -909,7 +860,7 @@ class ExternalTable(BaseModel):
     partitions: Optional[Union[List[str], List[ExternalPartition]]] = None
 
 
-class ColumnInfo10(ColumnInfo):
+class ColumnInfo8(ColumnInfo):
     pass
 
 
@@ -938,13 +889,12 @@ class SourceDefinition(BaseModel):
     source_description: str
     loader: str
     identifier: str
-    field_event_status: Optional[Dict[str, Any]] = Field(None, alias='_event_status')
     quoting: Optional[Quoting] = Field(None, title='Quoting')
     loaded_at_field: Optional[str] = None
     freshness: Optional[FreshnessThreshold] = None
     external: Optional[ExternalTable] = None
     description: Optional[str] = ''
-    columns: Optional[Dict[str, ColumnInfo10]] = None
+    columns: Optional[Dict[str, ColumnInfo8]] = None
     meta: Optional[Dict[str, Any]] = None
     source_meta: Optional[Dict[str, Any]] = None
     tags: Optional[List[str]] = None
@@ -1226,6 +1176,7 @@ class MetricConfig(BaseModel):
     field_extra: Optional[Dict[str, Any]] = Field(None, alias='_extra')
     enabled: Optional[bool] = True
     group: Optional[str] = None
+    meta: Optional[Dict[str, Any]] = None
 
 
 class Metric(BaseModel):
@@ -1270,15 +1221,97 @@ class Group(BaseModel):
     owner: Owner = Field(..., title='Owner')
 
 
-class NodeConfig4(NodeConfig):
+class SeedConfig1(SeedConfig):
     pass
 
 
-class ColumnInfo11(ColumnInfo):
+class ColumnInfo9(ColumnInfo):
     pass
 
 
-class AnalysisNode1(BaseModel):
+class NodeConfig6(NodeConfig):
+    pass
+
+
+class DeferRelation3(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    database: Optional[str] = None
+    schema_: str = Field(..., alias='schema')
+    alias: str
+    relation_name: Optional[str] = None
+    resource_type: Literal[
+        'model',
+        'analysis',
+        'test',
+        'snapshot',
+        'operation',
+        'seed',
+        'rpc',
+        'sql_operation',
+        'doc',
+        'source',
+        'macro',
+        'exposure',
+        'metric',
+        'group',
+        'saved_query',
+        'semantic_model',
+        'unit_test',
+        'fixture',
+    ]
+    name: str
+    description: str
+    compiled_code: Optional[str] = None
+    meta: Dict[str, Any]
+    tags: List[str]
+    config: Optional[NodeConfig6] = None
+
+
+class Seed1(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    database: Optional[str] = None
+    schema_: str = Field(..., alias='schema')
+    name: str
+    resource_type: Literal['seed']
+    package_name: str
+    path: str
+    original_file_path: str
+    unique_id: str
+    fqn: List[str]
+    alias: str
+    checksum: FileHash = Field(..., title='FileHash')
+    config: Optional[SeedConfig1] = Field(None, title='SeedConfig')
+    tags: Optional[List[str]] = None
+    description: Optional[str] = ''
+    columns: Optional[Dict[str, ColumnInfo9]] = None
+    meta: Optional[Dict[str, Any]] = None
+    group: Optional[str] = None
+    docs: Optional[Docs] = Field(None, title='Docs')
+    patch_path: Optional[str] = None
+    build_path: Optional[str] = None
+    unrendered_config: Optional[Dict[str, Any]] = None
+    created_at: Optional[float] = None
+    config_call_dict: Optional[Dict[str, Any]] = None
+    relation_name: Optional[str] = None
+    raw_code: Optional[str] = ''
+    root_path: Optional[str] = None
+    depends_on: Optional[MacroDependsOn] = Field(None, title='MacroDependsOn')
+    defer_relation: Optional[DeferRelation3] = None
+
+
+class NodeConfig7(NodeConfig):
+    pass
+
+
+class ColumnInfo10(ColumnInfo):
+    pass
+
+
+class Analysis1(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
@@ -1293,17 +1326,15 @@ class AnalysisNode1(BaseModel):
     fqn: List[str]
     alias: str
     checksum: FileHash = Field(..., title='FileHash')
-    config: Optional[NodeConfig4] = Field(None, title='NodeConfig')
-    field_event_status: Optional[Dict[str, Any]] = Field(None, alias='_event_status')
+    config: Optional[NodeConfig7] = Field(None, title='NodeConfig')
     tags: Optional[List[str]] = None
     description: Optional[str] = ''
-    columns: Optional[Dict[str, ColumnInfo11]] = None
+    columns: Optional[Dict[str, ColumnInfo10]] = None
     meta: Optional[Dict[str, Any]] = None
     group: Optional[str] = None
     docs: Optional[Docs] = Field(None, title='Docs')
     patch_path: Optional[str] = None
     build_path: Optional[str] = None
-    deferred: Optional[bool] = False
     unrendered_config: Optional[Dict[str, Any]] = None
     created_at: Optional[float] = None
     config_call_dict: Optional[Dict[str, Any]] = None
@@ -1323,11 +1354,11 @@ class AnalysisNode1(BaseModel):
     contract: Optional[Contract] = Field(None, title='Contract')
 
 
-class ColumnInfo12(ColumnInfo):
+class ColumnInfo11(ColumnInfo):
     pass
 
 
-class SingularTestNode1(BaseModel):
+class SingularTest1(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
@@ -1343,16 +1374,14 @@ class SingularTestNode1(BaseModel):
     alias: str
     checksum: FileHash = Field(..., title='FileHash')
     config: Optional[TestConfig] = Field(None, title='TestConfig')
-    field_event_status: Optional[Dict[str, Any]] = Field(None, alias='_event_status')
     tags: Optional[List[str]] = None
     description: Optional[str] = ''
-    columns: Optional[Dict[str, ColumnInfo12]] = None
+    columns: Optional[Dict[str, ColumnInfo11]] = None
     meta: Optional[Dict[str, Any]] = None
     group: Optional[str] = None
     docs: Optional[Docs] = Field(None, title='Docs')
     patch_path: Optional[str] = None
     build_path: Optional[str] = None
-    deferred: Optional[bool] = False
     unrendered_config: Optional[Dict[str, Any]] = None
     created_at: Optional[float] = None
     config_call_dict: Optional[Dict[str, Any]] = None
@@ -1372,11 +1401,11 @@ class SingularTestNode1(BaseModel):
     contract: Optional[Contract] = Field(None, title='Contract')
 
 
-class NodeConfig5(NodeConfig):
+class NodeConfig8(NodeConfig):
     pass
 
 
-class ColumnInfo13(ColumnInfo):
+class ColumnInfo12(ColumnInfo):
     pass
 
 
@@ -1395,17 +1424,15 @@ class HookNode1(BaseModel):
     fqn: List[str]
     alias: str
     checksum: FileHash = Field(..., title='FileHash')
-    config: Optional[NodeConfig5] = Field(None, title='NodeConfig')
-    field_event_status: Optional[Dict[str, Any]] = Field(None, alias='_event_status')
+    config: Optional[NodeConfig8] = Field(None, title='NodeConfig')
     tags: Optional[List[str]] = None
     description: Optional[str] = ''
-    columns: Optional[Dict[str, ColumnInfo13]] = None
+    columns: Optional[Dict[str, ColumnInfo12]] = None
     meta: Optional[Dict[str, Any]] = None
     group: Optional[str] = None
     docs: Optional[Docs] = Field(None, title='Docs')
     patch_path: Optional[str] = None
     build_path: Optional[str] = None
-    deferred: Optional[bool] = False
     unrendered_config: Optional[Dict[str, Any]] = None
     created_at: Optional[float] = None
     config_call_dict: Optional[Dict[str, Any]] = None
@@ -1430,11 +1457,51 @@ class ModelConfig1(ModelConfig):
     pass
 
 
-class ColumnInfo14(ColumnInfo):
+class ColumnInfo13(ColumnInfo):
     pass
 
 
-class ModelNode1(BaseModel):
+class NodeConfig9(NodeConfig):
+    pass
+
+
+class DeferRelation4(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    database: Optional[str] = None
+    schema_: str = Field(..., alias='schema')
+    alias: str
+    relation_name: Optional[str] = None
+    resource_type: Literal[
+        'model',
+        'analysis',
+        'test',
+        'snapshot',
+        'operation',
+        'seed',
+        'rpc',
+        'sql_operation',
+        'doc',
+        'source',
+        'macro',
+        'exposure',
+        'metric',
+        'group',
+        'saved_query',
+        'semantic_model',
+        'unit_test',
+        'fixture',
+    ]
+    name: str
+    description: str
+    compiled_code: Optional[str] = None
+    meta: Dict[str, Any]
+    tags: List[str]
+    config: Optional[NodeConfig9] = None
+
+
+class Model1(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
@@ -1450,16 +1517,14 @@ class ModelNode1(BaseModel):
     alias: str
     checksum: FileHash = Field(..., title='FileHash')
     config: Optional[ModelConfig1] = Field(None, title='ModelConfig')
-    field_event_status: Optional[Dict[str, Any]] = Field(None, alias='_event_status')
     tags: Optional[List[str]] = None
     description: Optional[str] = ''
-    columns: Optional[Dict[str, ColumnInfo14]] = None
+    columns: Optional[Dict[str, ColumnInfo13]] = None
     meta: Optional[Dict[str, Any]] = None
     group: Optional[str] = None
     docs: Optional[Docs] = Field(None, title='Docs')
     patch_path: Optional[str] = None
     build_path: Optional[str] = None
-    deferred: Optional[bool] = False
     unrendered_config: Optional[Dict[str, Any]] = None
     created_at: Optional[float] = None
     config_call_dict: Optional[Dict[str, Any]] = None
@@ -1482,71 +1547,19 @@ class ModelNode1(BaseModel):
     version: Optional[Union[str, float]] = None
     latest_version: Optional[Union[str, float]] = None
     deprecation_date: Optional[str] = None
-    defer_relation: Optional[DeferRelation] = None
+    defer_relation: Optional[DeferRelation4] = None
+    primary_key: Optional[List[str]] = None
 
 
-class NodeConfig6(NodeConfig):
+class NodeConfig10(NodeConfig):
     pass
 
 
-class ColumnInfo15(ColumnInfo):
+class ColumnInfo14(ColumnInfo):
     pass
 
 
-class RPCNode1(BaseModel):
-    model_config = ConfigDict(
-        extra='forbid',
-    )
-    database: Optional[str] = None
-    schema_: str = Field(..., alias='schema')
-    name: str
-    resource_type: Literal['rpc']
-    package_name: str
-    path: str
-    original_file_path: str
-    unique_id: str
-    fqn: List[str]
-    alias: str
-    checksum: FileHash = Field(..., title='FileHash')
-    config: Optional[NodeConfig6] = Field(None, title='NodeConfig')
-    field_event_status: Optional[Dict[str, Any]] = Field(None, alias='_event_status')
-    tags: Optional[List[str]] = None
-    description: Optional[str] = ''
-    columns: Optional[Dict[str, ColumnInfo15]] = None
-    meta: Optional[Dict[str, Any]] = None
-    group: Optional[str] = None
-    docs: Optional[Docs] = Field(None, title='Docs')
-    patch_path: Optional[str] = None
-    build_path: Optional[str] = None
-    deferred: Optional[bool] = False
-    unrendered_config: Optional[Dict[str, Any]] = None
-    created_at: Optional[float] = None
-    config_call_dict: Optional[Dict[str, Any]] = None
-    relation_name: Optional[str] = None
-    raw_code: Optional[str] = ''
-    language: Optional[str] = 'sql'
-    refs: Optional[List[RefArgs]] = None
-    sources: Optional[List[List[str]]] = None
-    metrics: Optional[List[List[str]]] = None
-    depends_on: Optional[DependsOn] = Field(None, title='DependsOn')
-    compiled_path: Optional[str] = None
-    compiled: Optional[bool] = False
-    compiled_code: Optional[str] = None
-    extra_ctes_injected: Optional[bool] = False
-    extra_ctes: Optional[List[InjectedCTE]] = None
-    field_pre_injected_sql: Optional[str] = Field(None, alias='_pre_injected_sql')
-    contract: Optional[Contract] = Field(None, title='Contract')
-
-
-class NodeConfig7(NodeConfig):
-    pass
-
-
-class ColumnInfo16(ColumnInfo):
-    pass
-
-
-class SqlNode1(BaseModel):
+class SqlOperation1(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
@@ -1561,17 +1574,15 @@ class SqlNode1(BaseModel):
     fqn: List[str]
     alias: str
     checksum: FileHash = Field(..., title='FileHash')
-    config: Optional[NodeConfig7] = Field(None, title='NodeConfig')
-    field_event_status: Optional[Dict[str, Any]] = Field(None, alias='_event_status')
+    config: Optional[NodeConfig10] = Field(None, title='NodeConfig')
     tags: Optional[List[str]] = None
     description: Optional[str] = ''
-    columns: Optional[Dict[str, ColumnInfo16]] = None
+    columns: Optional[Dict[str, ColumnInfo14]] = None
     meta: Optional[Dict[str, Any]] = None
     group: Optional[str] = None
     docs: Optional[Docs] = Field(None, title='Docs')
     patch_path: Optional[str] = None
     build_path: Optional[str] = None
-    deferred: Optional[bool] = False
     unrendered_config: Optional[Dict[str, Any]] = None
     created_at: Optional[float] = None
     config_call_dict: Optional[Dict[str, Any]] = None
@@ -1591,15 +1602,14 @@ class SqlNode1(BaseModel):
     contract: Optional[Contract] = Field(None, title='Contract')
 
 
-class ColumnInfo17(ColumnInfo):
+class ColumnInfo15(ColumnInfo):
     pass
 
 
-class GenericTestNode1(BaseModel):
+class GenericTest1(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    test_metadata: TestMetadata = Field(..., title='TestMetadata')
     database: Optional[str] = None
     schema_: str = Field(..., alias='schema')
     name: str
@@ -1612,16 +1622,14 @@ class GenericTestNode1(BaseModel):
     alias: str
     checksum: FileHash = Field(..., title='FileHash')
     config: Optional[TestConfig] = Field(None, title='TestConfig')
-    field_event_status: Optional[Dict[str, Any]] = Field(None, alias='_event_status')
     tags: Optional[List[str]] = None
     description: Optional[str] = ''
-    columns: Optional[Dict[str, ColumnInfo17]] = None
+    columns: Optional[Dict[str, ColumnInfo15]] = None
     meta: Optional[Dict[str, Any]] = None
     group: Optional[str] = None
     docs: Optional[Docs] = Field(None, title='Docs')
     patch_path: Optional[str] = None
     build_path: Optional[str] = None
-    deferred: Optional[bool] = False
     unrendered_config: Optional[Dict[str, Any]] = None
     created_at: Optional[float] = None
     config_call_dict: Optional[Dict[str, Any]] = None
@@ -1642,17 +1650,58 @@ class GenericTestNode1(BaseModel):
     column_name: Optional[str] = None
     file_key_name: Optional[str] = None
     attached_node: Optional[str] = None
+    test_metadata: Optional[TestMetadata] = Field(None, title='TestMetadata')
 
 
 class SnapshotConfig1(SnapshotConfig):
     pass
 
 
-class ColumnInfo18(ColumnInfo):
+class ColumnInfo16(ColumnInfo):
     pass
 
 
-class SnapshotNode1(BaseModel):
+class NodeConfig11(NodeConfig):
+    pass
+
+
+class DeferRelation5(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    database: Optional[str] = None
+    schema_: str = Field(..., alias='schema')
+    alias: str
+    relation_name: Optional[str] = None
+    resource_type: Literal[
+        'model',
+        'analysis',
+        'test',
+        'snapshot',
+        'operation',
+        'seed',
+        'rpc',
+        'sql_operation',
+        'doc',
+        'source',
+        'macro',
+        'exposure',
+        'metric',
+        'group',
+        'saved_query',
+        'semantic_model',
+        'unit_test',
+        'fixture',
+    ]
+    name: str
+    description: str
+    compiled_code: Optional[str] = None
+    meta: Dict[str, Any]
+    tags: List[str]
+    config: Optional[NodeConfig11] = None
+
+
+class Snapshot1(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
@@ -1668,16 +1717,14 @@ class SnapshotNode1(BaseModel):
     alias: str
     checksum: FileHash = Field(..., title='FileHash')
     config: SnapshotConfig1 = Field(..., title='SnapshotConfig')
-    field_event_status: Optional[Dict[str, Any]] = Field(None, alias='_event_status')
     tags: Optional[List[str]] = None
     description: Optional[str] = ''
-    columns: Optional[Dict[str, ColumnInfo18]] = None
+    columns: Optional[Dict[str, ColumnInfo16]] = None
     meta: Optional[Dict[str, Any]] = None
     group: Optional[str] = None
     docs: Optional[Docs] = Field(None, title='Docs')
     patch_path: Optional[str] = None
     build_path: Optional[str] = None
-    deferred: Optional[bool] = False
     unrendered_config: Optional[Dict[str, Any]] = None
     created_at: Optional[float] = None
     config_call_dict: Optional[Dict[str, Any]] = None
@@ -1695,107 +1742,7 @@ class SnapshotNode1(BaseModel):
     extra_ctes: Optional[List[InjectedCTE]] = None
     field_pre_injected_sql: Optional[str] = Field(None, alias='_pre_injected_sql')
     contract: Optional[Contract] = Field(None, title='Contract')
-    defer_relation: Optional[DeferRelation] = None
-
-
-class UnitTestNodeConfig1(UnitTestNodeConfig):
-    pass
-
-
-class ColumnInfo19(ColumnInfo):
-    pass
-
-
-class UnitTestNode1(BaseModel):
-    model_config = ConfigDict(
-        extra='forbid',
-    )
-    database: Optional[str] = None
-    schema_: str = Field(..., alias='schema')
-    name: str
-    resource_type: Literal['unit_test']
-    package_name: str
-    path: str
-    original_file_path: str
-    unique_id: str
-    fqn: List[str]
-    alias: str
-    checksum: FileHash = Field(..., title='FileHash')
-    config: Optional[UnitTestNodeConfig1] = Field(None, title='UnitTestNodeConfig')
-    field_event_status: Optional[Dict[str, Any]] = Field(None, alias='_event_status')
-    tags: Optional[List[str]] = None
-    description: Optional[str] = ''
-    columns: Optional[Dict[str, ColumnInfo19]] = None
-    meta: Optional[Dict[str, Any]] = None
-    group: Optional[str] = None
-    docs: Optional[Docs] = Field(None, title='Docs')
-    patch_path: Optional[str] = None
-    build_path: Optional[str] = None
-    deferred: Optional[bool] = False
-    unrendered_config: Optional[Dict[str, Any]] = None
-    created_at: Optional[float] = None
-    config_call_dict: Optional[Dict[str, Any]] = None
-    relation_name: Optional[str] = None
-    raw_code: Optional[str] = ''
-    language: Optional[str] = 'sql'
-    refs: Optional[List[RefArgs]] = None
-    sources: Optional[List[List[str]]] = None
-    metrics: Optional[List[List[str]]] = None
-    depends_on: Optional[DependsOn] = Field(None, title='DependsOn')
-    compiled_path: Optional[str] = None
-    compiled: Optional[bool] = False
-    compiled_code: Optional[str] = None
-    extra_ctes_injected: Optional[bool] = False
-    extra_ctes: Optional[List[InjectedCTE]] = None
-    field_pre_injected_sql: Optional[str] = Field(None, alias='_pre_injected_sql')
-    contract: Optional[Contract] = Field(None, title='Contract')
-    tested_node_unique_id: Optional[str] = None
-    this_input_node_unique_id: Optional[str] = None
-    overrides: Optional[UnitTestOverrides] = None
-
-
-class SeedConfig1(SeedConfig):
-    pass
-
-
-class ColumnInfo20(ColumnInfo):
-    pass
-
-
-class SeedNode1(BaseModel):
-    model_config = ConfigDict(
-        extra='forbid',
-    )
-    database: Optional[str] = None
-    schema_: str = Field(..., alias='schema')
-    name: str
-    resource_type: Literal['seed']
-    package_name: str
-    path: str
-    original_file_path: str
-    unique_id: str
-    fqn: List[str]
-    alias: str
-    checksum: FileHash = Field(..., title='FileHash')
-    config: Optional[SeedConfig1] = Field(None, title='SeedConfig')
-    field_event_status: Optional[Dict[str, Any]] = Field(None, alias='_event_status')
-    tags: Optional[List[str]] = None
-    description: Optional[str] = ''
-    columns: Optional[Dict[str, ColumnInfo20]] = None
-    meta: Optional[Dict[str, Any]] = None
-    group: Optional[str] = None
-    docs: Optional[Docs] = Field(None, title='Docs')
-    patch_path: Optional[str] = None
-    build_path: Optional[str] = None
-    deferred: Optional[bool] = False
-    unrendered_config: Optional[Dict[str, Any]] = None
-    created_at: Optional[float] = None
-    config_call_dict: Optional[Dict[str, Any]] = None
-    relation_name: Optional[str] = None
-    raw_code: Optional[str] = ''
-    root_path: Optional[str] = None
-    depends_on: Optional[MacroDependsOn] = Field(None, title='MacroDependsOn')
-    defer_relation: Optional[DeferRelation] = None
+    defer_relation: Optional[DeferRelation5] = None
 
 
 class FreshnessThreshold1(FreshnessThreshold):
@@ -1806,7 +1753,7 @@ class ExternalTable1(ExternalTable):
     pass
 
 
-class ColumnInfo21(ColumnInfo):
+class ColumnInfo17(ColumnInfo):
     pass
 
 
@@ -1827,13 +1774,12 @@ class SourceDefinition1(BaseModel):
     source_description: str
     loader: str
     identifier: str
-    field_event_status: Optional[Dict[str, Any]] = Field(None, alias='_event_status')
     quoting: Optional[Quoting] = Field(None, title='Quoting')
     loaded_at_field: Optional[str] = None
     freshness: Optional[FreshnessThreshold1] = None
     external: Optional[ExternalTable1] = None
     description: Optional[str] = ''
-    columns: Optional[Dict[str, ColumnInfo21]] = None
+    columns: Optional[Dict[str, ColumnInfo17]] = None
     meta: Optional[Dict[str, Any]] = None
     source_meta: Optional[Dict[str, Any]] = None
     tags: Optional[List[str]] = None
@@ -2037,6 +1983,7 @@ class ExportConfig(BaseModel):
     export_as: Literal['table', 'view']
     schema_name: Optional[str] = None
     alias: Optional[str] = None
+    database: Optional[str] = None
 
 
 class Export(BaseModel):
@@ -2051,6 +1998,13 @@ class SourceFileMetadata2(SourceFileMetadata):
     pass
 
 
+class SavedQueryCache(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    enabled: Optional[bool] = False
+
+
 class SavedQueryConfig(BaseModel):
     model_config = ConfigDict(
         extra='allow',
@@ -2061,6 +2015,7 @@ class SavedQueryConfig(BaseModel):
     meta: Optional[Dict[str, Any]] = None
     export_as: Optional[Literal['table', 'view']] = None
     schema_: Optional[str] = Field(None, alias='schema')
+    cache: Optional[SavedQueryCache] = Field(None, title='SavedQueryCache')
 
 
 class SavedQuery(BaseModel):
@@ -2104,7 +2059,6 @@ class SavedQuery(BaseModel):
     depends_on: Optional[DependsOn] = Field(None, title='DependsOn')
     created_at: Optional[float] = None
     refs: Optional[List[RefArgs]] = None
-    field_event_status: Optional[Dict[str, Any]] = Field(None, alias='_event_status')
 
 
 class NodeRelation(BaseModel):
@@ -2114,7 +2068,7 @@ class NodeRelation(BaseModel):
     alias: str
     schema_name: str
     database: Optional[str] = None
-    relation_name: Optional[str] = None
+    relation_name: Optional[str] = ''
 
 
 class Defaults(BaseModel):
@@ -2227,14 +2181,8 @@ class SourceFileMetadata4(SourceFileMetadata):
     pass
 
 
-class SemanticModelConfig(BaseModel):
-    model_config = ConfigDict(
-        extra='allow',
-    )
-    field_extra: Optional[Dict[str, Any]] = Field(None, alias='_extra')
-    enabled: Optional[bool] = True
-    group: Optional[str] = None
-    meta: Optional[Dict[str, Any]] = None
+class SemanticModelConfig(MetricConfig):
+    pass
 
 
 class SemanticModel(BaseModel):
@@ -2291,7 +2239,7 @@ class UnitTestInputFixture(BaseModel):
     )
     input: str
     rows: Optional[Union[str, List[Dict[str, Any]]]] = None
-    format: Optional[Literal['csv', 'dict']] = 'dict'
+    format: Optional[Literal['csv', 'dict', 'sql']] = 'dict'
     fixture: Optional[str] = None
 
 
@@ -2300,8 +2248,17 @@ class UnitTestOutputFixture(BaseModel):
         extra='forbid',
     )
     rows: Optional[Union[str, List[Dict[str, Any]]]] = None
-    format: Optional[Literal['csv', 'dict']] = 'dict'
+    format: Optional[Literal['csv', 'dict', 'sql']] = 'dict'
     fixture: Optional[str] = None
+
+
+class UnitTestOverrides(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    macros: Optional[Dict[str, Any]] = None
+    vars: Optional[Dict[str, Any]] = None
+    env_vars: Optional[Dict[str, Any]] = None
 
 
 class UnitTestConfig(BaseModel):
@@ -2354,7 +2311,6 @@ class UnitTestDefinition(BaseModel):
     original_file_path: str
     unique_id: str
     fqn: List[str]
-    field_event_status: Optional[Dict[str, Any]] = Field(None, alias='_event_status')
     description: Optional[str] = ''
     overrides: Optional[UnitTestOverrides] = None
     depends_on: Optional[DependsOn] = Field(None, title='DependsOn')
@@ -2384,6 +2340,10 @@ class Export1(Export):
 
 
 class SourceFileMetadata5(SourceFileMetadata):
+    pass
+
+
+class SavedQueryConfig1(SavedQueryConfig):
     pass
 
 
@@ -2422,7 +2382,7 @@ class SavedQuery1(BaseModel):
     description: Optional[str] = None
     label: Optional[str] = None
     metadata: Optional[SourceFileMetadata5] = None
-    config: Optional[SavedQueryConfig] = Field(None, title='SavedQueryConfig')
+    config: Optional[SavedQueryConfig1] = Field(None, title='SavedQueryConfig')
     unrendered_config: Optional[Dict[str, Any]] = None
     group: Optional[str] = None
     depends_on: Optional[DependsOn] = Field(None, title='DependsOn')
@@ -2522,16 +2482,14 @@ class WritableManifest(BaseModel):
     nodes: Dict[
         str,
         Union[
-            AnalysisNode,
-            SingularTestNode,
+            Seed,
+            Analysis,
+            SingularTest,
             HookNode,
-            ModelNode,
-            RPCNode,
-            SqlNode,
-            GenericTestNode,
-            SnapshotNode,
-            UnitTestNode,
-            SeedNode,
+            Model,
+            SqlOperation,
+            GenericTest,
+            Snapshot,
         ],
     ] = Field(
         ..., description='The nodes defined in the dbt project and its dependencies'
@@ -2562,16 +2520,14 @@ class WritableManifest(BaseModel):
             str,
             List[
                 Union[
-                    AnalysisNode1,
-                    SingularTestNode1,
+                    Seed1,
+                    Analysis1,
+                    SingularTest1,
                     HookNode1,
-                    ModelNode1,
-                    RPCNode1,
-                    SqlNode1,
-                    GenericTestNode1,
-                    SnapshotNode1,
-                    UnitTestNode1,
-                    SeedNode1,
+                    Model1,
+                    SqlOperation1,
+                    GenericTest1,
+                    Snapshot1,
                     SourceDefinition1,
                     Exposure1,
                     Metric1,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.6"
+version = "0.14.7"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/dbt/data/jaffle_v12/manifest.json
+++ b/tests/dbt/data/jaffle_v12/manifest.json
@@ -1,9 +1,9 @@
 {
   "metadata": {
     "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
-    "dbt_version": "1.8.0b2",
-    "generated_at": "2024-04-10T21:25:24.996714Z",
-    "invocation_id": "838a535b-e294-4d70-9ef4-4d3048f55f4c",
+    "dbt_version": "1.8.0",
+    "generated_at": "2024-05-20T21:56:59.029935Z",
+    "invocation_id": "2454d712-a02d-4156-8e0e-59bff7797ace",
     "env": {},
     "project_name": "jaffle_shop",
     "project_id": "06e5b98c2db46f8a72cc4f66410e9b3b",
@@ -83,11 +83,10 @@
       },
       "patch_path": "jaffle_shop://models/staging/__models.yml",
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {
         "materialized": "view"
       },
-      "created_at": 1712784318.834044,
+      "created_at": 1716242220.0957592,
       "relation_name": "DEV_DB.DBT_DEV.stg_products",
       "raw_code": "with\n\nsource as (\n\n    select * from raw_products\n\n),\n\nrenamed as (\n\n    select\n\n        ----------  ids\n        sku as product_id,\n\n        ---------- properties\n        name as product_name,\n        type as product_type,\n        description as product_description,\n        (price / 100.0) as product_price,\n\n\n        ---------- derived\n        case\n            when type = 'jaffle' then 1\n            else 0\n        end as is_food_item,\n\n        case\n            when type = 'beverage' then 1\n            else 0\n        end as is_drink_item\n\n    from source\n\n)\n\nselect * from renamed",
       "language": "sql",
@@ -185,11 +184,10 @@
       },
       "patch_path": "jaffle_shop://models/staging/__models.yml",
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {
         "materialized": "view"
       },
-      "created_at": 1712784318.832855,
+      "created_at": 1716242220.094442,
       "relation_name": "DEV_DB.DBT_DEV.stg_customers",
       "raw_code": "with\n\nsource as (\n\n    select * from raw_customers\n\n),\n\nrenamed as (\n\n    select\n\n        ----------  ids\n        id as customer_id,\n\n        ---------- properties\n        name as customer_name\n\n    from source\n\n)\n\nselect * from renamed",
       "language": "sql",
@@ -287,11 +285,10 @@
       },
       "patch_path": "jaffle_shop://models/staging/__models.yml",
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {
         "materialized": "view"
       },
-      "created_at": 1712784318.834455,
+      "created_at": 1716242220.0961769,
       "relation_name": "DEV_DB.DBT_DEV.stg_supplies",
       "raw_code": "with\n\nsource as (\n\n    select * from raw_supplies\n\n),\n\nrenamed as (\n\n    select\n\n        ----------  ids\n        {{ dbt_utils.generate_surrogate_key(['id', 'sku']) }} as supply_uuid,\n        id as supply_id,\n        sku as product_id,\n\n        ---------- properties\n        name as supply_name,\n        (cost / 100.0) as supply_cost,\n        perishable as is_perishable_supply\n\n    from source\n\n)\n\nselect * from renamed",
       "language": "sql",
@@ -391,12 +388,11 @@
       },
       "patch_path": "jaffle_shop://models/staging/__models.yml",
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {
         "materialized": "table",
         "unique_key": "order_id"
       },
-      "created_at": 1712784318.8339221,
+      "created_at": 1716242220.095634,
       "relation_name": "DEV_DB.DBT_DEV.stg_orders",
       "raw_code": "{{\n    config(\n        materialized = 'table',\n        unique_key = 'order_id'\n    )\n}}\n\nwith\n\nsource as (\n\n    select * from raw_orders\n\n    -- data runs to 2026, truncate timespan to desired range,\n    -- current time as default\n    -- where ordered_at <= {{ var('truncate_timespan_to') }}\n\n),\n\nrenamed as (\n\n    select\n\n        ----------  ids\n        id as order_id,\n        store_id as location_id,\n        customer as customer_id,\n\n        ---------- properties\n        (order_total / 100.0) as order_total,\n        (tax_paid / 100.0) as tax_paid,\n\n        ---------- timestamps\n        ordered_at\n\n    from source\n\n)\n\nselect * from renamed",
       "language": "sql",
@@ -496,11 +492,10 @@
       },
       "patch_path": "jaffle_shop://models/staging/__models.yml",
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {
         "materialized": "view"
       },
-      "created_at": 1712784318.833483,
+      "created_at": 1716242220.095197,
       "relation_name": "DEV_DB.DBT_DEV.stg_order_items",
       "raw_code": "with\n\nsource as (\n\n    select * from raw_items\n\n),\n\nrenamed as (\n\n    select\n\n        ----------  ids\n        id as order_item_id,\n        order_id,\n\n        ---------- properties\n        sku as product_id\n\n    from source\n\n)\n\nselect * from renamed",
       "language": "sql",
@@ -598,11 +593,10 @@
       },
       "patch_path": "jaffle_shop://models/staging/__models.yml",
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {
         "materialized": "view"
       },
-      "created_at": 1712784318.833008,
+      "created_at": 1716242220.0946019,
       "relation_name": "DEV_DB.DBT_DEV.stg_locations",
       "raw_code": "with\n\nsource as (\n\n    select * from raw_stores\n\n    -- {# data runs to 2026, truncate timespan to desired range, \n    -- current time as default #}\n    -- where opened_at <= {{ var('truncate_timespan_to') }}\n\n),\n\nrenamed as (\n\n    select\n\n        ----------  ids\n        id as location_id,\n\n        ---------- properties\n        name as location_name,\n        tax_rate,\n\n        ---------- timestamp\n        opened_at\n\n    from source\n\n)\n\nselect * from renamed",
       "language": "sql",
@@ -765,11 +759,10 @@
       },
       "patch_path": "jaffle_shop://models/marts/customers.yml",
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {
         "materialized": "table"
       },
-      "created_at": 1712784318.882386,
+      "created_at": 1716242220.145539,
       "relation_name": "DEV_DB.DBT_DEV.customers",
       "raw_code": "{{\n    config(\n        materialized='table'\n    )\n}}\n\nwith\n\ncustomers as (\n\n    select * from {{ ref('stg_customers') }}\n\n),\n\norders_mart as (\n\n    select * from {{ ref('orders') }}\n\n),\n\norder_items_mart as (\n\n    select * from {{ ref('order_items') }}\n),\n\norder_summary as (\n\n    select\n        customer_id,\n\n        count(distinct om.order_id) as count_lifetime_orders,\n        count(distinct om.order_id) > 1 as is_repeat_buyer,\n        min(om.ordered_at) as first_ordered_at,\n        max(om.ordered_at) as last_ordered_at,\n        sum(oi.subtotal) as lifetime_spend_pretax,\n        sum(om.order_total) as lifetime_spend\n\n    from orders_mart om\n    \n    left join order_items_mart oi on om.order_id = oi.order_id\n    \n    group by 1\n\n),\n\njoined as (\n\n    select\n        customers.*,\n        order_summary.count_lifetime_orders,\n        order_summary.first_ordered_at,\n        order_summary.last_ordered_at,\n        order_summary.lifetime_spend_pretax,\n        order_summary.lifetime_spend,\n\n        case\n            when order_summary.is_repeat_buyer then 'returning'\n            else 'new'\n        end as customer_type\n\n    from customers\n\n    left join order_summary\n        on customers.customer_id = order_summary.customer_id\n\n)\n\nselect * from joined",
       "language": "sql",
@@ -1022,12 +1015,11 @@
       },
       "patch_path": "jaffle_shop://models/marts/orders.yml",
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {
         "materialized": "table",
         "unique_key": "order_id"
       },
-      "created_at": 1712784318.89779,
+      "created_at": 1716242220.161142,
       "relation_name": "DEV_DB.DBT_DEV.orders",
       "raw_code": "{{\n    config(\n        materialized = 'table',\n        unique_key = 'order_id'\n    )\n}}\n\n\nwith orders as (\n    \n    select * from {{ ref('stg_orders')}}\n\n),\n\norder_items as (\n    \n    select * from {{ ref('stg_order_items')}}\n\n),\n\nproducts as (\n\n    select * from {{ ref('stg_products') }}\n),\n\nsupplies as (\n\n    select * from {{ ref('stg_supplies') }}\n\n),\n\n\norder_items_summary as (\n\n    select\n\n        order_items.order_id,\n\n        sum(supplies.supply_cost) as order_cost,\n        sum(is_food_item) as count_food_items,\n        sum(is_drink_item) as count_drink_items\n\n\n    from order_items\n\n    left join supplies on order_items.product_id = supplies.product_id\n    left join products on order_items.product_id = products.product_id\n\n    group by 1\n\n),\n\n\nfinal as (\n    select\n\n        orders.*,\n        count_food_items > 0 as is_food_order,\n        count_drink_items > 0 as is_drink_order,\n        order_cost\n\n    from orders\n    \n    left join order_items_summary on orders.order_id = order_items_summary.order_id\n)\n\nselect * from final",
       "language": "sql",
@@ -1141,11 +1133,10 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {
         "materialized": "table"
       },
-      "created_at": 1712784318.619474,
+      "created_at": 1716242219.861016,
       "relation_name": "DEV_DB.DBT_DEV.metricflow_time_spine",
       "raw_code": "-- metricflow_time_spine.sql\nwith days as (\n    --for BQ adapters use \"DATE('01/01/2000','mm/dd/yyyy')\"\n{{ dbt_date.get_base_dates(n_dateparts=365*10, datepart=\"day\") }}\n),\n\nfinal as (\n    select cast(date_day as date) as date_day\n    from days\n)\n\nselect *\nfrom final",
       "language": "sql",
@@ -1235,12 +1226,11 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {
         "materialized": "table",
         "unique_key": "order_item_id"
       },
-      "created_at": 1712784318.643062,
+      "created_at": 1716242219.884819,
       "relation_name": "DEV_DB.DBT_DEV.order_items",
       "raw_code": "{{\n    config(\n        materialized = 'table',\n        unique_key = 'order_item_id'\n    )\n}}\n\nwith order_items as (\n\n    select * from {{ ref('stg_order_items') }}\n\n),\n\n\norders as (\n    \n    select * from {{ ref('stg_orders')}}\n),\n\nproducts as (\n\n    select * from {{ ref('stg_products') }}\n\n),\n\n\nfinal as (\n    select\n        order_items.*,\n        orders.ordered_at,\n        products.product_price as subtotal,\n        products.is_food_item,\n        products.is_drink_item\n    from order_items\n\n    left join products on order_items.product_id = products.product_id\n    -- left join order_supplies_summary on order_items.order_id = order_supplies_summary.product_id\n    left join orders on order_items.order_id  = orders.order_id\n)\n\nselect * from final",
       "language": "sql",
@@ -1348,9 +1338,8 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {},
-      "created_at": 1712784318.689166,
+      "created_at": 1716242219.943251,
       "relation_name": "DEV_DB.DBT_DEV.raw_items",
       "raw_code": "",
       "root_path": "/Users/marslan/Metaphor/dbt/jaffle-sl-template",
@@ -1419,9 +1408,8 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {},
-      "created_at": 1712784318.6901708,
+      "created_at": 1716242219.944294,
       "relation_name": "DEV_DB.DBT_DEV.raw_customers",
       "raw_code": "",
       "root_path": "/Users/marslan/Metaphor/dbt/jaffle-sl-template",
@@ -1490,9 +1478,8 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {},
-      "created_at": 1712784318.691088,
+      "created_at": 1716242219.94525,
       "relation_name": "DEV_DB.DBT_DEV.raw_stores",
       "raw_code": "",
       "root_path": "/Users/marslan/Metaphor/dbt/jaffle-sl-template",
@@ -1561,9 +1548,8 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {},
-      "created_at": 1712784318.691989,
+      "created_at": 1716242219.946188,
       "relation_name": "DEV_DB.DBT_DEV.raw_orders",
       "raw_code": "",
       "root_path": "/Users/marslan/Metaphor/dbt/jaffle-sl-template",
@@ -1632,9 +1618,8 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {},
-      "created_at": 1712784318.692996,
+      "created_at": 1716242219.9471629,
       "relation_name": "DEV_DB.DBT_DEV.raw_supplies",
       "raw_code": "",
       "root_path": "/Users/marslan/Metaphor/dbt/jaffle-sl-template",
@@ -1703,9 +1688,8 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {},
-      "created_at": 1712784318.693932,
+      "created_at": 1716242219.948169,
       "relation_name": "DEV_DB.DBT_DEV.raw_products",
       "raw_code": "",
       "root_path": "/Users/marslan/Metaphor/dbt/jaffle-sl-template",
@@ -1761,9 +1745,8 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {},
-      "created_at": 1712784318.872787,
+      "created_at": 1716242220.136246,
       "relation_name": null,
       "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -1855,9 +1838,8 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {},
-      "created_at": 1712784318.8736188,
+      "created_at": 1716242220.137135,
       "relation_name": null,
       "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -1949,9 +1931,8 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {},
-      "created_at": 1712784318.87437,
+      "created_at": 1716242220.137889,
       "relation_name": null,
       "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -2043,9 +2024,8 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {},
-      "created_at": 1712784318.875067,
+      "created_at": 1716242220.138613,
       "relation_name": null,
       "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -2137,9 +2117,8 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {},
-      "created_at": 1712784318.8757582,
+      "created_at": 1716242220.139341,
       "relation_name": null,
       "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -2231,9 +2210,8 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {},
-      "created_at": 1712784318.8770719,
+      "created_at": 1716242220.1401632,
       "relation_name": null,
       "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -2325,9 +2303,8 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {},
-      "created_at": 1712784318.877769,
+      "created_at": 1716242220.1408699,
       "relation_name": null,
       "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -2419,9 +2396,8 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {},
-      "created_at": 1712784318.878459,
+      "created_at": 1716242220.141589,
       "relation_name": null,
       "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -2513,9 +2489,8 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {},
-      "created_at": 1712784318.8791602,
+      "created_at": 1716242220.142299,
       "relation_name": null,
       "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -2607,9 +2582,8 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {},
-      "created_at": 1712784318.879916,
+      "created_at": 1716242220.1430469,
       "relation_name": null,
       "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -2701,9 +2675,8 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {},
-      "created_at": 1712784318.880618,
+      "created_at": 1716242220.143774,
       "relation_name": null,
       "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -2795,9 +2768,8 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {},
-      "created_at": 1712784318.8813262,
+      "created_at": 1716242220.144476,
       "relation_name": null,
       "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -2889,9 +2861,8 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {},
-      "created_at": 1712784318.882806,
+      "created_at": 1716242220.1459682,
       "relation_name": null,
       "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -2983,9 +2954,8 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {},
-      "created_at": 1712784318.8836212,
+      "created_at": 1716242220.146764,
       "relation_name": null,
       "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -3077,9 +3047,8 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {},
-      "created_at": 1712784318.8843362,
+      "created_at": 1716242220.147487,
       "relation_name": null,
       "raw_code": "{{ test_accepted_values(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -3175,9 +3144,8 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {},
-      "created_at": 1712784318.89822,
+      "created_at": 1716242220.161572,
       "relation_name": null,
       "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -3269,9 +3237,8 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {},
-      "created_at": 1712784318.8989792,
+      "created_at": 1716242220.162294,
       "relation_name": null,
       "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -3363,11 +3330,10 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {
         "alias": "relationships_orders_0389c224a99a98c0b58aedb753f052f0"
       },
-      "created_at": 1712784318.8997629,
+      "created_at": 1716242220.1630762,
       "relation_name": null,
       "raw_code": "{{ test_relationships(**_dbt_generic_test_kwargs) }}{{ config(alias=\"relationships_orders_0389c224a99a98c0b58aedb753f052f0\") }}",
       "language": "sql",
@@ -3441,7 +3407,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.9114041,
+      "created_at": 1716242219.175045,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_catalog": {
@@ -3469,7 +3435,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.914986,
+      "created_at": 1716242219.178978,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_catalog_relations": {
@@ -3497,7 +3463,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.915334,
+      "created_at": 1716242219.179339,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_catalog_tables_sql": {
@@ -3519,7 +3485,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.915522,
+      "created_at": 1716242219.179531,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_catalog_columns_sql": {
@@ -3541,7 +3507,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.915633,
+      "created_at": 1716242219.179647,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_catalog_results_sql": {
@@ -3563,7 +3529,29 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.915709,
+      "created_at": 1716242219.179727,
+      "supported_languages": null
+    },
+    "macro.dbt_snowflake.snowflake__catalog_equals": {
+      "name": "snowflake__catalog_equals",
+      "resource_type": "macro",
+      "package_name": "dbt_snowflake",
+      "path": "macros/catalog.sql",
+      "original_file_path": "macros/catalog.sql",
+      "unique_id": "macro.dbt_snowflake.snowflake__catalog_equals",
+      "macro_sql": "{% macro snowflake__catalog_equals(field, value) %}\n    \"{{ field }}\" ilike '{{ value }}' and upper(\"{{ field }}\") = upper('{{ value }}')\n{% endmacro %}",
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1716242219.1798851,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_catalog_schemas_where_clause_sql": {
@@ -3573,9 +3561,11 @@
       "path": "macros/catalog.sql",
       "original_file_path": "macros/catalog.sql",
       "unique_id": "macro.dbt_snowflake.snowflake__get_catalog_schemas_where_clause_sql",
-      "macro_sql": "{% macro snowflake__get_catalog_schemas_where_clause_sql(schemas) -%}\n    where ({%- for schema in schemas -%}\n        upper(\"table_schema\") = upper('{{ schema }}'){%- if not loop.last %} or {% endif -%}\n    {%- endfor -%})\n{%- endmacro %}",
+      "macro_sql": "{% macro snowflake__get_catalog_schemas_where_clause_sql(schemas) -%}\n    where ({%- for schema in schemas -%}\n        ({{ snowflake__catalog_equals('table_schema', schema) }}){%- if not loop.last %} or {% endif -%}\n    {%- endfor -%})\n{%- endmacro %}",
       "depends_on": {
-        "macros": []
+        "macros": [
+          "macro.dbt_snowflake.snowflake__catalog_equals"
+        ]
       },
       "description": "",
       "meta": {},
@@ -3585,7 +3575,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.915919,
+      "created_at": 1716242219.180146,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_catalog_relations_where_clause_sql": {
@@ -3595,9 +3585,11 @@
       "path": "macros/catalog.sql",
       "original_file_path": "macros/catalog.sql",
       "unique_id": "macro.dbt_snowflake.snowflake__get_catalog_relations_where_clause_sql",
-      "macro_sql": "{% macro snowflake__get_catalog_relations_where_clause_sql(relations) -%}\n    where (\n        {%- for relation in relations -%}\n            {% if relation.schema and relation.identifier %}\n                (\n                    upper(\"table_schema\") = upper('{{ relation.schema }}')\n                    and upper(\"table_name\") = upper('{{ relation.identifier }}')\n                )\n            {% elif relation.schema %}\n                (\n                    upper(\"table_schema\") = upper('{{ relation.schema }}')\n                )\n            {% else %}\n                {% do exceptions.raise_compiler_error(\n                    '`get_catalog_relations` requires a list of relations, each with a schema'\n                ) %}\n            {% endif %}\n\n            {%- if not loop.last %} or {% endif -%}\n        {%- endfor -%}\n    )\n{%- endmacro %}",
+      "macro_sql": "{% macro snowflake__get_catalog_relations_where_clause_sql(relations) -%}\n    where (\n        {%- for relation in relations -%}\n            {% if relation.schema and relation.identifier %}\n                (\n                    {{ snowflake__catalog_equals('table_schema', relation.schema) }}\n                    and {{ snowflake__catalog_equals('table_name', relation.identifier) }}\n                )\n            {% elif relation.schema %}\n                (\n                    {{ snowflake__catalog_equals('table_schema', relation.schema) }}\n                )\n            {% else %}\n                {% do exceptions.raise_compiler_error(\n                    '`get_catalog_relations` requires a list of relations, each with a schema'\n                ) %}\n            {% endif %}\n\n            {%- if not loop.last %} or {% endif -%}\n        {%- endfor -%}\n    )\n{%- endmacro %}",
       "depends_on": {
-        "macros": []
+        "macros": [
+          "macro.dbt_snowflake.snowflake__catalog_equals"
+        ]
       },
       "description": "",
       "meta": {},
@@ -3607,7 +3599,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.91638,
+      "created_at": 1716242219.180737,
       "supported_languages": null
     },
     "macro.dbt_snowflake.get_column_comment_sql": {
@@ -3629,7 +3621,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.926042,
+      "created_at": 1716242219.190578,
       "supported_languages": null
     },
     "macro.dbt_snowflake.get_persist_docs_column_list": {
@@ -3653,7 +3645,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.926291,
+      "created_at": 1716242219.190837,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_columns_in_relation": {
@@ -3677,7 +3669,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.927009,
+      "created_at": 1716242219.1915572,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__list_schemas": {
@@ -3701,7 +3693,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.9275038,
+      "created_at": 1716242219.19206,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_paginated_relations_array": {
@@ -3725,7 +3717,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.9284952,
+      "created_at": 1716242219.193069,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__list_relations_without_caching": {
@@ -3750,7 +3742,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.9293299,
+      "created_at": 1716242219.193923,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__check_schema_exists": {
@@ -3774,7 +3766,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.92963,
+      "created_at": 1716242219.1942232,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__alter_column_type": {
@@ -3798,7 +3790,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.929854,
+      "created_at": 1716242219.194454,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__alter_relation_comment": {
@@ -3820,7 +3812,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.930145,
+      "created_at": 1716242219.1947572,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__alter_column_comment": {
@@ -3844,7 +3836,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.93071,
+      "created_at": 1716242219.19535,
       "supported_languages": null
     },
     "macro.dbt_snowflake.get_current_query_tag": {
@@ -3868,7 +3860,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.930881,
+      "created_at": 1716242219.195519,
       "supported_languages": null
     },
     "macro.dbt_snowflake.set_query_tag": {
@@ -3892,7 +3884,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.9310231,
+      "created_at": 1716242219.195665,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__set_query_tag": {
@@ -3917,7 +3909,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.9314308,
+      "created_at": 1716242219.1960871,
       "supported_languages": null
     },
     "macro.dbt_snowflake.unset_query_tag": {
@@ -3941,7 +3933,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.931595,
+      "created_at": 1716242219.1962528,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__unset_query_tag": {
@@ -3965,7 +3957,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.9320168,
+      "created_at": 1716242219.196757,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__alter_relation_add_remove_columns": {
@@ -3989,7 +3981,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.9328508,
+      "created_at": 1716242219.19755,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake_dml_explicit_transaction": {
@@ -4011,7 +4003,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.933043,
+      "created_at": 1716242219.197747,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__truncate_relation": {
@@ -4036,7 +4028,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.933256,
+      "created_at": 1716242219.19797,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__copy_grants": {
@@ -4058,7 +4050,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.933507,
+      "created_at": 1716242219.198227,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__support_multiple_grantees_per_dcl_statement": {
@@ -4080,7 +4072,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.9336169,
+      "created_at": 1716242219.1983302,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_relation_last_modified": {
@@ -4105,7 +4097,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.9342332,
+      "created_at": 1716242219.198942,
       "supported_languages": null
     },
     "macro.dbt_snowflake.materialization_test_snowflake": {
@@ -4131,7 +4123,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.934538,
+      "created_at": 1716242219.1992588,
       "supported_languages": [
         "sql"
       ]
@@ -4159,7 +4151,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.935782,
+      "created_at": 1716242219.200531,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_delete_insert_merge_sql": {
@@ -4184,7 +4176,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.936049,
+      "created_at": 1716242219.2008069,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__snapshot_merge_sql": {
@@ -4209,7 +4201,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.936272,
+      "created_at": 1716242219.2010372,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_incremental_append_sql": {
@@ -4234,7 +4226,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.936456,
+      "created_at": 1716242219.201227,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__load_csv_rows": {
@@ -4259,7 +4251,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.9384031,
+      "created_at": 1716242219.203199,
       "supported_languages": null
     },
     "macro.dbt_snowflake.materialization_seed_snowflake": {
@@ -4285,7 +4277,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.938942,
+      "created_at": 1716242219.2035341,
       "supported_languages": [
         "sql"
       ]
@@ -4314,7 +4306,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.9394329,
+      "created_at": 1716242219.20404,
       "supported_languages": [
         "sql"
       ]
@@ -4348,7 +4340,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.941498,
+      "created_at": 1716242219.206079,
       "supported_languages": [
         "sql",
         "python"
@@ -4375,7 +4367,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.9419599,
+      "created_at": 1716242219.206539,
       "supported_languages": null
     },
     "macro.dbt_snowflake.py_script_comment": {
@@ -4397,7 +4389,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.9420621,
+      "created_at": 1716242219.206642,
       "supported_languages": null
     },
     "macro.dbt_snowflake.dbt_snowflake_get_tmp_relation_type": {
@@ -4419,7 +4411,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.944363,
+      "created_at": 1716242219.208968,
       "supported_languages": null
     },
     "macro.dbt_snowflake.materialization_incremental_snowflake": {
@@ -4458,7 +4450,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.9711292,
+      "created_at": 1716242219.211942,
       "supported_languages": [
         "sql",
         "python"
@@ -4485,7 +4477,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.971346,
+      "created_at": 1716242219.212099,
       "supported_languages": null
     },
     "macro.dbt_snowflake.materialization_snapshot_snowflake": {
@@ -4511,7 +4503,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.971761,
+      "created_at": 1716242219.212419,
       "supported_languages": [
         "sql"
       ]
@@ -4543,7 +4535,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.975897,
+      "created_at": 1716242219.215791,
       "supported_languages": [
         "sql"
       ]
@@ -4573,7 +4565,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.977371,
+      "created_at": 1716242219.216954,
       "supported_languages": null
     },
     "macro.dbt_snowflake.dynamic_table_execute_no_op": {
@@ -4595,7 +4587,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.97763,
+      "created_at": 1716242219.217162,
       "supported_languages": null
     },
     "macro.dbt_snowflake.dynamic_table_execute_build_sql": {
@@ -4622,7 +4614,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.978155,
+      "created_at": 1716242219.217597,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_dynamic_table_configuration_changes": {
@@ -4646,7 +4638,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.978464,
+      "created_at": 1716242219.2178519,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__can_clone_table": {
@@ -4668,7 +4660,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.9787378,
+      "created_at": 1716242219.21808,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__create_or_replace_clone": {
@@ -4690,7 +4682,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.9790468,
+      "created_at": 1716242219.218337,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_drop_sql": {
@@ -4715,7 +4707,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.979381,
+      "created_at": 1716242219.218622,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_replace_sql": {
@@ -4740,7 +4732,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.979776,
+      "created_at": 1716242219.218981,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__rename_relation": {
@@ -4764,7 +4756,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.980004,
+      "created_at": 1716242219.219229,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_create_sql": {
@@ -4789,7 +4781,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.98031,
+      "created_at": 1716242219.219548,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_drop_table_sql": {
@@ -4811,7 +4803,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.9804318,
+      "created_at": 1716242219.2196748,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_replace_table_sql": {
@@ -4835,7 +4827,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.980604,
+      "created_at": 1716242219.2198458,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_rename_table_sql": {
@@ -4857,7 +4849,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.980762,
+      "created_at": 1716242219.219997,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__create_table_as": {
@@ -4884,7 +4876,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.984376,
+      "created_at": 1716242219.2236722,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_drop_view_sql": {
@@ -4906,7 +4898,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.984517,
+      "created_at": 1716242219.2238138,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_replace_view_sql": {
@@ -4930,7 +4922,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.9846761,
+      "created_at": 1716242219.223975,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_rename_view_sql": {
@@ -4952,7 +4944,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.98483,
+      "created_at": 1716242219.2241411,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__create_view_as_with_temp_flag": {
@@ -4978,7 +4970,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.986482,
+      "created_at": 1716242219.225753,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__create_view_as": {
@@ -5002,7 +4994,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.986638,
+      "created_at": 1716242219.225891,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__create_or_replace_view": {
@@ -5032,7 +5024,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.987628,
+      "created_at": 1716242219.226877,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_drop_dynamic_table_sql": {
@@ -5054,7 +5046,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.9877892,
+      "created_at": 1716242219.227015,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_replace_dynamic_table_sql": {
@@ -5078,7 +5070,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.988138,
+      "created_at": 1716242219.227361,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__describe_dynamic_table": {
@@ -5102,7 +5094,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.9886332,
+      "created_at": 1716242219.2278621,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__refresh_dynamic_table": {
@@ -5124,7 +5116,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.9888399,
+      "created_at": 1716242219.2280478,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_alter_dynamic_table_as_sql": {
@@ -5148,7 +5140,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.989826,
+      "created_at": 1716242219.229043,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_create_dynamic_table_as_sql": {
@@ -5170,7 +5162,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.990125,
+      "created_at": 1716242219.2293482,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__current_timestamp": {
@@ -5192,7 +5184,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.990384,
+      "created_at": 1716242219.229612,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__snapshot_string_as_time": {
@@ -5214,7 +5206,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.9905422,
+      "created_at": 1716242219.229772,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__snapshot_get_time": {
@@ -5238,7 +5230,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.990638,
+      "created_at": 1716242219.2298691,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__current_timestamp_backcompat": {
@@ -5262,7 +5254,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.990751,
+      "created_at": 1716242219.229965,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__current_timestamp_in_utc_backcompat": {
@@ -5287,7 +5279,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.990876,
+      "created_at": 1716242219.230088,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__escape_single_quotes": {
@@ -5309,7 +5301,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.991055,
+      "created_at": 1716242219.230259,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__right": {
@@ -5331,7 +5323,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.991296,
+      "created_at": 1716242219.230473,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__safe_cast": {
@@ -5357,7 +5349,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.9920151,
+      "created_at": 1716242219.231166,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__cast": {
@@ -5379,7 +5371,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.99239,
+      "created_at": 1716242219.231549,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__bool_or": {
@@ -5401,7 +5393,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.992513,
+      "created_at": 1716242219.231675,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__array_construct": {
@@ -5423,7 +5415,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.992667,
+      "created_at": 1716242219.231835,
       "supported_languages": null
     },
     "macro.dbt.run_hooks": {
@@ -5447,7 +5439,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.993639,
+      "created_at": 1716242219.23282,
       "supported_languages": null
     },
     "macro.dbt.make_hook_config": {
@@ -5469,7 +5461,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.993838,
+      "created_at": 1716242219.233,
       "supported_languages": null
     },
     "macro.dbt.before_begin": {
@@ -5493,7 +5485,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.9939709,
+      "created_at": 1716242219.233129,
       "supported_languages": null
     },
     "macro.dbt.in_transaction": {
@@ -5517,7 +5509,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.994103,
+      "created_at": 1716242219.233258,
       "supported_languages": null
     },
     "macro.dbt.after_commit": {
@@ -5541,7 +5533,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.994231,
+      "created_at": 1716242219.2333891,
       "supported_languages": null
     },
     "macro.dbt.set_sql_header": {
@@ -5563,7 +5555,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.994566,
+      "created_at": 1716242219.233727,
       "supported_languages": null
     },
     "macro.dbt.should_full_refresh": {
@@ -5585,7 +5577,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.994826,
+      "created_at": 1716242219.233995,
       "supported_languages": null
     },
     "macro.dbt.should_store_failures": {
@@ -5607,7 +5599,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.995092,
+      "created_at": 1716242219.234269,
       "supported_languages": null
     },
     "macro.dbt.snapshot_merge_sql": {
@@ -5631,7 +5623,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.995486,
+      "created_at": 1716242219.234674,
       "supported_languages": null
     },
     "macro.dbt.default__snapshot_merge_sql": {
@@ -5653,7 +5645,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.9957418,
+      "created_at": 1716242219.2349231,
       "supported_languages": null
     },
     "macro.dbt.strategy_dispatch": {
@@ -5675,7 +5667,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.999051,
+      "created_at": 1716242219.238258,
       "supported_languages": null
     },
     "macro.dbt.snapshot_hash_arguments": {
@@ -5699,7 +5691,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.999202,
+      "created_at": 1716242219.238414,
       "supported_languages": null
     },
     "macro.dbt.default__snapshot_hash_arguments": {
@@ -5721,7 +5713,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784317.9994,
+      "created_at": 1716242219.238613,
       "supported_languages": null
     },
     "macro.dbt.snapshot_timestamp_strategy": {
@@ -5745,7 +5737,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.000031,
+      "created_at": 1716242219.239254,
       "supported_languages": null
     },
     "macro.dbt.snapshot_string_as_time": {
@@ -5769,7 +5761,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.000179,
+      "created_at": 1716242219.239404,
       "supported_languages": null
     },
     "macro.dbt.default__snapshot_string_as_time": {
@@ -5791,7 +5783,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0003278,
+      "created_at": 1716242219.239558,
       "supported_languages": null
     },
     "macro.dbt.snapshot_check_all_get_existing_columns": {
@@ -5815,7 +5807,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0015638,
+      "created_at": 1716242219.240797,
       "supported_languages": null
     },
     "macro.dbt.snapshot_check_strategy": {
@@ -5842,7 +5834,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.002794,
+      "created_at": 1716242219.242177,
       "supported_languages": null
     },
     "macro.dbt.create_columns": {
@@ -5866,7 +5858,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.006871,
+      "created_at": 1716242219.246123,
       "supported_languages": null
     },
     "macro.dbt.default__create_columns": {
@@ -5890,7 +5882,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.007126,
+      "created_at": 1716242219.246376,
       "supported_languages": null
     },
     "macro.dbt.post_snapshot": {
@@ -5914,7 +5906,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.007284,
+      "created_at": 1716242219.246526,
       "supported_languages": null
     },
     "macro.dbt.default__post_snapshot": {
@@ -5936,7 +5928,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.007367,
+      "created_at": 1716242219.246607,
       "supported_languages": null
     },
     "macro.dbt.get_true_sql": {
@@ -5960,7 +5952,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.007499,
+      "created_at": 1716242219.246737,
       "supported_languages": null
     },
     "macro.dbt.default__get_true_sql": {
@@ -5982,7 +5974,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.007605,
+      "created_at": 1716242219.246846,
       "supported_languages": null
     },
     "macro.dbt.snapshot_staging_table": {
@@ -6006,7 +5998,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0077922,
+      "created_at": 1716242219.2470322,
       "supported_languages": null
     },
     "macro.dbt.default__snapshot_staging_table": {
@@ -6030,7 +6022,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0085912,
+      "created_at": 1716242219.2478368,
       "supported_languages": null
     },
     "macro.dbt.build_snapshot_table": {
@@ -6054,7 +6046,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0087612,
+      "created_at": 1716242219.248009,
       "supported_languages": null
     },
     "macro.dbt.default__build_snapshot_table": {
@@ -6076,7 +6068,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.008993,
+      "created_at": 1716242219.248236,
       "supported_languages": null
     },
     "macro.dbt.build_snapshot_staging_table": {
@@ -6103,7 +6095,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.009374,
+      "created_at": 1716242219.2486138,
       "supported_languages": null
     },
     "macro.dbt.materialization_snapshot_default": {
@@ -6140,7 +6132,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.015408,
+      "created_at": 1716242219.254373,
       "supported_languages": [
         "sql"
       ]
@@ -6169,7 +6161,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0178628,
+      "created_at": 1716242219.2568362,
       "supported_languages": [
         "sql"
       ]
@@ -6195,7 +6187,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.01892,
+      "created_at": 1716242219.257887,
       "supported_languages": null
     },
     "macro.dbt.default__get_test_sql": {
@@ -6217,7 +6209,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.019199,
+      "created_at": 1716242219.25816,
       "supported_languages": null
     },
     "macro.dbt.get_unit_test_sql": {
@@ -6241,7 +6233,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.019389,
+      "created_at": 1716242219.2583501,
       "supported_languages": null
     },
     "macro.dbt.default__get_unit_test_sql": {
@@ -6265,7 +6257,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.019933,
+      "created_at": 1716242219.258894,
       "supported_languages": null
     },
     "macro.dbt.get_where_subquery": {
@@ -6289,7 +6281,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0202959,
+      "created_at": 1716242219.2592409,
       "supported_languages": null
     },
     "macro.dbt.default__get_where_subquery": {
@@ -6311,7 +6303,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.020649,
+      "created_at": 1716242219.2595851,
       "supported_languages": null
     },
     "macro.dbt.materialization_unit_default": {
@@ -6321,7 +6313,7 @@
       "path": "macros/materializations/tests/unit.sql",
       "original_file_path": "macros/materializations/tests/unit.sql",
       "unique_id": "macro.dbt.materialization_unit_default",
-      "macro_sql": "{%- materialization unit, default -%}\n\n  {% set relations = [] %}\n\n  {% set expected_rows = config.get('expected_rows') %}\n  {% set tested_expected_column_names = expected_rows[0].keys() if (expected_rows | length ) > 0 else get_columns_in_query(sql) %} %}\n\n  {%- set target_relation = this.incorporate(type='table') -%}\n  {%- set temp_relation = make_temp_relation(target_relation)-%}\n  {% do run_query(get_create_table_as_sql(True, temp_relation, get_empty_subquery_sql(sql))) %}\n  {%- set columns_in_relation = adapter.get_columns_in_relation(temp_relation) -%}\n  {%- set column_name_to_data_types = {} -%}\n  {%- for column in columns_in_relation -%}\n  {%- do column_name_to_data_types.update({column.name|lower: column.data_type}) -%}\n  {%- endfor -%}\n\n  {% set unit_test_sql = get_unit_test_sql(sql, get_expected_sql(expected_rows, column_name_to_data_types), tested_expected_column_names) %}\n\n  {% call statement('main', fetch_result=True) -%}\n\n    {{ unit_test_sql }}\n\n  {%- endcall %}\n\n  {% do adapter.drop_relation(temp_relation) %}\n\n  {{ return({'relations': relations}) }}\n\n{%- endmaterialization -%}",
+      "macro_sql": "{%- materialization unit, default -%}\n\n  {% set relations = [] %}\n\n  {% set expected_rows = config.get('expected_rows') %}\n  {% set expected_sql = config.get('expected_sql') %}\n  {% set tested_expected_column_names = expected_rows[0].keys() if (expected_rows | length ) > 0 else get_columns_in_query(sql) %} %}\n\n  {%- set target_relation = this.incorporate(type='table') -%}\n  {%- set temp_relation = make_temp_relation(target_relation)-%}\n  {% do run_query(get_create_table_as_sql(True, temp_relation, get_empty_subquery_sql(sql))) %}\n  {%- set columns_in_relation = adapter.get_columns_in_relation(temp_relation) -%}\n  {%- set column_name_to_data_types = {} -%}\n  {%- for column in columns_in_relation -%}\n  {%-   do column_name_to_data_types.update({column.name|lower: column.data_type}) -%}\n  {%- endfor -%}\n\n  {% if not expected_sql %}\n  {%   set expected_sql = get_expected_sql(expected_rows, column_name_to_data_types) %}\n  {% endif %}\n  {% set unit_test_sql = get_unit_test_sql(sql, expected_sql, tested_expected_column_names) %}\n\n  {% call statement('main', fetch_result=True) -%}\n\n    {{ unit_test_sql }}\n\n  {%- endcall %}\n\n  {% do adapter.drop_relation(temp_relation) %}\n\n  {{ return({'relations': relations}) }}\n\n{%- endmaterialization -%}",
       "depends_on": {
         "macros": [
           "macro.dbt.get_columns_in_query",
@@ -6329,8 +6321,8 @@
           "macro.dbt.run_query",
           "macro.dbt.get_create_table_as_sql",
           "macro.dbt.get_empty_subquery_sql",
-          "macro.dbt.get_unit_test_sql",
           "macro.dbt.get_expected_sql",
+          "macro.dbt.get_unit_test_sql",
           "macro.dbt.statement"
         ]
       },
@@ -6342,7 +6334,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.022027,
+      "created_at": 1716242219.261164,
       "supported_languages": [
         "sql"
       ]
@@ -6375,7 +6367,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.026737,
+      "created_at": 1716242219.265839,
       "supported_languages": [
         "sql"
       ]
@@ -6403,7 +6395,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.027085,
+      "created_at": 1716242219.2661881,
       "supported_languages": null
     },
     "macro.dbt.materialized_view_teardown": {
@@ -6428,7 +6420,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.027313,
+      "created_at": 1716242219.266411,
       "supported_languages": null
     },
     "macro.dbt.materialized_view_get_build_sql": {
@@ -6457,7 +6449,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0285351,
+      "created_at": 1716242219.267601,
       "supported_languages": null
     },
     "macro.dbt.materialized_view_execute_no_op": {
@@ -6479,7 +6471,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.028744,
+      "created_at": 1716242219.267812,
       "supported_languages": null
     },
     "macro.dbt.materialized_view_execute_build_sql": {
@@ -6507,7 +6499,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0293279,
+      "created_at": 1716242219.268395,
       "supported_languages": null
     },
     "macro.dbt.materialization_view_default": {
@@ -6540,7 +6532,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.031958,
+      "created_at": 1716242219.2710211,
       "supported_languages": [
         "sql"
       ]
@@ -6576,7 +6568,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.03457,
+      "created_at": 1716242219.273648,
       "supported_languages": [
         "sql"
       ]
@@ -6600,7 +6592,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0361001,
+      "created_at": 1716242219.2751648,
       "supported_languages": null
     },
     "macro.dbt.diff_columns": {
@@ -6622,7 +6614,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.036588,
+      "created_at": 1716242219.275655,
       "supported_languages": null
     },
     "macro.dbt.diff_column_data_types": {
@@ -6644,7 +6636,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.037177,
+      "created_at": 1716242219.2762408,
       "supported_languages": null
     },
     "macro.dbt.get_merge_update_columns": {
@@ -6668,7 +6660,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0373929,
+      "created_at": 1716242219.276458,
       "supported_languages": null
     },
     "macro.dbt.default__get_merge_update_columns": {
@@ -6690,7 +6682,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0380359,
+      "created_at": 1716242219.277094,
       "supported_languages": null
     },
     "macro.dbt.get_merge_sql": {
@@ -6714,7 +6706,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.044617,
+      "created_at": 1716242219.283308,
       "supported_languages": null
     },
     "macro.dbt.default__get_merge_sql": {
@@ -6739,7 +6731,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.046093,
+      "created_at": 1716242219.2847779,
       "supported_languages": null
     },
     "macro.dbt.get_delete_insert_merge_sql": {
@@ -6763,7 +6755,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.046336,
+      "created_at": 1716242219.285019,
       "supported_languages": null
     },
     "macro.dbt.default__get_delete_insert_merge_sql": {
@@ -6787,7 +6779,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.047234,
+      "created_at": 1716242219.285918,
       "supported_languages": null
     },
     "macro.dbt.get_insert_overwrite_merge_sql": {
@@ -6811,7 +6803,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.04748,
+      "created_at": 1716242219.286162,
       "supported_languages": null
     },
     "macro.dbt.default__get_insert_overwrite_merge_sql": {
@@ -6835,7 +6827,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.048064,
+      "created_at": 1716242219.2867358,
       "supported_languages": null
     },
     "macro.dbt.is_incremental": {
@@ -6859,7 +6851,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.048634,
+      "created_at": 1716242219.287327,
       "supported_languages": null
     },
     "macro.dbt.get_incremental_append_sql": {
@@ -6883,7 +6875,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0494552,
+      "created_at": 1716242219.288142,
       "supported_languages": null
     },
     "macro.dbt.default__get_incremental_append_sql": {
@@ -6907,7 +6899,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.049674,
+      "created_at": 1716242219.288357,
       "supported_languages": null
     },
     "macro.dbt.get_incremental_delete_insert_sql": {
@@ -6931,7 +6923,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.049844,
+      "created_at": 1716242219.2885242,
       "supported_languages": null
     },
     "macro.dbt.default__get_incremental_delete_insert_sql": {
@@ -6955,7 +6947,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.050111,
+      "created_at": 1716242219.288788,
       "supported_languages": null
     },
     "macro.dbt.get_incremental_merge_sql": {
@@ -6979,7 +6971,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.050279,
+      "created_at": 1716242219.288955,
       "supported_languages": null
     },
     "macro.dbt.default__get_incremental_merge_sql": {
@@ -7003,7 +6995,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.050545,
+      "created_at": 1716242219.289222,
       "supported_languages": null
     },
     "macro.dbt.get_incremental_insert_overwrite_sql": {
@@ -7027,7 +7019,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.050713,
+      "created_at": 1716242219.28939,
       "supported_languages": null
     },
     "macro.dbt.default__get_incremental_insert_overwrite_sql": {
@@ -7051,7 +7043,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0509539,
+      "created_at": 1716242219.2896268,
       "supported_languages": null
     },
     "macro.dbt.get_incremental_default_sql": {
@@ -7075,7 +7067,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.051121,
+      "created_at": 1716242219.289793,
       "supported_languages": null
     },
     "macro.dbt.default__get_incremental_default_sql": {
@@ -7099,7 +7091,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.051258,
+      "created_at": 1716242219.289938,
       "supported_languages": null
     },
     "macro.dbt.get_insert_into_sql": {
@@ -7123,7 +7115,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.051507,
+      "created_at": 1716242219.290189,
       "supported_languages": null
     },
     "macro.dbt.materialization_incremental_default": {
@@ -7162,7 +7154,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.056016,
+      "created_at": 1716242219.294691,
       "supported_languages": [
         "sql"
       ]
@@ -7186,7 +7178,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.061594,
+      "created_at": 1716242219.3000991,
       "supported_languages": null
     },
     "macro.dbt.check_for_schema_changes": {
@@ -7211,7 +7203,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0626738,
+      "created_at": 1716242219.301184,
       "supported_languages": null
     },
     "macro.dbt.sync_column_schemas": {
@@ -7236,7 +7228,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.063734,
+      "created_at": 1716242219.302241,
       "supported_languages": null
     },
     "macro.dbt.process_schema_changes": {
@@ -7261,7 +7253,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.064493,
+      "created_at": 1716242219.3029969,
       "supported_languages": null
     },
     "macro.dbt.can_clone_table": {
@@ -7285,7 +7277,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.064714,
+      "created_at": 1716242219.303215,
       "supported_languages": null
     },
     "macro.dbt.default__can_clone_table": {
@@ -7307,7 +7299,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.06482,
+      "created_at": 1716242219.3033202,
       "supported_languages": null
     },
     "macro.dbt.create_or_replace_clone": {
@@ -7331,7 +7323,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.065086,
+      "created_at": 1716242219.303586,
       "supported_languages": null
     },
     "macro.dbt.default__create_or_replace_clone": {
@@ -7353,7 +7345,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.065208,
+      "created_at": 1716242219.303711,
       "supported_languages": null
     },
     "macro.dbt.materialization_clone_default": {
@@ -7384,7 +7376,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.068598,
+      "created_at": 1716242219.307046,
       "supported_languages": [
         "sql"
       ]
@@ -7420,7 +7412,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.071519,
+      "created_at": 1716242219.3099551,
       "supported_languages": [
         "sql"
       ]
@@ -7446,7 +7438,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0764859,
+      "created_at": 1716242219.314813,
       "supported_languages": null
     },
     "macro.dbt.default__create_csv_table": {
@@ -7470,7 +7462,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.077294,
+      "created_at": 1716242219.315607,
       "supported_languages": null
     },
     "macro.dbt.reset_csv_table": {
@@ -7494,7 +7486,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0775099,
+      "created_at": 1716242219.315823,
       "supported_languages": null
     },
     "macro.dbt.default__reset_csv_table": {
@@ -7518,7 +7510,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.07796,
+      "created_at": 1716242219.316247,
       "supported_languages": null
     },
     "macro.dbt.get_csv_sql": {
@@ -7542,7 +7534,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.078138,
+      "created_at": 1716242219.316421,
       "supported_languages": null
     },
     "macro.dbt.default__get_csv_sql": {
@@ -7564,7 +7556,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.078259,
+      "created_at": 1716242219.316541,
       "supported_languages": null
     },
     "macro.dbt.get_binding_char": {
@@ -7588,7 +7580,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.078387,
+      "created_at": 1716242219.316677,
       "supported_languages": null
     },
     "macro.dbt.default__get_binding_char": {
@@ -7610,7 +7602,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0784938,
+      "created_at": 1716242219.316792,
       "supported_languages": null
     },
     "macro.dbt.get_batch_size": {
@@ -7634,7 +7626,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0786629,
+      "created_at": 1716242219.316938,
       "supported_languages": null
     },
     "macro.dbt.default__get_batch_size": {
@@ -7656,7 +7648,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.078775,
+      "created_at": 1716242219.3170428,
       "supported_languages": null
     },
     "macro.dbt.get_seed_column_quoted_csv": {
@@ -7678,7 +7670,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0792,
+      "created_at": 1716242219.317464,
       "supported_languages": null
     },
     "macro.dbt.load_csv_rows": {
@@ -7702,7 +7694,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.079366,
+      "created_at": 1716242219.317632,
       "supported_languages": null
     },
     "macro.dbt.default__load_csv_rows": {
@@ -7728,7 +7720,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0805361,
+      "created_at": 1716242219.31877,
       "supported_languages": null
     },
     "macro.dbt.generate_alias_name": {
@@ -7752,7 +7744,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.080945,
+      "created_at": 1716242219.319169,
       "supported_languages": null
     },
     "macro.dbt.default__generate_alias_name": {
@@ -7774,7 +7766,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.08129,
+      "created_at": 1716242219.3195221,
       "supported_languages": null
     },
     "macro.dbt.generate_schema_name": {
@@ -7798,7 +7790,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0817878,
+      "created_at": 1716242219.3199959,
       "supported_languages": null
     },
     "macro.dbt.default__generate_schema_name": {
@@ -7820,7 +7812,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.082025,
+      "created_at": 1716242219.32023,
       "supported_languages": null
     },
     "macro.dbt.generate_schema_name_for_env": {
@@ -7842,7 +7834,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.082282,
+      "created_at": 1716242219.320492,
       "supported_languages": null
     },
     "macro.dbt.generate_database_name": {
@@ -7866,7 +7858,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0826628,
+      "created_at": 1716242219.32085,
       "supported_languages": null
     },
     "macro.dbt.default__generate_database_name": {
@@ -7888,7 +7880,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.082897,
+      "created_at": 1716242219.321087,
       "supported_languages": null
     },
     "macro.dbt.get_drop_sql": {
@@ -7912,7 +7904,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.083564,
+      "created_at": 1716242219.3217468,
       "supported_languages": null
     },
     "macro.dbt.default__get_drop_sql": {
@@ -7938,7 +7930,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0839171,
+      "created_at": 1716242219.3220742,
       "supported_languages": null
     },
     "macro.dbt.drop_relation": {
@@ -7962,7 +7954,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.084082,
+      "created_at": 1716242219.322243,
       "supported_languages": null
     },
     "macro.dbt.default__drop_relation": {
@@ -7987,7 +7979,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.084264,
+      "created_at": 1716242219.322428,
       "supported_languages": null
     },
     "macro.dbt.drop_relation_if_exists": {
@@ -8009,7 +8001,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.084436,
+      "created_at": 1716242219.322598,
       "supported_languages": null
     },
     "macro.dbt.get_replace_sql": {
@@ -8033,7 +8025,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.085165,
+      "created_at": 1716242219.323327,
       "supported_languages": null
     },
     "macro.dbt.default__get_replace_sql": {
@@ -8065,7 +8057,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.086325,
+      "created_at": 1716242219.324477,
       "supported_languages": null
     },
     "macro.dbt.get_create_intermediate_sql": {
@@ -8089,7 +8081,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.086696,
+      "created_at": 1716242219.324821,
       "supported_languages": null
     },
     "macro.dbt.default__get_create_intermediate_sql": {
@@ -8115,7 +8107,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.086934,
+      "created_at": 1716242219.3250492,
       "supported_languages": null
     },
     "macro.dbt.drop_schema_named": {
@@ -8139,7 +8131,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.087177,
+      "created_at": 1716242219.325299,
       "supported_languages": null
     },
     "macro.dbt.default__drop_schema_named": {
@@ -8161,7 +8153,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.087372,
+      "created_at": 1716242219.325493,
       "supported_languages": null
     },
     "macro.dbt.get_drop_backup_sql": {
@@ -8185,7 +8177,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0876858,
+      "created_at": 1716242219.32578,
       "supported_languages": null
     },
     "macro.dbt.default__get_drop_backup_sql": {
@@ -8210,7 +8202,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.087873,
+      "created_at": 1716242219.3259678,
       "supported_languages": null
     },
     "macro.dbt.get_rename_sql": {
@@ -8234,7 +8226,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.088524,
+      "created_at": 1716242219.326614,
       "supported_languages": null
     },
     "macro.dbt.default__get_rename_sql": {
@@ -8260,7 +8252,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.088934,
+      "created_at": 1716242219.3270001,
       "supported_languages": null
     },
     "macro.dbt.rename_relation": {
@@ -8284,7 +8276,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0891242,
+      "created_at": 1716242219.3271859,
       "supported_languages": null
     },
     "macro.dbt.default__rename_relation": {
@@ -8308,7 +8300,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.089378,
+      "created_at": 1716242219.3274372,
       "supported_languages": null
     },
     "macro.dbt.get_create_backup_sql": {
@@ -8332,7 +8324,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0897212,
+      "created_at": 1716242219.327758,
       "supported_languages": null
     },
     "macro.dbt.default__get_create_backup_sql": {
@@ -8358,7 +8350,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0899782,
+      "created_at": 1716242219.328,
       "supported_languages": null
     },
     "macro.dbt.get_create_sql": {
@@ -8382,7 +8374,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.090409,
+      "created_at": 1716242219.328434,
       "supported_languages": null
     },
     "macro.dbt.default__get_create_sql": {
@@ -8408,7 +8400,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.090826,
+      "created_at": 1716242219.328833,
       "supported_languages": null
     },
     "macro.dbt.get_rename_intermediate_sql": {
@@ -8432,7 +8424,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.091129,
+      "created_at": 1716242219.32913,
       "supported_languages": null
     },
     "macro.dbt.default__get_rename_intermediate_sql": {
@@ -8457,7 +8449,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.091316,
+      "created_at": 1716242219.3293152,
       "supported_languages": null
     },
     "macro.dbt.drop_materialized_view": {
@@ -8481,7 +8473,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.091546,
+      "created_at": 1716242219.329542,
       "supported_languages": null
     },
     "macro.dbt.default__drop_materialized_view": {
@@ -8503,7 +8495,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.09166,
+      "created_at": 1716242219.3296409,
       "supported_languages": null
     },
     "macro.dbt.get_replace_materialized_view_sql": {
@@ -8527,7 +8519,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.091915,
+      "created_at": 1716242219.329888,
       "supported_languages": null
     },
     "macro.dbt.default__get_replace_materialized_view_sql": {
@@ -8549,7 +8541,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.092227,
+      "created_at": 1716242219.33008,
       "supported_languages": null
     },
     "macro.dbt.refresh_materialized_view": {
@@ -8573,7 +8565,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.092505,
+      "created_at": 1716242219.330357,
       "supported_languages": null
     },
     "macro.dbt.default__refresh_materialized_view": {
@@ -8595,7 +8587,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0926452,
+      "created_at": 1716242219.3304791,
       "supported_languages": null
     },
     "macro.dbt.get_rename_materialized_view_sql": {
@@ -8619,7 +8611,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.092891,
+      "created_at": 1716242219.3307252,
       "supported_languages": null
     },
     "macro.dbt.default__get_rename_materialized_view_sql": {
@@ -8641,7 +8633,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.093023,
+      "created_at": 1716242219.3308558,
       "supported_languages": null
     },
     "macro.dbt.get_alter_materialized_view_as_sql": {
@@ -8665,7 +8657,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.09359,
+      "created_at": 1716242219.331412,
       "supported_languages": null
     },
     "macro.dbt.default__get_alter_materialized_view_as_sql": {
@@ -8687,7 +8679,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.09377,
+      "created_at": 1716242219.33158,
       "supported_languages": null
     },
     "macro.dbt.get_materialized_view_configuration_changes": {
@@ -8711,7 +8703,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.094027,
+      "created_at": 1716242219.3318348,
       "supported_languages": null
     },
     "macro.dbt.default__get_materialized_view_configuration_changes": {
@@ -8733,7 +8725,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0941591,
+      "created_at": 1716242219.331965,
       "supported_languages": null
     },
     "macro.dbt.get_create_materialized_view_as_sql": {
@@ -8757,7 +8749,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.094409,
+      "created_at": 1716242219.332212,
       "supported_languages": null
     },
     "macro.dbt.default__get_create_materialized_view_as_sql": {
@@ -8779,7 +8771,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.094538,
+      "created_at": 1716242219.33234,
       "supported_languages": null
     },
     "macro.dbt.get_table_columns_and_constraints": {
@@ -8803,7 +8795,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.095489,
+      "created_at": 1716242219.3332648,
       "supported_languages": null
     },
     "macro.dbt.default__get_table_columns_and_constraints": {
@@ -8827,7 +8819,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0956101,
+      "created_at": 1716242219.333374,
       "supported_languages": null
     },
     "macro.dbt.table_columns_and_constraints": {
@@ -8849,7 +8841,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.096094,
+      "created_at": 1716242219.333842,
       "supported_languages": null
     },
     "macro.dbt.get_assert_columns_equivalent": {
@@ -8873,7 +8865,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.096245,
+      "created_at": 1716242219.333994,
       "supported_languages": null
     },
     "macro.dbt.default__get_assert_columns_equivalent": {
@@ -8897,7 +8889,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0963688,
+      "created_at": 1716242219.334115,
       "supported_languages": null
     },
     "macro.dbt.assert_columns_equivalent": {
@@ -8923,7 +8915,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.097604,
+      "created_at": 1716242219.3353071,
       "supported_languages": null
     },
     "macro.dbt.format_columns": {
@@ -8947,7 +8939,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.097989,
+      "created_at": 1716242219.335649,
       "supported_languages": null
     },
     "macro.dbt.default__format_column": {
@@ -8969,7 +8961,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.098297,
+      "created_at": 1716242219.335955,
       "supported_languages": null
     },
     "macro.dbt.drop_table": {
@@ -8993,7 +8985,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.098526,
+      "created_at": 1716242219.33618,
       "supported_languages": null
     },
     "macro.dbt.default__drop_table": {
@@ -9015,7 +9007,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0986502,
+      "created_at": 1716242219.3362749,
       "supported_languages": null
     },
     "macro.dbt.get_replace_table_sql": {
@@ -9039,7 +9031,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.098902,
+      "created_at": 1716242219.336519,
       "supported_languages": null
     },
     "macro.dbt.default__get_replace_table_sql": {
@@ -9061,7 +9053,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.099037,
+      "created_at": 1716242219.336649,
       "supported_languages": null
     },
     "macro.dbt.get_rename_table_sql": {
@@ -9085,7 +9077,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0993102,
+      "created_at": 1716242219.336896,
       "supported_languages": null
     },
     "macro.dbt.default__get_rename_table_sql": {
@@ -9107,7 +9099,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.0994592,
+      "created_at": 1716242219.337025,
       "supported_languages": null
     },
     "macro.dbt.get_create_table_as_sql": {
@@ -9131,7 +9123,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1002738,
+      "created_at": 1716242219.337813,
       "supported_languages": null
     },
     "macro.dbt.default__get_create_table_as_sql": {
@@ -9155,7 +9147,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.100443,
+      "created_at": 1716242219.3379788,
       "supported_languages": null
     },
     "macro.dbt.create_table_as": {
@@ -9179,7 +9171,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.100862,
+      "created_at": 1716242219.338368,
       "supported_languages": null
     },
     "macro.dbt.default__create_table_as": {
@@ -9205,7 +9197,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.101482,
+      "created_at": 1716242219.338978,
       "supported_languages": null
     },
     "macro.dbt.default__get_column_names": {
@@ -9227,7 +9219,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.101919,
+      "created_at": 1716242219.3393989,
       "supported_languages": null
     },
     "macro.dbt.get_select_subquery": {
@@ -9251,7 +9243,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.102091,
+      "created_at": 1716242219.339565,
       "supported_languages": null
     },
     "macro.dbt.default__get_select_subquery": {
@@ -9275,7 +9267,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.102252,
+      "created_at": 1716242219.339725,
       "supported_languages": null
     },
     "macro.dbt.drop_view": {
@@ -9299,7 +9291,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1024761,
+      "created_at": 1716242219.339942,
       "supported_languages": null
     },
     "macro.dbt.default__drop_view": {
@@ -9321,7 +9313,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.102578,
+      "created_at": 1716242219.340039,
       "supported_languages": null
     },
     "macro.dbt.get_replace_view_sql": {
@@ -9345,7 +9337,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1033862,
+      "created_at": 1716242219.3408298,
       "supported_languages": null
     },
     "macro.dbt.default__get_replace_view_sql": {
@@ -9367,7 +9359,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.103521,
+      "created_at": 1716242219.340959,
       "supported_languages": null
     },
     "macro.dbt.create_or_replace_view": {
@@ -9397,7 +9389,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.104624,
+      "created_at": 1716242219.342029,
       "supported_languages": null
     },
     "macro.dbt.handle_existing_table": {
@@ -9421,7 +9413,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.104809,
+      "created_at": 1716242219.342208,
       "supported_languages": null
     },
     "macro.dbt.default__handle_existing_table": {
@@ -9443,7 +9435,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1050072,
+      "created_at": 1716242219.3424032,
       "supported_languages": null
     },
     "macro.dbt.get_rename_view_sql": {
@@ -9467,7 +9459,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1052558,
+      "created_at": 1716242219.342648,
       "supported_languages": null
     },
     "macro.dbt.default__get_rename_view_sql": {
@@ -9489,7 +9481,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.10539,
+      "created_at": 1716242219.3427799,
       "supported_languages": null
     },
     "macro.dbt.get_create_view_as_sql": {
@@ -9513,7 +9505,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.105788,
+      "created_at": 1716242219.343157,
       "supported_languages": null
     },
     "macro.dbt.default__get_create_view_as_sql": {
@@ -9537,7 +9529,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.105935,
+      "created_at": 1716242219.343304,
       "supported_languages": null
     },
     "macro.dbt.create_view_as": {
@@ -9561,7 +9553,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.106102,
+      "created_at": 1716242219.343467,
       "supported_languages": null
     },
     "macro.dbt.default__create_view_as": {
@@ -9585,7 +9577,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.106477,
+      "created_at": 1716242219.343837,
       "supported_languages": null
     },
     "macro.dbt.default__test_relationships": {
@@ -9607,7 +9599,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1068218,
+      "created_at": 1716242219.3441548,
       "supported_languages": null
     },
     "macro.dbt.default__test_not_null": {
@@ -9631,7 +9623,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1070879,
+      "created_at": 1716242219.3444219,
       "supported_languages": null
     },
     "macro.dbt.default__test_unique": {
@@ -9653,7 +9645,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.107313,
+      "created_at": 1716242219.344645,
       "supported_languages": null
     },
     "macro.dbt.default__test_accepted_values": {
@@ -9675,7 +9667,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.10785,
+      "created_at": 1716242219.345161,
       "supported_languages": null
     },
     "macro.dbt.statement": {
@@ -9697,7 +9689,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.109322,
+      "created_at": 1716242219.3464918,
       "supported_languages": null
     },
     "macro.dbt.noop_statement": {
@@ -9719,7 +9711,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1099231,
+      "created_at": 1716242219.347003,
       "supported_languages": null
     },
     "macro.dbt.run_query": {
@@ -9743,7 +9735,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1102011,
+      "created_at": 1716242219.347261,
       "supported_languages": null
     },
     "macro.dbt.convert_datetime": {
@@ -9765,7 +9757,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.112076,
+      "created_at": 1716242219.3489978,
       "supported_languages": null
     },
     "macro.dbt.dates_in_range": {
@@ -9789,7 +9781,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1132421,
+      "created_at": 1716242219.350098,
       "supported_languages": null
     },
     "macro.dbt.partition_range": {
@@ -9813,7 +9805,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.113942,
+      "created_at": 1716242219.350761,
       "supported_languages": null
     },
     "macro.dbt.py_current_timestring": {
@@ -9835,7 +9827,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.114157,
+      "created_at": 1716242219.350967,
       "supported_languages": null
     },
     "macro.dbt.except": {
@@ -9859,7 +9851,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.114367,
+      "created_at": 1716242219.3511722,
       "supported_languages": null
     },
     "macro.dbt.default__except": {
@@ -9881,7 +9873,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.114441,
+      "created_at": 1716242219.351243,
       "supported_languages": null
     },
     "macro.dbt.get_intervals_between": {
@@ -9905,7 +9897,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.115188,
+      "created_at": 1716242219.351935,
       "supported_languages": null
     },
     "macro.dbt.default__get_intervals_between": {
@@ -9930,7 +9922,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1157398,
+      "created_at": 1716242219.352465,
       "supported_languages": null
     },
     "macro.dbt.date_spine": {
@@ -9954,7 +9946,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.115964,
+      "created_at": 1716242219.352675,
       "supported_languages": null
     },
     "macro.dbt.default__date_spine": {
@@ -9980,7 +9972,53 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1163032,
+      "created_at": 1716242219.3530052,
+      "supported_languages": null
+    },
+    "macro.dbt.date": {
+      "name": "date",
+      "resource_type": "macro",
+      "package_name": "dbt",
+      "path": "macros/utils/date.sql",
+      "original_file_path": "macros/utils/date.sql",
+      "unique_id": "macro.dbt.date",
+      "macro_sql": "{% macro date(year, month, day) %}\n  {{ return(adapter.dispatch('date', 'dbt') (year, month, day)) }}\n{% endmacro %}",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__date"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1716242219.353306,
+      "supported_languages": null
+    },
+    "macro.dbt.default__date": {
+      "name": "default__date",
+      "resource_type": "macro",
+      "package_name": "dbt",
+      "path": "macros/utils/date.sql",
+      "original_file_path": "macros/utils/date.sql",
+      "unique_id": "macro.dbt.default__date",
+      "macro_sql": "{% macro default__date(year, month, day) -%}\n    {%- set dt = modules.datetime.date(year, month, day) -%}\n    {%- set iso_8601_formatted_date = dt.strftime('%Y-%m-%d') -%}\n    to_date('{{ iso_8601_formatted_date }}', 'YYYY-MM-DD')\n{%- endmacro %}",
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1716242219.3535628,
       "supported_languages": null
     },
     "macro.dbt.replace": {
@@ -10004,7 +10042,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.116617,
+      "created_at": 1716242219.3538592,
       "supported_languages": null
     },
     "macro.dbt.default__replace": {
@@ -10026,7 +10064,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.11678,
+      "created_at": 1716242219.354006,
       "supported_languages": null
     },
     "macro.dbt.concat": {
@@ -10050,7 +10088,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1170151,
+      "created_at": 1716242219.354225,
       "supported_languages": null
     },
     "macro.dbt.default__concat": {
@@ -10072,7 +10110,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.117135,
+      "created_at": 1716242219.354336,
       "supported_languages": null
     },
     "macro.dbt.get_powers_of_two": {
@@ -10096,7 +10134,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.117939,
+      "created_at": 1716242219.355108,
       "supported_languages": null
     },
     "macro.dbt.default__get_powers_of_two": {
@@ -10118,7 +10156,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.118334,
+      "created_at": 1716242219.355477,
       "supported_languages": null
     },
     "macro.dbt.generate_series": {
@@ -10142,7 +10180,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.11851,
+      "created_at": 1716242219.355646,
       "supported_languages": null
     },
     "macro.dbt.default__generate_series": {
@@ -10166,7 +10204,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1190012,
+      "created_at": 1716242219.356101,
       "supported_languages": null
     },
     "macro.dbt.length": {
@@ -10190,7 +10228,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.119238,
+      "created_at": 1716242219.356338,
       "supported_languages": null
     },
     "macro.dbt.default__length": {
@@ -10212,7 +10250,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.119336,
+      "created_at": 1716242219.3564339,
       "supported_languages": null
     },
     "macro.dbt.dateadd": {
@@ -10236,7 +10274,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.119663,
+      "created_at": 1716242219.3567371,
       "supported_languages": null
     },
     "macro.dbt.default__dateadd": {
@@ -10258,7 +10296,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.119824,
+      "created_at": 1716242219.357078,
       "supported_languages": null
     },
     "macro.dbt.intersect": {
@@ -10282,7 +10320,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.120033,
+      "created_at": 1716242219.357279,
       "supported_languages": null
     },
     "macro.dbt.default__intersect": {
@@ -10304,7 +10342,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1201699,
+      "created_at": 1716242219.3573492,
       "supported_languages": null
     },
     "macro.dbt.escape_single_quotes": {
@@ -10328,7 +10366,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.120406,
+      "created_at": 1716242219.357582,
       "supported_languages": null
     },
     "macro.dbt.default__escape_single_quotes": {
@@ -10350,7 +10388,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.120532,
+      "created_at": 1716242219.3577092,
       "supported_languages": null
     },
     "macro.dbt.right": {
@@ -10374,7 +10412,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.120821,
+      "created_at": 1716242219.35797,
       "supported_languages": null
     },
     "macro.dbt.default__right": {
@@ -10396,7 +10434,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.120957,
+      "created_at": 1716242219.358092,
       "supported_languages": null
     },
     "macro.dbt.listagg": {
@@ -10420,7 +10458,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.121554,
+      "created_at": 1716242219.358679,
       "supported_languages": null
     },
     "macro.dbt.default__listagg": {
@@ -10442,7 +10480,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.12195,
+      "created_at": 1716242219.3590488,
       "supported_languages": null
     },
     "macro.dbt.datediff": {
@@ -10466,7 +10504,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.122257,
+      "created_at": 1716242219.35935,
       "supported_languages": null
     },
     "macro.dbt.default__datediff": {
@@ -10488,7 +10526,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.122408,
+      "created_at": 1716242219.359498,
       "supported_languages": null
     },
     "macro.dbt.safe_cast": {
@@ -10512,7 +10550,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.122689,
+      "created_at": 1716242219.359752,
       "supported_languages": null
     },
     "macro.dbt.default__safe_cast": {
@@ -10534,7 +10572,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.122818,
+      "created_at": 1716242219.3598762,
       "supported_languages": null
     },
     "macro.dbt.hash": {
@@ -10558,7 +10596,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.12305,
+      "created_at": 1716242219.360105,
       "supported_languages": null
     },
     "macro.dbt.default__hash": {
@@ -10580,7 +10618,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.123196,
+      "created_at": 1716242219.3602471,
       "supported_languages": null
     },
     "macro.dbt.cast_bool_to_text": {
@@ -10604,7 +10642,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.123415,
+      "created_at": 1716242219.3604648,
       "supported_languages": null
     },
     "macro.dbt.default__cast_bool_to_text": {
@@ -10626,7 +10664,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.123564,
+      "created_at": 1716242219.360607,
       "supported_languages": null
     },
     "macro.dbt.cast": {
@@ -10650,7 +10688,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.123829,
+      "created_at": 1716242219.360851,
       "supported_languages": null
     },
     "macro.dbt.default__cast": {
@@ -10672,7 +10710,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.123946,
+      "created_at": 1716242219.36097,
       "supported_languages": null
     },
     "macro.dbt.any_value": {
@@ -10696,7 +10734,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.12417,
+      "created_at": 1716242219.3611898,
       "supported_languages": null
     },
     "macro.dbt.default__any_value": {
@@ -10718,7 +10756,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.124265,
+      "created_at": 1716242219.3613482,
       "supported_languages": null
     },
     "macro.dbt.position": {
@@ -10742,7 +10780,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.124523,
+      "created_at": 1716242219.3616068,
       "supported_languages": null
     },
     "macro.dbt.default__position": {
@@ -10764,7 +10802,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1247308,
+      "created_at": 1716242219.361732,
       "supported_languages": null
     },
     "macro.dbt.string_literal": {
@@ -10788,7 +10826,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.12495,
+      "created_at": 1716242219.3619468,
       "supported_languages": null
     },
     "macro.dbt.default__string_literal": {
@@ -10810,7 +10848,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.125043,
+      "created_at": 1716242219.362041,
       "supported_languages": null
     },
     "macro.dbt.type_string": {
@@ -10834,7 +10872,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.125921,
+      "created_at": 1716242219.362918,
       "supported_languages": null
     },
     "macro.dbt.default__type_string": {
@@ -10856,7 +10894,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.12606,
+      "created_at": 1716242219.363054,
       "supported_languages": null
     },
     "macro.dbt.type_timestamp": {
@@ -10880,7 +10918,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.12621,
+      "created_at": 1716242219.363199,
       "supported_languages": null
     },
     "macro.dbt.default__type_timestamp": {
@@ -10902,7 +10940,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.126348,
+      "created_at": 1716242219.363335,
       "supported_languages": null
     },
     "macro.dbt.type_float": {
@@ -10926,7 +10964,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.126494,
+      "created_at": 1716242219.363483,
       "supported_languages": null
     },
     "macro.dbt.default__type_float": {
@@ -10948,7 +10986,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1266491,
+      "created_at": 1716242219.3636181,
       "supported_languages": null
     },
     "macro.dbt.type_numeric": {
@@ -10972,7 +11010,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1267982,
+      "created_at": 1716242219.363764,
       "supported_languages": null
     },
     "macro.dbt.default__type_numeric": {
@@ -10994,7 +11032,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.126957,
+      "created_at": 1716242219.3639228,
       "supported_languages": null
     },
     "macro.dbt.type_bigint": {
@@ -11018,7 +11056,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.127103,
+      "created_at": 1716242219.364074,
       "supported_languages": null
     },
     "macro.dbt.default__type_bigint": {
@@ -11040,7 +11078,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.127239,
+      "created_at": 1716242219.3642082,
       "supported_languages": null
     },
     "macro.dbt.type_int": {
@@ -11064,7 +11102,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1273851,
+      "created_at": 1716242219.364352,
       "supported_languages": null
     },
     "macro.dbt.default__type_int": {
@@ -11086,7 +11124,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1275141,
+      "created_at": 1716242219.364485,
       "supported_languages": null
     },
     "macro.dbt.type_boolean": {
@@ -11110,7 +11148,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.127681,
+      "created_at": 1716242219.364635,
       "supported_languages": null
     },
     "macro.dbt.default__type_boolean": {
@@ -11132,7 +11170,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1278121,
+      "created_at": 1716242219.364765,
       "supported_languages": null
     },
     "macro.dbt.array_concat": {
@@ -11156,7 +11194,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1280599,
+      "created_at": 1716242219.3650188,
       "supported_languages": null
     },
     "macro.dbt.default__array_concat": {
@@ -11178,7 +11216,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.128182,
+      "created_at": 1716242219.3651998,
       "supported_languages": null
     },
     "macro.dbt.bool_or": {
@@ -11202,7 +11240,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.128402,
+      "created_at": 1716242219.365431,
       "supported_languages": null
     },
     "macro.dbt.default__bool_or": {
@@ -11224,7 +11262,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.128563,
+      "created_at": 1716242219.365524,
       "supported_languages": null
     },
     "macro.dbt.last_day": {
@@ -11248,7 +11286,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.128889,
+      "created_at": 1716242219.365833,
       "supported_languages": null
     },
     "macro.dbt.default_last_day": {
@@ -11273,7 +11311,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.129131,
+      "created_at": 1716242219.36607,
       "supported_languages": null
     },
     "macro.dbt.default__last_day": {
@@ -11297,7 +11335,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.129266,
+      "created_at": 1716242219.366206,
       "supported_languages": null
     },
     "macro.dbt.split_part": {
@@ -11321,7 +11359,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1297789,
+      "created_at": 1716242219.366687,
       "supported_languages": null
     },
     "macro.dbt.default__split_part": {
@@ -11343,7 +11381,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.129931,
+      "created_at": 1716242219.3668349,
       "supported_languages": null
     },
     "macro.dbt._split_part_negative": {
@@ -11365,7 +11403,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.130136,
+      "created_at": 1716242219.367035,
       "supported_languages": null
     },
     "macro.dbt.date_trunc": {
@@ -11389,7 +11427,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.130385,
+      "created_at": 1716242219.367282,
       "supported_languages": null
     },
     "macro.dbt.default__date_trunc": {
@@ -11411,7 +11449,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.130504,
+      "created_at": 1716242219.367399,
       "supported_languages": null
     },
     "macro.dbt.array_construct": {
@@ -11435,7 +11473,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1308649,
+      "created_at": 1716242219.367732,
       "supported_languages": null
     },
     "macro.dbt.default__array_construct": {
@@ -11457,7 +11495,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.131084,
+      "created_at": 1716242219.367949,
       "supported_languages": null
     },
     "macro.dbt.array_append": {
@@ -11481,7 +11519,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.131336,
+      "created_at": 1716242219.368208,
       "supported_languages": null
     },
     "macro.dbt.default__array_append": {
@@ -11503,7 +11541,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.131458,
+      "created_at": 1716242219.3683379,
       "supported_languages": null
     },
     "macro.dbt.create_schema": {
@@ -11527,7 +11565,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1318212,
+      "created_at": 1716242219.3686762,
       "supported_languages": null
     },
     "macro.dbt.default__create_schema": {
@@ -11551,7 +11589,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.131988,
+      "created_at": 1716242219.3688488,
       "supported_languages": null
     },
     "macro.dbt.drop_schema": {
@@ -11575,7 +11613,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1321359,
+      "created_at": 1716242219.369004,
       "supported_languages": null
     },
     "macro.dbt.default__drop_schema": {
@@ -11599,7 +11637,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.132302,
+      "created_at": 1716242219.369177,
       "supported_languages": null
     },
     "macro.dbt.current_timestamp": {
@@ -11623,7 +11661,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1327848,
+      "created_at": 1716242219.36962,
       "supported_languages": null
     },
     "macro.dbt.default__current_timestamp": {
@@ -11645,7 +11683,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1329222,
+      "created_at": 1716242219.369813,
       "supported_languages": null
     },
     "macro.dbt.snapshot_get_time": {
@@ -11669,7 +11707,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.133118,
+      "created_at": 1716242219.369945,
       "supported_languages": null
     },
     "macro.dbt.default__snapshot_get_time": {
@@ -11693,7 +11731,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.133219,
+      "created_at": 1716242219.370039,
       "supported_languages": null
     },
     "macro.dbt.current_timestamp_backcompat": {
@@ -11717,7 +11755,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1333818,
+      "created_at": 1716242219.370189,
       "supported_languages": null
     },
     "macro.dbt.default__current_timestamp_backcompat": {
@@ -11739,7 +11777,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1334558,
+      "created_at": 1716242219.3702579,
       "supported_languages": null
     },
     "macro.dbt.current_timestamp_in_utc_backcompat": {
@@ -11763,7 +11801,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1336231,
+      "created_at": 1716242219.3704078,
       "supported_languages": null
     },
     "macro.dbt.default__current_timestamp_in_utc_backcompat": {
@@ -11788,7 +11826,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.133783,
+      "created_at": 1716242219.370562,
       "supported_languages": null
     },
     "macro.dbt.get_create_index_sql": {
@@ -11812,7 +11850,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.134565,
+      "created_at": 1716242219.371337,
       "supported_languages": null
     },
     "macro.dbt.default__get_create_index_sql": {
@@ -11834,7 +11872,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.134708,
+      "created_at": 1716242219.3714619,
       "supported_languages": null
     },
     "macro.dbt.create_indexes": {
@@ -11858,7 +11896,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.134851,
+      "created_at": 1716242219.371608,
       "supported_languages": null
     },
     "macro.dbt.default__create_indexes": {
@@ -11883,7 +11921,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.135206,
+      "created_at": 1716242219.371962,
       "supported_languages": null
     },
     "macro.dbt.get_drop_index_sql": {
@@ -11907,7 +11945,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.13538,
+      "created_at": 1716242219.372132,
       "supported_languages": null
     },
     "macro.dbt.default__get_drop_index_sql": {
@@ -11929,7 +11967,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.135503,
+      "created_at": 1716242219.372255,
       "supported_languages": null
     },
     "macro.dbt.get_show_indexes_sql": {
@@ -11953,7 +11991,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.135666,
+      "created_at": 1716242219.372394,
       "supported_languages": null
     },
     "macro.dbt.default__get_show_indexes_sql": {
@@ -11975,7 +12013,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.135782,
+      "created_at": 1716242219.3725069,
       "supported_languages": null
     },
     "macro.dbt.make_intermediate_relation": {
@@ -11999,7 +12037,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.137755,
+      "created_at": 1716242219.374422,
       "supported_languages": null
     },
     "macro.dbt.default__make_intermediate_relation": {
@@ -12023,7 +12061,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1379042,
+      "created_at": 1716242219.3745768,
       "supported_languages": null
     },
     "macro.dbt.make_temp_relation": {
@@ -12047,7 +12085,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.138102,
+      "created_at": 1716242219.37477,
       "supported_languages": null
     },
     "macro.dbt.default__make_temp_relation": {
@@ -12069,7 +12107,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.138359,
+      "created_at": 1716242219.375026,
       "supported_languages": null
     },
     "macro.dbt.make_backup_relation": {
@@ -12093,7 +12131,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1386619,
+      "created_at": 1716242219.3753111,
       "supported_languages": null
     },
     "macro.dbt.default__make_backup_relation": {
@@ -12115,7 +12153,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.138954,
+      "created_at": 1716242219.375596,
       "supported_languages": null
     },
     "macro.dbt.truncate_relation": {
@@ -12139,7 +12177,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.139116,
+      "created_at": 1716242219.375762,
       "supported_languages": null
     },
     "macro.dbt.default__truncate_relation": {
@@ -12163,7 +12201,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.139263,
+      "created_at": 1716242219.3759081,
       "supported_languages": null
     },
     "macro.dbt.get_or_create_relation": {
@@ -12187,7 +12225,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1394858,
+      "created_at": 1716242219.37613,
       "supported_languages": null
     },
     "macro.dbt.default__get_or_create_relation": {
@@ -12209,7 +12247,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.140009,
+      "created_at": 1716242219.376627,
       "supported_languages": null
     },
     "macro.dbt.load_cached_relation": {
@@ -12231,7 +12269,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.140217,
+      "created_at": 1716242219.376833,
       "supported_languages": null
     },
     "macro.dbt.load_relation": {
@@ -12255,7 +12293,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1403468,
+      "created_at": 1716242219.376961,
       "supported_languages": null
     },
     "macro.dbt.collect_freshness": {
@@ -12279,7 +12317,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.140749,
+      "created_at": 1716242219.377345,
       "supported_languages": null
     },
     "macro.dbt.default__collect_freshness": {
@@ -12304,7 +12342,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.141118,
+      "created_at": 1716242219.377708,
       "supported_languages": null
     },
     "macro.dbt.validate_sql": {
@@ -12328,7 +12366,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.141372,
+      "created_at": 1716242219.377963,
       "supported_languages": null
     },
     "macro.dbt.default__validate_sql": {
@@ -12352,7 +12390,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.141577,
+      "created_at": 1716242219.3781602,
       "supported_languages": null
     },
     "macro.dbt.copy_grants": {
@@ -12376,7 +12414,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.143202,
+      "created_at": 1716242219.379745,
       "supported_languages": null
     },
     "macro.dbt.default__copy_grants": {
@@ -12398,7 +12436,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.14331,
+      "created_at": 1716242219.37985,
       "supported_languages": null
     },
     "macro.dbt.support_multiple_grantees_per_dcl_statement": {
@@ -12422,7 +12460,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.14346,
+      "created_at": 1716242219.379999,
       "supported_languages": null
     },
     "macro.dbt.default__support_multiple_grantees_per_dcl_statement": {
@@ -12444,7 +12482,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1435788,
+      "created_at": 1716242219.380102,
       "supported_languages": null
     },
     "macro.dbt.should_revoke": {
@@ -12468,7 +12506,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.143899,
+      "created_at": 1716242219.380406,
       "supported_languages": null
     },
     "macro.dbt.get_show_grant_sql": {
@@ -12492,7 +12530,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1440709,
+      "created_at": 1716242219.3805718,
       "supported_languages": null
     },
     "macro.dbt.default__get_show_grant_sql": {
@@ -12514,7 +12552,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.144165,
+      "created_at": 1716242219.380664,
       "supported_languages": null
     },
     "macro.dbt.get_grant_sql": {
@@ -12538,7 +12576,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.144371,
+      "created_at": 1716242219.380864,
       "supported_languages": null
     },
     "macro.dbt.default__get_grant_sql": {
@@ -12560,7 +12598,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1446168,
+      "created_at": 1716242219.3810902,
       "supported_languages": null
     },
     "macro.dbt.get_revoke_sql": {
@@ -12584,7 +12622,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1448371,
+      "created_at": 1716242219.381292,
       "supported_languages": null
     },
     "macro.dbt.default__get_revoke_sql": {
@@ -12606,7 +12644,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1450062,
+      "created_at": 1716242219.381461,
       "supported_languages": null
     },
     "macro.dbt.get_dcl_statement_list": {
@@ -12630,7 +12668,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.145215,
+      "created_at": 1716242219.381669,
       "supported_languages": null
     },
     "macro.dbt.default__get_dcl_statement_list": {
@@ -12654,7 +12692,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.145848,
+      "created_at": 1716242219.3822799,
       "supported_languages": null
     },
     "macro.dbt.call_dcl_statements": {
@@ -12678,7 +12716,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.146019,
+      "created_at": 1716242219.3824482,
       "supported_languages": null
     },
     "macro.dbt.default__call_dcl_statements": {
@@ -12702,7 +12740,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.146243,
+      "created_at": 1716242219.3826702,
       "supported_languages": null
     },
     "macro.dbt.apply_grants": {
@@ -12726,7 +12764,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.146454,
+      "created_at": 1716242219.382881,
       "supported_languages": null
     },
     "macro.dbt.default__apply_grants": {
@@ -12753,7 +12791,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.14749,
+      "created_at": 1716242219.3838809,
       "supported_languages": null
     },
     "macro.dbt.get_show_sql": {
@@ -12777,7 +12815,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.147999,
+      "created_at": 1716242219.3843598,
       "supported_languages": null
     },
     "macro.dbt.get_limit_subquery_sql": {
@@ -12801,7 +12839,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.148171,
+      "created_at": 1716242219.384532,
       "supported_languages": null
     },
     "macro.dbt.default__get_limit_subquery_sql": {
@@ -12823,7 +12861,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.148294,
+      "created_at": 1716242219.384654,
       "supported_languages": null
     },
     "macro.dbt.alter_column_comment": {
@@ -12847,7 +12885,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.148936,
+      "created_at": 1716242219.3852742,
       "supported_languages": null
     },
     "macro.dbt.default__alter_column_comment": {
@@ -12869,7 +12907,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.149088,
+      "created_at": 1716242219.3854232,
       "supported_languages": null
     },
     "macro.dbt.alter_relation_comment": {
@@ -12893,7 +12931,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.149272,
+      "created_at": 1716242219.3856032,
       "supported_languages": null
     },
     "macro.dbt.default__alter_relation_comment": {
@@ -12915,7 +12953,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1494231,
+      "created_at": 1716242219.385751,
       "supported_languages": null
     },
     "macro.dbt.persist_docs": {
@@ -12939,7 +12977,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.149697,
+      "created_at": 1716242219.3859909,
       "supported_languages": null
     },
     "macro.dbt.default__persist_docs": {
@@ -12965,7 +13003,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.150183,
+      "created_at": 1716242219.386477,
       "supported_languages": null
     },
     "macro.dbt.get_catalog_relations": {
@@ -12989,7 +13027,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.15297,
+      "created_at": 1716242219.389156,
       "supported_languages": null
     },
     "macro.dbt.default__get_catalog_relations": {
@@ -13011,7 +13049,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.153224,
+      "created_at": 1716242219.389384,
       "supported_languages": null
     },
     "macro.dbt.get_catalog": {
@@ -13035,7 +13073,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.153446,
+      "created_at": 1716242219.389568,
       "supported_languages": null
     },
     "macro.dbt.default__get_catalog": {
@@ -13057,7 +13095,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.153727,
+      "created_at": 1716242219.3898041,
       "supported_languages": null
     },
     "macro.dbt.information_schema_name": {
@@ -13081,7 +13119,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.153924,
+      "created_at": 1716242219.389972,
       "supported_languages": null
     },
     "macro.dbt.default__information_schema_name": {
@@ -13103,7 +13141,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.154092,
+      "created_at": 1716242219.3901162,
       "supported_languages": null
     },
     "macro.dbt.list_schemas": {
@@ -13127,7 +13165,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.154273,
+      "created_at": 1716242219.3902788,
       "supported_languages": null
     },
     "macro.dbt.default__list_schemas": {
@@ -13152,7 +13190,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.154519,
+      "created_at": 1716242219.390495,
       "supported_languages": null
     },
     "macro.dbt.check_schema_exists": {
@@ -13176,7 +13214,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.154733,
+      "created_at": 1716242219.390677,
       "supported_languages": null
     },
     "macro.dbt.default__check_schema_exists": {
@@ -13201,7 +13239,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.155042,
+      "created_at": 1716242219.390941,
       "supported_languages": null
     },
     "macro.dbt.list_relations_without_caching": {
@@ -13225,7 +13263,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.155232,
+      "created_at": 1716242219.3911119,
       "supported_languages": null
     },
     "macro.dbt.default__list_relations_without_caching": {
@@ -13247,7 +13285,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.155404,
+      "created_at": 1716242219.391254,
       "supported_languages": null
     },
     "macro.dbt.get_relations": {
@@ -13271,7 +13309,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.155581,
+      "created_at": 1716242219.391405,
       "supported_languages": null
     },
     "macro.dbt.default__get_relations": {
@@ -13293,7 +13331,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.155749,
+      "created_at": 1716242219.391541,
       "supported_languages": null
     },
     "macro.dbt.get_relation_last_modified": {
@@ -13317,7 +13355,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.155964,
+      "created_at": 1716242219.3917282,
       "supported_languages": null
     },
     "macro.dbt.default__get_relation_last_modified": {
@@ -13339,7 +13377,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.156149,
+      "created_at": 1716242219.391881,
       "supported_languages": null
     },
     "macro.dbt.get_columns_in_relation": {
@@ -13363,7 +13401,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.158627,
+      "created_at": 1716242219.3939772,
       "supported_languages": null
     },
     "macro.dbt.default__get_columns_in_relation": {
@@ -13385,7 +13423,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.158798,
+      "created_at": 1716242219.39412,
       "supported_languages": null
     },
     "macro.dbt.sql_convert_columns_in_relation": {
@@ -13407,7 +13445,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.159189,
+      "created_at": 1716242219.394454,
       "supported_languages": null
     },
     "macro.dbt.get_empty_subquery_sql": {
@@ -13431,7 +13469,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.159415,
+      "created_at": 1716242219.3946502,
       "supported_languages": null
     },
     "macro.dbt.default__get_empty_subquery_sql": {
@@ -13453,7 +13491,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1596391,
+      "created_at": 1716242219.394829,
       "supported_languages": null
     },
     "macro.dbt.get_empty_schema_sql": {
@@ -13477,7 +13515,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.159827,
+      "created_at": 1716242219.394992,
       "supported_languages": null
     },
     "macro.dbt.default__get_empty_schema_sql": {
@@ -13487,9 +13525,11 @@
       "path": "macros/adapters/columns.sql",
       "original_file_path": "macros/adapters/columns.sql",
       "unique_id": "macro.dbt.default__get_empty_schema_sql",
-      "macro_sql": "{% macro default__get_empty_schema_sql(columns) %}\n    {%- set col_err = [] -%}\n    {%- set col_naked_numeric = [] -%}\n    select\n    {% for i in columns %}\n      {%- set col = columns[i] -%}\n      {%- if col['data_type'] is not defined -%}\n        {%- do col_err.append(col['name']) -%}\n      {#-- If this column's type is just 'numeric' then it is missing precision/scale, raise a warning --#}\n      {%- elif col['data_type'].strip().lower() in ('numeric', 'decimal', 'number') -%}\n        {%- do col_naked_numeric.append(col['name']) -%}\n      {%- endif -%}\n      {% set col_name = adapter.quote(col['name']) if col.get('quote') else col['name'] %}\n      cast(null as {{ col['data_type'] }}) as {{ col_name }}{{ \", \" if not loop.last }}\n    {%- endfor -%}\n    {%- if (col_err | length) > 0 -%}\n      {{ exceptions.column_type_missing(column_names=col_err) }}\n    {%- elif (col_naked_numeric | length) > 0 -%}\n      {{ exceptions.warn(\"Detected columns with numeric type and unspecified precision/scale, this can lead to unintended rounding: \" ~ col_naked_numeric ~ \"`\") }}\n    {%- endif -%}\n{% endmacro %}",
+      "macro_sql": "{% macro default__get_empty_schema_sql(columns) %}\n    {%- set col_err = [] -%}\n    {%- set col_naked_numeric = [] -%}\n    select\n    {% for i in columns %}\n      {%- set col = columns[i] -%}\n      {%- if col['data_type'] is not defined -%}\n        {%- do col_err.append(col['name']) -%}\n      {#-- If this column's type is just 'numeric' then it is missing precision/scale, raise a warning --#}\n      {%- elif col['data_type'].strip().lower() in ('numeric', 'decimal', 'number') -%}\n        {%- do col_naked_numeric.append(col['name']) -%}\n      {%- endif -%}\n      {% set col_name = adapter.quote(col['name']) if col.get('quote') else col['name'] %}\n      {{ cast('null', col['data_type']) }} as {{ col_name }}{{ \", \" if not loop.last }}\n    {%- endfor -%}\n    {%- if (col_err | length) > 0 -%}\n      {{ exceptions.column_type_missing(column_names=col_err) }}\n    {%- elif (col_naked_numeric | length) > 0 -%}\n      {{ exceptions.warn(\"Detected columns with numeric type and unspecified precision/scale, this can lead to unintended rounding: \" ~ col_naked_numeric ~ \"`\") }}\n    {%- endif -%}\n{% endmacro %}",
       "depends_on": {
-        "macros": []
+        "macros": [
+          "macro.dbt.cast"
+        ]
       },
       "description": "",
       "meta": {},
@@ -13499,7 +13539,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.16099,
+      "created_at": 1716242219.396035,
       "supported_languages": null
     },
     "macro.dbt.get_column_schema_from_query": {
@@ -13523,7 +13563,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1613388,
+      "created_at": 1716242219.396344,
       "supported_languages": null
     },
     "macro.dbt.get_columns_in_query": {
@@ -13547,7 +13587,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.161525,
+      "created_at": 1716242219.396516,
       "supported_languages": null
     },
     "macro.dbt.default__get_columns_in_query": {
@@ -13572,7 +13612,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.161881,
+      "created_at": 1716242219.396827,
       "supported_languages": null
     },
     "macro.dbt.alter_column_type": {
@@ -13596,7 +13636,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.162122,
+      "created_at": 1716242219.397033,
       "supported_languages": null
     },
     "macro.dbt.default__alter_column_type": {
@@ -13620,7 +13660,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1627252,
+      "created_at": 1716242219.397575,
       "supported_languages": null
     },
     "macro.dbt.alter_relation_add_remove_columns": {
@@ -13644,7 +13684,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1629891,
+      "created_at": 1716242219.397804,
       "supported_languages": null
     },
     "macro.dbt.default__alter_relation_add_remove_columns": {
@@ -13668,7 +13708,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1637719,
+      "created_at": 1716242219.398487,
       "supported_languages": null
     },
     "macro.dbt.get_fixture_sql": {
@@ -13694,7 +13734,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1673658,
+      "created_at": 1716242219.401439,
       "supported_languages": null
     },
     "macro.dbt.get_expected_sql": {
@@ -13718,7 +13758,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.167926,
+      "created_at": 1716242219.4019341,
       "supported_languages": null
     },
     "macro.dbt.format_row": {
@@ -13728,7 +13768,7 @@
       "path": "macros/unit_test_sql/get_fixture_sql.sql",
       "original_file_path": "macros/unit_test_sql/get_fixture_sql.sql",
       "unique_id": "macro.dbt.format_row",
-      "macro_sql": "\n\n{%- macro format_row(row, column_name_to_data_types) -%}\n    {#-- generate case-insensitive formatted row --#}\n    {% set formatted_row = {} %}\n    {%- for column_name, column_value in row.items() -%}\n        {% set column_name = column_name|lower %}\n\n        {%- if column_name not in column_name_to_data_types %}\n            {#-- if user-provided row contains column name that relation does not contain, raise an error --#}\n            {% set fixture_name = \"expected output\" if model.resource_type == 'unit_test' else (\"'\" ~ model.name ~ \"'\") %}\n            {{ exceptions.raise_compiler_error(\n                \"Invalid column name: '\" ~ column_name ~ \"' in unit test fixture for \" ~ fixture_name ~ \".\"\n                \"\\nAccepted columns for \" ~ fixture_name ~ \" are: \" ~ (column_name_to_data_types.keys()|list)\n            ) }}\n        {%- endif -%}\n\n        {%- set column_type = column_name_to_data_types[column_name] %}\n        \n        {#-- sanitize column_value: wrap yaml strings in quotes, apply cast --#}\n        {%- set column_value_clean = column_value -%}\n        {%- if column_value is string -%}\n            {%- set column_value_clean = dbt.string_literal(dbt.escape_single_quotes(column_value)) -%}\n        {%- elif column_value is none -%}\n            {%- set column_value_clean = 'null' -%}\n        {%- endif -%}\n\n        {%- set row_update = {column_name: safe_cast(column_value_clean, column_type) } -%}\n        {%- do formatted_row.update(row_update) -%}\n    {%- endfor -%}\n    {{ return(formatted_row) }}\n{%- endmacro -%}",
+      "macro_sql": "\n\n{%- macro format_row(row, column_name_to_data_types) -%}\n    {#-- generate case-insensitive formatted row --#}\n    {% set formatted_row = {} %}\n    {%- for column_name, column_value in row.items() -%}\n        {% set column_name = column_name|lower %}\n\n        {%- if column_name not in column_name_to_data_types %}\n            {#-- if user-provided row contains column name that relation does not contain, raise an error --#}\n            {% set fixture_name = \"expected output\" if model.resource_type == 'unit_test' else (\"'\" ~ model.name ~ \"'\") %}\n            {{ exceptions.raise_compiler_error(\n                \"Invalid column name: '\" ~ column_name ~ \"' in unit test fixture for \" ~ fixture_name ~ \".\"\n                \"\\nAccepted columns for \" ~ fixture_name ~ \" are: \" ~ (column_name_to_data_types.keys()|list)\n            ) }}\n        {%- endif -%}\n\n        {%- set column_type = column_name_to_data_types[column_name] %}\n\n        {#-- sanitize column_value: wrap yaml strings in quotes, apply cast --#}\n        {%- set column_value_clean = column_value -%}\n        {%- if column_value is string -%}\n            {%- set column_value_clean = dbt.string_literal(dbt.escape_single_quotes(column_value)) -%}\n        {%- elif column_value is none -%}\n            {%- set column_value_clean = 'null' -%}\n        {%- endif -%}\n\n        {%- set row_update = {column_name: safe_cast(column_value_clean, column_type) } -%}\n        {%- do formatted_row.update(row_update) -%}\n    {%- endfor -%}\n    {{ return(formatted_row) }}\n{%- endmacro -%}",
       "depends_on": {
         "macros": [
           "macro.dbt.string_literal",
@@ -13744,7 +13784,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.169034,
+      "created_at": 1716242219.40292,
       "supported_languages": null
     },
     "macro.dbt.resolve_model_name": {
@@ -13768,7 +13808,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.170781,
+      "created_at": 1716242219.404465,
       "supported_languages": null
     },
     "macro.dbt.default__resolve_model_name": {
@@ -13790,7 +13830,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.170937,
+      "created_at": 1716242219.404604,
       "supported_languages": null
     },
     "macro.dbt.build_ref_function": {
@@ -13814,7 +13854,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1717389,
+      "created_at": 1716242219.405335,
       "supported_languages": null
     },
     "macro.dbt.build_source_function": {
@@ -13838,7 +13878,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.172142,
+      "created_at": 1716242219.4057012,
       "supported_languages": null
     },
     "macro.dbt.build_config_dict": {
@@ -13860,7 +13900,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1727092,
+      "created_at": 1716242219.406215,
       "supported_languages": null
     },
     "macro.dbt.py_script_postfix": {
@@ -13889,7 +13929,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.173196,
+      "created_at": 1716242219.406639,
       "supported_languages": null
     },
     "macro.dbt.py_script_comment": {
@@ -13911,7 +13951,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.173286,
+      "created_at": 1716242219.406707,
       "supported_languages": null
     },
     "macro.dbt.test_unique": {
@@ -13935,7 +13975,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.173878,
+      "created_at": 1716242219.407179,
       "supported_languages": null
     },
     "macro.dbt.test_not_null": {
@@ -13959,7 +13999,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1741629,
+      "created_at": 1716242219.407404,
       "supported_languages": null
     },
     "macro.dbt.test_accepted_values": {
@@ -13983,7 +14023,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.174502,
+      "created_at": 1716242219.407679,
       "supported_languages": null
     },
     "macro.dbt.test_relationships": {
@@ -14007,7 +14047,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1748428,
+      "created_at": 1716242219.407947,
       "supported_languages": null
     },
     "macro.dbt_utils.get_url_host": {
@@ -14031,7 +14071,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.175539,
+      "created_at": 1716242219.408278,
       "supported_languages": null
     },
     "macro.dbt_utils.default__get_url_host": {
@@ -14058,7 +14098,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.176214,
+      "created_at": 1716242219.4087071,
       "supported_languages": null
     },
     "macro.dbt_utils.get_url_path": {
@@ -14082,7 +14122,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.176786,
+      "created_at": 1716242219.409154,
       "supported_languages": null
     },
     "macro.dbt_utils.default__get_url_path": {
@@ -14112,7 +14152,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.17743,
+      "created_at": 1716242219.40974,
       "supported_languages": null
     },
     "macro.dbt_utils.get_url_parameter": {
@@ -14136,7 +14176,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1777458,
+      "created_at": 1716242219.410021,
       "supported_languages": null
     },
     "macro.dbt_utils.default__get_url_parameter": {
@@ -14160,7 +14200,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.178062,
+      "created_at": 1716242219.4103072,
       "supported_languages": null
     },
     "macro.dbt_utils.test_fewer_rows_than": {
@@ -14184,7 +14224,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.179157,
+      "created_at": 1716242219.4113111,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_fewer_rows_than": {
@@ -14206,7 +14246,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.180209,
+      "created_at": 1716242219.412276,
       "supported_languages": null
     },
     "macro.dbt_utils.test_equal_rowcount": {
@@ -14230,7 +14270,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.181053,
+      "created_at": 1716242219.413064,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_equal_rowcount": {
@@ -14252,7 +14292,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.182119,
+      "created_at": 1716242219.414017,
       "supported_languages": null
     },
     "macro.dbt_utils.test_relationships_where": {
@@ -14276,7 +14316,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1827772,
+      "created_at": 1716242219.414612,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_relationships_where": {
@@ -14298,7 +14338,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.183115,
+      "created_at": 1716242219.414918,
       "supported_languages": null
     },
     "macro.dbt_utils.test_recency": {
@@ -14322,7 +14362,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.18383,
+      "created_at": 1716242219.415581,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_recency": {
@@ -14348,7 +14388,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.184623,
+      "created_at": 1716242219.41631,
       "supported_languages": null
     },
     "macro.dbt_utils.test_not_constant": {
@@ -14372,7 +14412,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.185056,
+      "created_at": 1716242219.41671,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_not_constant": {
@@ -14394,7 +14434,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.185499,
+      "created_at": 1716242219.417116,
       "supported_languages": null
     },
     "macro.dbt_utils.test_accepted_range": {
@@ -14418,7 +14458,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.18609,
+      "created_at": 1716242219.417666,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_accepted_range": {
@@ -14440,7 +14480,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.186545,
+      "created_at": 1716242219.418092,
       "supported_languages": null
     },
     "macro.dbt_utils.test_not_accepted_values": {
@@ -14464,7 +14504,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.187089,
+      "created_at": 1716242219.418614,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_not_accepted_values": {
@@ -14486,7 +14526,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1874602,
+      "created_at": 1716242219.418965,
       "supported_languages": null
     },
     "macro.dbt_utils.test_at_least_one": {
@@ -14510,7 +14550,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.187903,
+      "created_at": 1716242219.419379,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_at_least_one": {
@@ -14532,7 +14572,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.18834,
+      "created_at": 1716242219.419798,
       "supported_languages": null
     },
     "macro.dbt_utils.test_unique_combination_of_columns": {
@@ -14556,7 +14596,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.188951,
+      "created_at": 1716242219.420369,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_unique_combination_of_columns": {
@@ -14578,7 +14618,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.189625,
+      "created_at": 1716242219.420993,
       "supported_languages": null
     },
     "macro.dbt_utils.test_cardinality_equality": {
@@ -14602,7 +14642,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1901429,
+      "created_at": 1716242219.42149,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_cardinality_equality": {
@@ -14626,7 +14666,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.190464,
+      "created_at": 1716242219.421797,
       "supported_languages": null
     },
     "macro.dbt_utils.test_expression_is_true": {
@@ -14650,7 +14690,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.190838,
+      "created_at": 1716242219.422154,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_expression_is_true": {
@@ -14674,7 +14714,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.191168,
+      "created_at": 1716242219.4224691,
       "supported_languages": null
     },
     "macro.dbt_utils.test_not_null_proportion": {
@@ -14698,7 +14738,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.191774,
+      "created_at": 1716242219.423053,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_not_null_proportion": {
@@ -14720,7 +14760,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.192519,
+      "created_at": 1716242219.4237719,
       "supported_languages": null
     },
     "macro.dbt_utils.test_sequential_values": {
@@ -14744,7 +14784,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.193398,
+      "created_at": 1716242219.42462,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_sequential_values": {
@@ -14770,7 +14810,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.194185,
+      "created_at": 1716242219.4254222,
       "supported_languages": null
     },
     "macro.dbt_utils.test_equality": {
@@ -14794,7 +14834,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.194856,
+      "created_at": 1716242219.426108,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_equality": {
@@ -14820,7 +14860,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.1956449,
+      "created_at": 1716242219.4268959,
       "supported_languages": null
     },
     "macro.dbt_utils.test_not_empty_string": {
@@ -14844,7 +14884,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.196112,
+      "created_at": 1716242219.427365,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_not_empty_string": {
@@ -14866,7 +14906,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.196379,
+      "created_at": 1716242219.4276328,
       "supported_languages": null
     },
     "macro.dbt_utils.test_mutually_exclusive_ranges": {
@@ -14890,7 +14930,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.199775,
+      "created_at": 1716242219.430976,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_mutually_exclusive_ranges": {
@@ -14912,7 +14952,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.201204,
+      "created_at": 1716242219.432394,
       "supported_languages": null
     },
     "macro.dbt_utils.pretty_log_format": {
@@ -14936,7 +14976,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.201453,
+      "created_at": 1716242219.432637,
       "supported_languages": null
     },
     "macro.dbt_utils.default__pretty_log_format": {
@@ -14960,7 +15000,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2016041,
+      "created_at": 1716242219.432786,
       "supported_languages": null
     },
     "macro.dbt_utils._is_relation": {
@@ -14982,7 +15022,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.202,
+      "created_at": 1716242219.433177,
       "supported_languages": null
     },
     "macro.dbt_utils.pretty_time": {
@@ -15006,7 +15046,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.202255,
+      "created_at": 1716242219.4334238,
       "supported_languages": null
     },
     "macro.dbt_utils.default__pretty_time": {
@@ -15028,7 +15068,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.202432,
+      "created_at": 1716242219.433596,
       "supported_languages": null
     },
     "macro.dbt_utils.log_info": {
@@ -15052,7 +15092,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.202663,
+      "created_at": 1716242219.4338229,
       "supported_languages": null
     },
     "macro.dbt_utils.default__log_info": {
@@ -15076,7 +15116,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2028182,
+      "created_at": 1716242219.4339762,
       "supported_languages": null
     },
     "macro.dbt_utils.slugify": {
@@ -15098,7 +15138,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.203389,
+      "created_at": 1716242219.4345212,
       "supported_languages": null
     },
     "macro.dbt_utils._is_ephemeral": {
@@ -15120,7 +15160,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2041411,
+      "created_at": 1716242219.4352791,
       "supported_languages": null
     },
     "macro.dbt_utils.get_intervals_between": {
@@ -15144,7 +15184,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2048352,
+      "created_at": 1716242219.435932,
       "supported_languages": null
     },
     "macro.dbt_utils.default__get_intervals_between": {
@@ -15169,7 +15209,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2053728,
+      "created_at": 1716242219.436453,
       "supported_languages": null
     },
     "macro.dbt_utils.date_spine": {
@@ -15193,7 +15233,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.205594,
+      "created_at": 1716242219.4366632,
       "supported_languages": null
     },
     "macro.dbt_utils.default__date_spine": {
@@ -15219,7 +15259,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2059321,
+      "created_at": 1716242219.4369879,
       "supported_languages": null
     },
     "macro.dbt_utils.nullcheck_table": {
@@ -15243,7 +15283,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.206218,
+      "created_at": 1716242219.437268,
       "supported_languages": null
     },
     "macro.dbt_utils.default__nullcheck_table": {
@@ -15269,7 +15309,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.206521,
+      "created_at": 1716242219.437571,
       "supported_languages": null
     },
     "macro.dbt_utils.get_relations_by_pattern": {
@@ -15293,7 +15333,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.207168,
+      "created_at": 1716242219.43821,
       "supported_languages": null
     },
     "macro.dbt_utils.default__get_relations_by_pattern": {
@@ -15318,7 +15358,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.20799,
+      "created_at": 1716242219.439153,
       "supported_languages": null
     },
     "macro.dbt_utils.get_powers_of_two": {
@@ -15342,7 +15382,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2087731,
+      "created_at": 1716242219.439931,
       "supported_languages": null
     },
     "macro.dbt_utils.default__get_powers_of_two": {
@@ -15364,7 +15404,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.209138,
+      "created_at": 1716242219.440295,
       "supported_languages": null
     },
     "macro.dbt_utils.generate_series": {
@@ -15388,7 +15428,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.209312,
+      "created_at": 1716242219.4404638,
       "supported_languages": null
     },
     "macro.dbt_utils.default__generate_series": {
@@ -15412,7 +15452,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2097769,
+      "created_at": 1716242219.440917,
       "supported_languages": null
     },
     "macro.dbt_utils.get_relations_by_prefix": {
@@ -15436,7 +15476,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.210426,
+      "created_at": 1716242219.441549,
       "supported_languages": null
     },
     "macro.dbt_utils.default__get_relations_by_prefix": {
@@ -15461,7 +15501,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.211187,
+      "created_at": 1716242219.442301,
       "supported_languages": null
     },
     "macro.dbt_utils.get_tables_by_prefix_sql": {
@@ -15485,7 +15525,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2115588,
+      "created_at": 1716242219.4426649,
       "supported_languages": null
     },
     "macro.dbt_utils.default__get_tables_by_prefix_sql": {
@@ -15509,7 +15549,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.211814,
+      "created_at": 1716242219.442917,
       "supported_languages": null
     },
     "macro.dbt_utils.star": {
@@ -15533,7 +15573,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.213063,
+      "created_at": 1716242219.444108,
       "supported_languages": null
     },
     "macro.dbt_utils.default__star": {
@@ -15559,7 +15599,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2143722,
+      "created_at": 1716242219.445416,
       "supported_languages": null
     },
     "macro.dbt_utils.unpivot": {
@@ -15583,7 +15623,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.215657,
+      "created_at": 1716242219.446666,
       "supported_languages": null
     },
     "macro.dbt_utils.default__unpivot": {
@@ -15610,7 +15650,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2170691,
+      "created_at": 1716242219.448071,
       "supported_languages": null
     },
     "macro.dbt_utils.safe_divide": {
@@ -15634,7 +15674,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2173362,
+      "created_at": 1716242219.4483368,
       "supported_languages": null
     },
     "macro.dbt_utils.default__safe_divide": {
@@ -15656,7 +15696,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.217458,
+      "created_at": 1716242219.448458,
       "supported_languages": null
     },
     "macro.dbt_utils.union_relations": {
@@ -15680,7 +15720,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.220672,
+      "created_at": 1716242219.451564,
       "supported_languages": null
     },
     "macro.dbt_utils.default__union_relations": {
@@ -15707,7 +15747,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.223718,
+      "created_at": 1716242219.454601,
       "supported_languages": null
     },
     "macro.dbt_utils.group_by": {
@@ -15731,7 +15771,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.223994,
+      "created_at": 1716242219.454876,
       "supported_languages": null
     },
     "macro.dbt_utils.default__group_by": {
@@ -15753,7 +15793,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.224221,
+      "created_at": 1716242219.4550989,
       "supported_languages": null
     },
     "macro.dbt_utils.deduplicate": {
@@ -15777,7 +15817,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.224917,
+      "created_at": 1716242219.4557939,
       "supported_languages": null
     },
     "macro.dbt_utils.default__deduplicate": {
@@ -15799,7 +15839,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.225121,
+      "created_at": 1716242219.455988,
       "supported_languages": null
     },
     "macro.dbt_utils.redshift__deduplicate": {
@@ -15823,7 +15863,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.225303,
+      "created_at": 1716242219.456175,
       "supported_languages": null
     },
     "macro.dbt_utils.postgres__deduplicate": {
@@ -15845,7 +15885,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.225479,
+      "created_at": 1716242219.4563541,
       "supported_languages": null
     },
     "macro.dbt_utils.snowflake__deduplicate": {
@@ -15867,7 +15907,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2256289,
+      "created_at": 1716242219.456505,
       "supported_languages": null
     },
     "macro.dbt_utils.bigquery__deduplicate": {
@@ -15889,7 +15929,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.225787,
+      "created_at": 1716242219.456665,
       "supported_languages": null
     },
     "macro.dbt_utils.surrogate_key": {
@@ -15913,7 +15953,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.226135,
+      "created_at": 1716242219.457013,
       "supported_languages": null
     },
     "macro.dbt_utils.default__surrogate_key": {
@@ -15935,7 +15975,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.22635,
+      "created_at": 1716242219.457224,
       "supported_languages": null
     },
     "macro.dbt_utils.safe_add": {
@@ -15959,7 +15999,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2266939,
+      "created_at": 1716242219.4575691,
       "supported_languages": null
     },
     "macro.dbt_utils.default__safe_add": {
@@ -15981,7 +16021,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.227175,
+      "created_at": 1716242219.458051,
       "supported_languages": null
     },
     "macro.dbt_utils.nullcheck": {
@@ -16005,7 +16045,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2274811,
+      "created_at": 1716242219.458359,
       "supported_languages": null
     },
     "macro.dbt_utils.default__nullcheck": {
@@ -16027,7 +16067,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2277818,
+      "created_at": 1716242219.458654,
       "supported_languages": null
     },
     "macro.dbt_utils.get_tables_by_pattern_sql": {
@@ -16051,7 +16091,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.229449,
+      "created_at": 1716242219.460316,
       "supported_languages": null
     },
     "macro.dbt_utils.default__get_tables_by_pattern_sql": {
@@ -16075,7 +16115,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.229779,
+      "created_at": 1716242219.460641,
       "supported_languages": null
     },
     "macro.dbt_utils.bigquery__get_tables_by_pattern_sql": {
@@ -16100,7 +16140,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2304718,
+      "created_at": 1716242219.461343,
       "supported_languages": null
     },
     "macro.dbt_utils._bigquery__get_matching_schemata": {
@@ -16124,7 +16164,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2309172,
+      "created_at": 1716242219.4618108,
       "supported_languages": null
     },
     "macro.dbt_utils.get_column_values": {
@@ -16148,7 +16188,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.23199,
+      "created_at": 1716242219.4628649,
       "supported_languages": null
     },
     "macro.dbt_utils.default__get_column_values": {
@@ -16174,7 +16214,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.233321,
+      "created_at": 1716242219.464208,
       "supported_languages": null
     },
     "macro.dbt_utils.pivot": {
@@ -16198,7 +16238,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.234315,
+      "created_at": 1716242219.465184,
       "supported_languages": null
     },
     "macro.dbt_utils.default__pivot": {
@@ -16223,7 +16263,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.235064,
+      "created_at": 1716242219.465939,
       "supported_languages": null
     },
     "macro.dbt_utils.get_filtered_columns_in_relation": {
@@ -16247,7 +16287,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.235501,
+      "created_at": 1716242219.466364,
       "supported_languages": null
     },
     "macro.dbt_utils.default__get_filtered_columns_in_relation": {
@@ -16272,7 +16312,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2361479,
+      "created_at": 1716242219.467009,
       "supported_languages": null
     },
     "macro.dbt_utils.width_bucket": {
@@ -16296,7 +16336,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2375832,
+      "created_at": 1716242219.4684129,
       "supported_languages": null
     },
     "macro.dbt_utils.default__width_bucket": {
@@ -16321,7 +16361,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2380018,
+      "created_at": 1716242219.468841,
       "supported_languages": null
     },
     "macro.dbt_utils.redshift__width_bucket": {
@@ -16346,7 +16386,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.238419,
+      "created_at": 1716242219.469256,
       "supported_languages": null
     },
     "macro.dbt_utils.snowflake__width_bucket": {
@@ -16368,7 +16408,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2385888,
+      "created_at": 1716242219.469434,
       "supported_languages": null
     },
     "macro.dbt_utils.get_query_results_as_dict": {
@@ -16392,7 +16432,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2389572,
+      "created_at": 1716242219.469789,
       "supported_languages": null
     },
     "macro.dbt_utils.default__get_query_results_as_dict": {
@@ -16416,7 +16456,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.239491,
+      "created_at": 1716242219.470314,
       "supported_languages": null
     },
     "macro.dbt_utils.generate_surrogate_key": {
@@ -16440,7 +16480,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2399201,
+      "created_at": 1716242219.470739,
       "supported_languages": null
     },
     "macro.dbt_utils.default__generate_surrogate_key": {
@@ -16466,7 +16506,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.240502,
+      "created_at": 1716242219.471322,
       "supported_languages": null
     },
     "macro.dbt_utils.get_table_types_sql": {
@@ -16490,7 +16530,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2408829,
+      "created_at": 1716242219.4716978,
       "supported_languages": null
     },
     "macro.dbt_utils.default__get_table_types_sql": {
@@ -16512,7 +16552,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.241013,
+      "created_at": 1716242219.471827,
       "supported_languages": null
     },
     "macro.dbt_utils.postgres__get_table_types_sql": {
@@ -16534,7 +16574,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.241141,
+      "created_at": 1716242219.471951,
       "supported_languages": null
     },
     "macro.dbt_utils.get_single_value": {
@@ -16558,7 +16598,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.241618,
+      "created_at": 1716242219.4724228,
       "supported_languages": null
     },
     "macro.dbt_utils.default__get_single_value": {
@@ -16582,7 +16622,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.242338,
+      "created_at": 1716242219.4731321,
       "supported_languages": null
     },
     "macro.dbt_utils.degrees_to_radians": {
@@ -16604,7 +16644,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2433841,
+      "created_at": 1716242219.4741492,
       "supported_languages": null
     },
     "macro.dbt_utils.haversine_distance": {
@@ -16628,7 +16668,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2436411,
+      "created_at": 1716242219.474407,
       "supported_languages": null
     },
     "macro.dbt_utils.default__haversine_distance": {
@@ -16650,7 +16690,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.244151,
+      "created_at": 1716242219.474901,
       "supported_languages": null
     },
     "macro.dbt_utils.bigquery__haversine_distance": {
@@ -16674,7 +16714,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.244879,
+      "created_at": 1716242219.475622,
       "supported_languages": null
     },
     "macro.dbt_date.get_date_dimension": {
@@ -16698,7 +16738,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2530959,
+      "created_at": 1716242219.483895,
       "supported_languages": null
     },
     "macro.dbt_date.default__get_date_dimension": {
@@ -16740,7 +16780,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2551281,
+      "created_at": 1716242219.48591,
       "supported_languages": null
     },
     "macro.dbt_date.postgres__get_date_dimension": {
@@ -16782,7 +16822,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2572181,
+      "created_at": 1716242219.487927,
       "supported_languages": null
     },
     "macro.dbt_date.get_base_dates": {
@@ -16806,7 +16846,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.258155,
+      "created_at": 1716242219.488866,
       "supported_languages": null
     },
     "macro.dbt_date.default__get_base_dates": {
@@ -16834,7 +16874,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2588181,
+      "created_at": 1716242219.489527,
       "supported_languages": null
     },
     "macro.dbt_date.bigquery__get_base_dates": {
@@ -16862,7 +16902,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.25942,
+      "created_at": 1716242219.490125,
       "supported_languages": null
     },
     "macro.dbt_date.get_intervals_between": {
@@ -16886,7 +16926,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.26008,
+      "created_at": 1716242219.490782,
       "supported_languages": null
     },
     "macro.dbt_date.default__get_intervals_between": {
@@ -16911,7 +16951,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.260604,
+      "created_at": 1716242219.491306,
       "supported_languages": null
     },
     "macro.dbt_date.date_spine": {
@@ -16935,7 +16975,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.260813,
+      "created_at": 1716242219.491511,
       "supported_languages": null
     },
     "macro.dbt_date.default__date_spine": {
@@ -16961,7 +17001,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.261142,
+      "created_at": 1716242219.491842,
       "supported_languages": null
     },
     "macro.dbt_date.get_powers_of_two": {
@@ -16985,7 +17025,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.261919,
+      "created_at": 1716242219.492618,
       "supported_languages": null
     },
     "macro.dbt_date.default__get_powers_of_two": {
@@ -17007,7 +17047,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.262284,
+      "created_at": 1716242219.492981,
       "supported_languages": null
     },
     "macro.dbt_date.generate_series": {
@@ -17031,7 +17071,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.262454,
+      "created_at": 1716242219.4931462,
       "supported_languages": null
     },
     "macro.dbt_date.default__generate_series": {
@@ -17055,7 +17095,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.262912,
+      "created_at": 1716242219.4936,
       "supported_languages": null
     },
     "macro.dbt_date.get_fiscal_year_dates": {
@@ -17079,7 +17119,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.264643,
+      "created_at": 1716242219.49529,
       "supported_languages": null
     },
     "macro.dbt_date.default__get_fiscal_year_dates": {
@@ -17104,7 +17144,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.265186,
+      "created_at": 1716242219.495826,
       "supported_languages": null
     },
     "macro.dbt_date.get_fiscal_periods": {
@@ -17129,7 +17169,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.266073,
+      "created_at": 1716242219.496707,
       "supported_languages": null
     },
     "macro.dbt_date.tomorrow": {
@@ -17153,7 +17193,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2662709,
+      "created_at": 1716242219.496906,
       "supported_languages": null
     },
     "macro.dbt_date.next_week": {
@@ -17177,7 +17217,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2664351,
+      "created_at": 1716242219.497067,
       "supported_languages": null
     },
     "macro.dbt_date.next_month_name": {
@@ -17202,7 +17242,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2666519,
+      "created_at": 1716242219.49728,
       "supported_languages": null
     },
     "macro.dbt_date.next_month": {
@@ -17226,7 +17266,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.266814,
+      "created_at": 1716242219.497449,
       "supported_languages": null
     },
     "macro.dbt_date.day_name": {
@@ -17250,7 +17290,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.267387,
+      "created_at": 1716242219.4980211,
       "supported_languages": null
     },
     "macro.dbt_date.default__day_name": {
@@ -17272,7 +17312,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.267631,
+      "created_at": 1716242219.498262,
       "supported_languages": null
     },
     "macro.dbt_date.snowflake__day_name": {
@@ -17294,7 +17334,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2678232,
+      "created_at": 1716242219.498452,
       "supported_languages": null
     },
     "macro.dbt_date.bigquery__day_name": {
@@ -17316,7 +17356,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.268001,
+      "created_at": 1716242219.498631,
       "supported_languages": null
     },
     "macro.dbt_date.postgres__day_name": {
@@ -17338,7 +17378,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.268186,
+      "created_at": 1716242219.498812,
       "supported_languages": null
     },
     "macro.dbt_date.to_unixtimestamp": {
@@ -17362,7 +17402,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.268461,
+      "created_at": 1716242219.4990919,
       "supported_languages": null
     },
     "macro.dbt_date.default__to_unixtimestamp": {
@@ -17386,7 +17426,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.268588,
+      "created_at": 1716242219.49922,
       "supported_languages": null
     },
     "macro.dbt_date.snowflake__to_unixtimestamp": {
@@ -17410,7 +17450,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.268714,
+      "created_at": 1716242219.499346,
       "supported_languages": null
     },
     "macro.dbt_date.bigquery__to_unixtimestamp": {
@@ -17432,7 +17472,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.268811,
+      "created_at": 1716242219.499441,
       "supported_languages": null
     },
     "macro.dbt_date.n_days_away": {
@@ -17456,7 +17496,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2690392,
+      "created_at": 1716242219.499661,
       "supported_languages": null
     },
     "macro.dbt_date.week_start": {
@@ -17481,7 +17521,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.269474,
+      "created_at": 1716242219.5000792,
       "supported_languages": null
     },
     "macro.dbt_date.default__week_start": {
@@ -17505,7 +17545,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2696059,
+      "created_at": 1716242219.500212,
       "supported_languages": null
     },
     "macro.dbt_date.snowflake__week_start": {
@@ -17530,7 +17570,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.269869,
+      "created_at": 1716242219.500472,
       "supported_languages": null
     },
     "macro.dbt_date.postgres__week_start": {
@@ -17555,7 +17595,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.270113,
+      "created_at": 1716242219.500706,
       "supported_languages": null
     },
     "macro.dbt_date.iso_week_start": {
@@ -17580,7 +17620,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.270559,
+      "created_at": 1716242219.5011442,
       "supported_languages": null
     },
     "macro.dbt_date._iso_week_start": {
@@ -17604,7 +17644,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.270704,
+      "created_at": 1716242219.5012832,
       "supported_languages": null
     },
     "macro.dbt_date.default__iso_week_start": {
@@ -17628,7 +17668,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2708302,
+      "created_at": 1716242219.501409,
       "supported_languages": null
     },
     "macro.dbt_date.snowflake__iso_week_start": {
@@ -17652,7 +17692,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2709591,
+      "created_at": 1716242219.501533,
       "supported_languages": null
     },
     "macro.dbt_date.postgres__iso_week_start": {
@@ -17676,7 +17716,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.271086,
+      "created_at": 1716242219.5016582,
       "supported_languages": null
     },
     "macro.dbt_date.n_days_ago": {
@@ -17701,7 +17741,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.271463,
+      "created_at": 1716242219.502017,
       "supported_languages": null
     },
     "macro.dbt_date.last_week": {
@@ -17725,7 +17765,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.271629,
+      "created_at": 1716242219.502178,
       "supported_languages": null
     },
     "macro.dbt_date.now": {
@@ -17750,7 +17790,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.271806,
+      "created_at": 1716242219.502357,
       "supported_languages": null
     },
     "macro.dbt_date.periods_since": {
@@ -17775,7 +17815,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.272105,
+      "created_at": 1716242219.502652,
       "supported_languages": null
     },
     "macro.dbt_date.today": {
@@ -17799,7 +17839,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2722628,
+      "created_at": 1716242219.502805,
       "supported_languages": null
     },
     "macro.dbt_date.last_month": {
@@ -17823,7 +17863,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2724218,
+      "created_at": 1716242219.502968,
       "supported_languages": null
     },
     "macro.dbt_date.day_of_year": {
@@ -17847,7 +17887,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2727082,
+      "created_at": 1716242219.50325,
       "supported_languages": null
     },
     "macro.dbt_date.default__day_of_year": {
@@ -17871,7 +17911,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.272835,
+      "created_at": 1716242219.5033758,
       "supported_languages": null
     },
     "macro.dbt_date.postgres__day_of_year": {
@@ -17895,7 +17935,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.272964,
+      "created_at": 1716242219.5035,
       "supported_languages": null
     },
     "macro.dbt_date.redshift__day_of_year": {
@@ -17920,7 +17960,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.273129,
+      "created_at": 1716242219.503662,
       "supported_languages": null
     },
     "macro.dbt_date.round_timestamp": {
@@ -17945,7 +17985,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.273345,
+      "created_at": 1716242219.5038788,
       "supported_languages": null
     },
     "macro.dbt_date.from_unixtimestamp": {
@@ -17969,7 +18009,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2745101,
+      "created_at": 1716242219.505025,
       "supported_languages": null
     },
     "macro.dbt_date.default__from_unixtimestamp": {
@@ -17991,7 +18031,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.274745,
+      "created_at": 1716242219.50526,
       "supported_languages": null
     },
     "macro.dbt_date.postgres__from_unixtimestamp": {
@@ -18013,7 +18053,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.274982,
+      "created_at": 1716242219.505492,
       "supported_languages": null
     },
     "macro.dbt_date.snowflake__from_unixtimestamp": {
@@ -18035,7 +18075,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2754,
+      "created_at": 1716242219.505903,
       "supported_languages": null
     },
     "macro.dbt_date.bigquery__from_unixtimestamp": {
@@ -18057,7 +18097,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.275747,
+      "created_at": 1716242219.506248,
       "supported_languages": null
     },
     "macro.dbt_date.n_months_ago": {
@@ -18083,7 +18123,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.276074,
+      "created_at": 1716242219.5065742,
       "supported_languages": null
     },
     "macro.dbt_date.date_part": {
@@ -18107,7 +18147,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.276341,
+      "created_at": 1716242219.5068429,
       "supported_languages": null
     },
     "macro.dbt_date.default__date_part": {
@@ -18129,7 +18169,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2764611,
+      "created_at": 1716242219.506963,
       "supported_languages": null
     },
     "macro.dbt_date.bigquery__date_part": {
@@ -18151,7 +18191,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.27658,
+      "created_at": 1716242219.5070798,
       "supported_languages": null
     },
     "macro.dbt_date.n_weeks_away": {
@@ -18177,7 +18217,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.276887,
+      "created_at": 1716242219.507385,
       "supported_languages": null
     },
     "macro.dbt_date.day_of_month": {
@@ -18201,7 +18241,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.27708,
+      "created_at": 1716242219.507576,
       "supported_languages": null
     },
     "macro.dbt_date.redshift__day_of_month": {
@@ -18226,7 +18266,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.277416,
+      "created_at": 1716242219.5077991,
       "supported_languages": null
     },
     "macro.dbt_date.yesterday": {
@@ -18250,7 +18290,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.27761,
+      "created_at": 1716242219.507992,
       "supported_languages": null
     },
     "macro.dbt_date.day_of_week": {
@@ -18274,7 +18314,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.279333,
+      "created_at": 1716242219.509674,
       "supported_languages": null
     },
     "macro.dbt_date.default__day_of_week": {
@@ -18298,7 +18338,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.279595,
+      "created_at": 1716242219.509938,
       "supported_languages": null
     },
     "macro.dbt_date.snowflake__day_of_week": {
@@ -18322,7 +18362,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.279957,
+      "created_at": 1716242219.5103061,
       "supported_languages": null
     },
     "macro.dbt_date.bigquery__day_of_week": {
@@ -18346,7 +18386,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.280216,
+      "created_at": 1716242219.5105689,
       "supported_languages": null
     },
     "macro.dbt_date.postgres__day_of_week": {
@@ -18371,7 +18411,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.28059,
+      "created_at": 1716242219.5109482,
       "supported_languages": null
     },
     "macro.dbt_date.redshift__day_of_week": {
@@ -18396,7 +18436,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.280923,
+      "created_at": 1716242219.511272,
       "supported_languages": null
     },
     "macro.dbt_date.iso_week_end": {
@@ -18421,7 +18461,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.281331,
+      "created_at": 1716242219.5116758,
       "supported_languages": null
     },
     "macro.dbt_date._iso_week_end": {
@@ -18446,7 +18486,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2815201,
+      "created_at": 1716242219.5118651,
       "supported_languages": null
     },
     "macro.dbt_date.default__iso_week_end": {
@@ -18470,7 +18510,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2816498,
+      "created_at": 1716242219.5119932,
       "supported_languages": null
     },
     "macro.dbt_date.snowflake__iso_week_end": {
@@ -18494,7 +18534,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.281775,
+      "created_at": 1716242219.512118,
       "supported_languages": null
     },
     "macro.dbt_date.n_weeks_ago": {
@@ -18520,7 +18560,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.282112,
+      "created_at": 1716242219.5124412,
       "supported_languages": null
     },
     "macro.dbt_date.month_name": {
@@ -18544,7 +18584,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.282539,
+      "created_at": 1716242219.512877,
       "supported_languages": null
     },
     "macro.dbt_date.default__month_name": {
@@ -18566,7 +18606,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.28272,
+      "created_at": 1716242219.513056,
       "supported_languages": null
     },
     "macro.dbt_date.bigquery__month_name": {
@@ -18588,7 +18628,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.282898,
+      "created_at": 1716242219.513233,
       "supported_languages": null
     },
     "macro.dbt_date.snowflake__month_name": {
@@ -18610,7 +18650,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.283078,
+      "created_at": 1716242219.513411,
       "supported_languages": null
     },
     "macro.dbt_date.postgres__month_name": {
@@ -18632,7 +18672,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.283266,
+      "created_at": 1716242219.513591,
       "supported_languages": null
     },
     "macro.dbt_date.last_month_name": {
@@ -18657,7 +18697,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.283482,
+      "created_at": 1716242219.5138052,
       "supported_languages": null
     },
     "macro.dbt_date.week_of_year": {
@@ -18682,7 +18722,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.283915,
+      "created_at": 1716242219.51423,
       "supported_languages": null
     },
     "macro.dbt_date.default__week_of_year": {
@@ -18707,7 +18747,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.284081,
+      "created_at": 1716242219.514393,
       "supported_languages": null
     },
     "macro.dbt_date.postgres__week_of_year": {
@@ -18731,7 +18771,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2842171,
+      "created_at": 1716242219.51453,
       "supported_languages": null
     },
     "macro.dbt_date.convert_timezone": {
@@ -18755,7 +18795,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.285084,
+      "created_at": 1716242219.5153909,
       "supported_languages": null
     },
     "macro.dbt_date.default__convert_timezone": {
@@ -18779,7 +18819,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.285268,
+      "created_at": 1716242219.515574,
       "supported_languages": null
     },
     "macro.dbt_date.bigquery__convert_timezone": {
@@ -18801,7 +18841,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.285409,
+      "created_at": 1716242219.515712,
       "supported_languages": null
     },
     "macro.dbt_date.spark__convert_timezone": {
@@ -18823,7 +18863,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.285558,
+      "created_at": 1716242219.515861,
       "supported_languages": null
     },
     "macro.dbt_date.postgres__convert_timezone": {
@@ -18847,7 +18887,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.285766,
+      "created_at": 1716242219.516068,
       "supported_languages": null
     },
     "macro.dbt_date.redshift__convert_timezone": {
@@ -18871,7 +18911,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.285938,
+      "created_at": 1716242219.5162392,
       "supported_languages": null
     },
     "macro.dbt_date.n_months_away": {
@@ -18897,7 +18937,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.286252,
+      "created_at": 1716242219.516544,
       "supported_languages": null
     },
     "macro.dbt_date.iso_week_of_year": {
@@ -18922,7 +18962,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.286753,
+      "created_at": 1716242219.517025,
       "supported_languages": null
     },
     "macro.dbt_date._iso_week_of_year": {
@@ -18947,7 +18987,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.286923,
+      "created_at": 1716242219.5171971,
       "supported_languages": null
     },
     "macro.dbt_date.default__iso_week_of_year": {
@@ -18971,7 +19011,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.287051,
+      "created_at": 1716242219.517324,
       "supported_languages": null
     },
     "macro.dbt_date.snowflake__iso_week_of_year": {
@@ -18995,7 +19035,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.287178,
+      "created_at": 1716242219.51745,
       "supported_languages": null
     },
     "macro.dbt_date.postgres__iso_week_of_year": {
@@ -19019,7 +19059,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2873118,
+      "created_at": 1716242219.5175838,
       "supported_languages": null
     },
     "macro.dbt_date.week_end": {
@@ -19044,7 +19084,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.287724,
+      "created_at": 1716242219.517992,
       "supported_languages": null
     },
     "macro.dbt_date.default__week_end": {
@@ -19068,7 +19108,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2878442,
+      "created_at": 1716242219.518111,
       "supported_languages": null
     },
     "macro.dbt_date.snowflake__week_end": {
@@ -19093,7 +19133,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.288022,
+      "created_at": 1716242219.5182898,
       "supported_languages": null
     },
     "macro.dbt_date.postgres__week_end": {
@@ -19118,7 +19158,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2882051,
+      "created_at": 1716242219.518466,
       "supported_languages": null
     },
     "macro.dbt_date.next_month_number": {
@@ -19143,7 +19183,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.2884,
+      "created_at": 1716242219.51866,
       "supported_languages": null
     },
     "macro.dbt_date.last_month_number": {
@@ -19168,7 +19208,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1712784318.288596,
+      "created_at": 1716242219.518854,
       "supported_languages": null
     }
   },
@@ -19244,7 +19284,7 @@
       },
       "refs": [],
       "metrics": [],
-      "created_at": 1712784318.80478,
+      "created_at": 1716242220.0655081,
       "group": null
     },
     "metric.jaffle_shop.customers_with_orders": {
@@ -19306,7 +19346,7 @@
       },
       "refs": [],
       "metrics": [],
-      "created_at": 1712784318.8949409,
+      "created_at": 1716242220.1582751,
       "group": null
     },
     "metric.jaffle_shop.new_customer": {
@@ -19374,7 +19414,7 @@
       },
       "refs": [],
       "metrics": [],
-      "created_at": 1712784318.895398,
+      "created_at": 1716242220.158738,
       "group": null
     },
     "metric.jaffle_shop.order_total": {
@@ -19436,7 +19476,7 @@
       },
       "refs": [],
       "metrics": [],
-      "created_at": 1712784318.9033878,
+      "created_at": 1716242220.1667352,
       "group": null
     },
     "metric.jaffle_shop.revenue": {
@@ -19498,7 +19538,7 @@
       },
       "refs": [],
       "metrics": [],
-      "created_at": 1712784318.907369,
+      "created_at": 1716242220.170729,
       "group": null
     },
     "metric.jaffle_shop.order_cost": {
@@ -19560,7 +19600,7 @@
       },
       "refs": [],
       "metrics": [],
-      "created_at": 1712784318.9076748,
+      "created_at": 1716242220.17104,
       "group": null
     },
     "metric.jaffle_shop.median_revenue": {
@@ -19622,7 +19662,7 @@
       },
       "refs": [],
       "metrics": [],
-      "created_at": 1712784318.908122,
+      "created_at": 1716242220.171485,
       "group": null
     },
     "metric.jaffle_shop.large_order": {
@@ -19690,7 +19730,7 @@
       },
       "refs": [],
       "metrics": [],
-      "created_at": 1712784318.908577,
+      "created_at": 1716242220.171927,
       "group": null
     },
     "metric.jaffle_shop.orders": {
@@ -19752,7 +19792,7 @@
       },
       "refs": [],
       "metrics": [],
-      "created_at": 1712784318.908871,
+      "created_at": 1716242220.172315,
       "group": null
     },
     "metric.jaffle_shop.food_orders": {
@@ -19820,7 +19860,7 @@
       },
       "refs": [],
       "metrics": [],
-      "created_at": 1712784318.909405,
+      "created_at": 1716242220.172765,
       "group": null
     },
     "metric.jaffle_shop.food_revenue": {
@@ -19882,7 +19922,7 @@
       },
       "refs": [],
       "metrics": [],
-      "created_at": 1712784318.909836,
+      "created_at": 1716242220.173205,
       "group": null
     },
     "metric.jaffle_shop.food_revenue_pct": {
@@ -19958,7 +19998,7 @@
       },
       "refs": [],
       "metrics": [],
-      "created_at": 1712784318.911555,
+      "created_at": 1716242220.174939,
       "group": null
     },
     "metric.jaffle_shop.revenue_growth_mom": {
@@ -20032,7 +20072,7 @@
       },
       "refs": [],
       "metrics": [],
-      "created_at": 1712784318.912799,
+      "created_at": 1716242220.176163,
       "group": null
     },
     "metric.jaffle_shop.order_gross_profit": {
@@ -20111,7 +20151,7 @@
       },
       "refs": [],
       "metrics": [],
-      "created_at": 1712784318.913632,
+      "created_at": 1716242220.176996,
       "group": null
     },
     "metric.jaffle_shop.cumulative_revenue": {
@@ -20173,7 +20213,7 @@
       },
       "refs": [],
       "metrics": [],
-      "created_at": 1712784318.914203,
+      "created_at": 1716242220.17757,
       "group": null
     }
   },
@@ -20244,7 +20284,6 @@
         },
         "patch_path": null,
         "build_path": null,
-        "deferred": false,
         "unrendered_config": {
           "materialized": "table",
           "enabled": false,
@@ -20252,14 +20291,7 @@
             "pandas==1.5.2"
           ]
         },
-        "created_at": 1712784318.644358,
-        "config_call_dict": {
-          "materialized": "table",
-          "enabled": false,
-          "packages": [
-            "pandas==1.5.2"
-          ]
-        },
+        "created_at": 1716242219.886135,
         "relation_name": "DEV_DB.DBT_DEV.customer_status_histories",
         "raw_code": "import pandas as pd\n\n\ndef model(dbt, session):\n    # set length of time considered a churn\n    pd.Timedelta(days=2)\n\n    dbt.config(enabled=False, materialized=\"table\", packages=[\"pandas==1.5.2\"])\n\n    orders_relation = dbt.ref(\"stg_orders\")\n\n    # converting a DuckDB Python Relation into a pandas DataFrame\n    orders_df = orders_relation.df()\n\n    orders_df.sort_values(by=\"ordered_at\", inplace=True)\n    orders_df[\"previous_order_at\"] = orders_df.groupby(\"customer_id\")[\n        \"ordered_at\"\n    ].shift(1)\n    orders_df[\"next_order_at\"] = orders_df.groupby(\"customer_id\")[\"ordered_at\"].shift(\n        -1\n    )\n    return orders_df",
         "language": "python",
@@ -20286,8 +20318,7 @@
         "constraints": [],
         "version": null,
         "latest_version": null,
-        "deprecation_date": null,
-        "defer_relation": null
+        "deprecation_date": null
       }
     ]
   },
@@ -20672,7 +20703,7 @@
           "version": null
         }
       ],
-      "created_at": 1712784318.766575,
+      "created_at": 1716242220.02584,
       "config": {
         "enabled": true,
         "group": null,
@@ -20799,7 +20830,7 @@
           "version": null
         }
       ],
-      "created_at": 1712784318.7698612,
+      "created_at": 1716242220.0291011,
       "config": {
         "enabled": true,
         "group": null,
@@ -20888,7 +20919,7 @@
           "version": null
         }
       ],
-      "created_at": 1712784318.8062038,
+      "created_at": 1716242220.066827,
       "config": {
         "enabled": true,
         "group": null,
@@ -21075,7 +21106,7 @@
           "version": null
         }
       ],
-      "created_at": 1712784318.906559,
+      "created_at": 1716242220.169923,
       "config": {
         "enabled": true,
         "group": null,
@@ -21230,7 +21261,7 @@
           "version": null
         }
       ],
-      "created_at": 1712784318.915827,
+      "created_at": 1716242220.179175,
       "config": {
         "enabled": true,
         "group": null,

--- a/tests/dbt/data/jaffle_v12/run_results.json
+++ b/tests/dbt/data/jaffle_v12/run_results.json
@@ -1,575 +1,874 @@
 {
   "metadata": {
     "dbt_schema_version": "https://schemas.getdbt.com/dbt/run-results/v6.json",
-    "dbt_version": "1.8.0b2",
-    "generated_at": "2024-04-10T23:18:49.149568Z",
-    "invocation_id": "413ad4da-e7de-4a7c-b755-e8e14624de55",
+    "dbt_version": "1.8.0",
+    "generated_at": "2024-05-20T21:57:02.377380Z",
+    "invocation_id": "2454d712-a02d-4156-8e0e-59bff7797ace",
     "env": {}
   },
   "results": [
     {
-      "status": "pass",
+      "status": "success",
       "timing": [
         {
           "name": "compile",
-          "started_at": "2024-04-10T23:18:35.995269Z",
-          "completed_at": "2024-04-10T23:18:36.017418Z"
+          "started_at": "2024-05-20T21:57:01.294067Z",
+          "completed_at": "2024-05-20T21:57:02.081803Z"
         },
         {
           "name": "execute",
-          "started_at": "2024-04-10T23:18:36.018160Z",
-          "completed_at": "2024-04-10T23:18:36.672424Z"
+          "started_at": "2024-05-20T21:57:02.082551Z",
+          "completed_at": "2024-05-20T21:57:02.082592Z"
         }
       ],
       "thread_id": "Thread-1",
-      "execution_time": 0.8094990253448486,
-      "adapter_response": {
-        "_message": "SUCCESS 1",
-        "code": "SUCCESS",
-        "rows_affected": 1,
-        "query_id": "01b395d6-0604-836d-0029-c00305fa066e"
-      },
+      "execution_time": 0.9084291458129883,
+      "adapter_response": {},
       "message": null,
-      "failures": 0,
-      "unique_id": "test.jaffle_shop.accepted_values_customers_customer_type__new__returning.d12f0947c8",
+      "failures": null,
+      "unique_id": "model.jaffle_shop.metricflow_time_spine",
       "compiled": true,
-      "compiled_code": "\n    \n    \n\nwith all_values as (\n\n    select\n        customer_type as value_field,\n        count(*) as n_records\n\n    from DEV_DB.DBT_DEV.customers\n    group by customer_type\n\n)\n\nselect *\nfrom all_values\nwhere value_field not in (\n    'new','returning'\n)\n\n\n",
+      "compiled_code": "-- metricflow_time_spine.sql\nwith days as (\n    --for BQ adapters use \"DATE('01/01/2000','mm/dd/yyyy')\"\n\n    with date_spine as\n(\n\n    \n\n\n\n\n\nwith rawdata as (\n\n    \n\n    \n\n    with p as (\n        select 0 as generated_number union all select 1\n    ), unioned as (\n\n    select\n\n    \n    p0.generated_number * power(2, 0)\n     + \n    \n    p1.generated_number * power(2, 1)\n     + \n    \n    p2.generated_number * power(2, 2)\n     + \n    \n    p3.generated_number * power(2, 3)\n     + \n    \n    p4.generated_number * power(2, 4)\n     + \n    \n    p5.generated_number * power(2, 5)\n     + \n    \n    p6.generated_number * power(2, 6)\n     + \n    \n    p7.generated_number * power(2, 7)\n     + \n    \n    p8.generated_number * power(2, 8)\n     + \n    \n    p9.generated_number * power(2, 9)\n     + \n    \n    p10.generated_number * power(2, 10)\n     + \n    \n    p11.generated_number * power(2, 11)\n    \n    \n    + 1\n    as generated_number\n\n    from\n\n    \n    p as p0\n     cross join \n    \n    p as p1\n     cross join \n    \n    p as p2\n     cross join \n    \n    p as p3\n     cross join \n    \n    p as p4\n     cross join \n    \n    p as p5\n     cross join \n    \n    p as p6\n     cross join \n    \n    p as p7\n     cross join \n    \n    p as p8\n     cross join \n    \n    p as p9\n     cross join \n    \n    p as p10\n     cross join \n    \n    p as p11\n    \n    \n\n    )\n\n    select *\n    from unioned\n    where generated_number <= 3651\n    order by generated_number\n\n\n\n),\n\nall_periods as (\n\n    select (\n        \n\n    dateadd(\n        day,\n        row_number() over (order by 1) - 1,\n        \n\n    dateadd(\n        day,\n        -3650,\n        cast(convert_timezone('UTC', 'America/Los_Angeles',\n    cast(convert_timezone('UTC', current_timestamp()) as timestamp)\n) as date)\n        )\n\n\n        )\n\n\n    ) as date_day\n    from rawdata\n\n),\n\nfiltered as (\n\n    select *\n    from all_periods\n    where date_day <= cast(\n\n    dateadd(\n        day,\n        1,\n        cast(convert_timezone('UTC', 'America/Los_Angeles',\n    cast(convert_timezone('UTC', current_timestamp()) as timestamp)\n) as date)\n        )\n\n as date)\n\n)\n\nselect * from filtered\n\n\n\n)\nselect\n    cast(d.date_day as timestamp) as date_day\nfrom\n    date_spine d\n\n\n),\n\nfinal as (\n    select cast(date_day as date) as date_day\n    from days\n)\n\nselect *\nfrom final",
+      "relation_name": "DEV_DB.DBT_DEV.metricflow_time_spine"
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-20T21:57:02.204865Z",
+          "completed_at": "2024-05-20T21:57:02.210561Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-20T21:57:02.210924Z",
+          "completed_at": "2024-05-20T21:57:02.210934Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.007913827896118164,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
+      "unique_id": "model.jaffle_shop.stg_customers",
+      "compiled": true,
+      "compiled_code": "with\n\nsource as (\n\n    select * from raw_customers\n\n),\n\nrenamed as (\n\n    select\n\n        ----------  ids\n        id as customer_id,\n\n        ---------- properties\n        name as customer_name\n\n    from source\n\n)\n\nselect * from renamed",
+      "relation_name": "DEV_DB.DBT_DEV.stg_customers"
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-20T21:57:02.212754Z",
+          "completed_at": "2024-05-20T21:57:02.216397Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-20T21:57:02.216687Z",
+          "completed_at": "2024-05-20T21:57:02.216693Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.004608869552612305,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
+      "unique_id": "model.jaffle_shop.stg_locations",
+      "compiled": true,
+      "compiled_code": "with\n\nsource as (\n\n    select * from raw_stores\n\n    -- \n    -- where opened_at <= convert_timezone('UTC', current_timestamp())\n\n),\n\nrenamed as (\n\n    select\n\n        ----------  ids\n        id as location_id,\n\n        ---------- properties\n        name as location_name,\n        tax_rate,\n\n        ---------- timestamp\n        opened_at\n\n    from source\n\n)\n\nselect * from renamed",
+      "relation_name": "DEV_DB.DBT_DEV.stg_locations"
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-20T21:57:02.218284Z",
+          "completed_at": "2024-05-20T21:57:02.220550Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-20T21:57:02.220816Z",
+          "completed_at": "2024-05-20T21:57:02.220820Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.0033550262451171875,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
+      "unique_id": "model.jaffle_shop.stg_order_items",
+      "compiled": true,
+      "compiled_code": "with\n\nsource as (\n\n    select * from raw_items\n\n),\n\nrenamed as (\n\n    select\n\n        ----------  ids\n        id as order_item_id,\n        order_id,\n\n        ---------- properties\n        sku as product_id\n\n    from source\n\n)\n\nselect * from renamed",
+      "relation_name": "DEV_DB.DBT_DEV.stg_order_items"
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-20T21:57:02.222175Z",
+          "completed_at": "2024-05-20T21:57:02.225431Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-20T21:57:02.225676Z",
+          "completed_at": "2024-05-20T21:57:02.225680Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.004102230072021484,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
+      "unique_id": "model.jaffle_shop.stg_orders",
+      "compiled": true,
+      "compiled_code": "\n\nwith\n\nsource as (\n\n    select * from raw_orders\n\n    -- data runs to 2026, truncate timespan to desired range,\n    -- current time as default\n    -- where ordered_at <= convert_timezone('UTC', current_timestamp())\n\n),\n\nrenamed as (\n\n    select\n\n        ----------  ids\n        id as order_id,\n        store_id as location_id,\n        customer as customer_id,\n\n        ---------- properties\n        (order_total / 100.0) as order_total,\n        (tax_paid / 100.0) as tax_paid,\n\n        ---------- timestamps\n        ordered_at\n\n    from source\n\n)\n\nselect * from renamed",
+      "relation_name": "DEV_DB.DBT_DEV.stg_orders"
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-20T21:57:02.226917Z",
+          "completed_at": "2024-05-20T21:57:02.228847Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-20T21:57:02.229096Z",
+          "completed_at": "2024-05-20T21:57:02.229100Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.0028350353240966797,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
+      "unique_id": "model.jaffle_shop.stg_products",
+      "compiled": true,
+      "compiled_code": "with\n\nsource as (\n\n    select * from raw_products\n\n),\n\nrenamed as (\n\n    select\n\n        ----------  ids\n        sku as product_id,\n\n        ---------- properties\n        name as product_name,\n        type as product_type,\n        description as product_description,\n        (price / 100.0) as product_price,\n\n\n        ---------- derived\n        case\n            when type = 'jaffle' then 1\n            else 0\n        end as is_food_item,\n\n        case\n            when type = 'beverage' then 1\n            else 0\n        end as is_drink_item\n\n    from source\n\n)\n\nselect * from renamed",
+      "relation_name": "DEV_DB.DBT_DEV.stg_products"
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-20T21:57:02.230530Z",
+          "completed_at": "2024-05-20T21:57:02.269613Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-20T21:57:02.269864Z",
+          "completed_at": "2024-05-20T21:57:02.269870Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.04000496864318848,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
+      "unique_id": "model.jaffle_shop.stg_supplies",
+      "compiled": true,
+      "compiled_code": "with\n\nsource as (\n\n    select * from raw_supplies\n\n),\n\nrenamed as (\n\n    select\n\n        ----------  ids\n        \n    \nmd5(cast(coalesce(cast(id as TEXT), '_dbt_utils_surrogate_key_null_') || '-' || coalesce(cast(sku as TEXT), '_dbt_utils_surrogate_key_null_') as TEXT)) as supply_uuid,\n        id as supply_id,\n        sku as product_id,\n\n        ---------- properties\n        name as supply_name,\n        (cost / 100.0) as supply_cost,\n        perishable as is_perishable_supply\n\n    from source\n\n)\n\nselect * from renamed",
+      "relation_name": "DEV_DB.DBT_DEV.stg_supplies"
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-20T21:57:02.271207Z",
+          "completed_at": "2024-05-20T21:57:02.272653Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-20T21:57:02.272898Z",
+          "completed_at": "2024-05-20T21:57:02.272903Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.002285003662109375,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
+      "unique_id": "seed.jaffle_shop.raw_customers",
+      "compiled": null,
+      "compiled_code": null,
       "relation_name": null
     },
     {
-      "status": "pass",
+      "status": "success",
       "timing": [
         {
           "name": "compile",
-          "started_at": "2024-04-10T23:18:36.808176Z",
-          "completed_at": "2024-04-10T23:18:36.819434Z"
+          "started_at": "2024-05-20T21:57:02.273949Z",
+          "completed_at": "2024-05-20T21:57:02.275214Z"
         },
         {
           "name": "execute",
-          "started_at": "2024-04-10T23:18:36.820355Z",
-          "completed_at": "2024-04-10T23:18:37.233464Z"
+          "started_at": "2024-05-20T21:57:02.275451Z",
+          "completed_at": "2024-05-20T21:57:02.275454Z"
         }
       ],
       "thread_id": "Thread-1",
-      "execution_time": 0.5666348934173584,
-      "adapter_response": {
-        "_message": "SUCCESS 1",
-        "code": "SUCCESS",
-        "rows_affected": 1,
-        "query_id": "01b395d6-0604-836d-0029-c00305fa0672"
-      },
+      "execution_time": 0.0019800662994384766,
+      "adapter_response": {},
       "message": null,
-      "failures": 0,
-      "unique_id": "test.jaffle_shop.not_null_customers_customer_id.5c9bf9911d",
-      "compiled": true,
-      "compiled_code": "\n    \n    \n\n\n\nselect customer_id\nfrom DEV_DB.DBT_DEV.customers\nwhere customer_id is null\n\n\n",
+      "failures": null,
+      "unique_id": "seed.jaffle_shop.raw_items",
+      "compiled": null,
+      "compiled_code": null,
       "relation_name": null
     },
     {
-      "status": "pass",
+      "status": "success",
       "timing": [
         {
           "name": "compile",
-          "started_at": "2024-04-10T23:18:37.377558Z",
-          "completed_at": "2024-04-10T23:18:37.383532Z"
+          "started_at": "2024-05-20T21:57:02.276414Z",
+          "completed_at": "2024-05-20T21:57:02.277625Z"
         },
         {
           "name": "execute",
-          "started_at": "2024-04-10T23:18:37.384078Z",
-          "completed_at": "2024-04-10T23:18:37.827425Z"
+          "started_at": "2024-05-20T21:57:02.277820Z",
+          "completed_at": "2024-05-20T21:57:02.277823Z"
         }
       ],
       "thread_id": "Thread-1",
-      "execution_time": 0.5722403526306152,
-      "adapter_response": {
-        "_message": "SUCCESS 1",
-        "code": "SUCCESS",
-        "rows_affected": 1,
-        "query_id": "01b395d6-0604-836d-0029-c00305fa0676"
-      },
+      "execution_time": 0.00185394287109375,
+      "adapter_response": {},
       "message": null,
-      "failures": 0,
-      "unique_id": "test.jaffle_shop.not_null_orders_order_id.cf6c17daed",
-      "compiled": true,
-      "compiled_code": "\n    \n    \n\n\n\nselect order_id\nfrom DEV_DB.DBT_DEV.orders\nwhere order_id is null\n\n\n",
+      "failures": null,
+      "unique_id": "seed.jaffle_shop.raw_orders",
+      "compiled": null,
+      "compiled_code": null,
       "relation_name": null
     },
     {
-      "status": "pass",
+      "status": "success",
       "timing": [
         {
           "name": "compile",
-          "started_at": "2024-04-10T23:18:37.956443Z",
-          "completed_at": "2024-04-10T23:18:37.966438Z"
+          "started_at": "2024-05-20T21:57:02.278768Z",
+          "completed_at": "2024-05-20T21:57:02.279973Z"
         },
         {
           "name": "execute",
-          "started_at": "2024-04-10T23:18:37.967517Z",
-          "completed_at": "2024-04-10T23:18:38.458071Z"
+          "started_at": "2024-05-20T21:57:02.280169Z",
+          "completed_at": "2024-05-20T21:57:02.280173Z"
         }
       ],
       "thread_id": "Thread-1",
-      "execution_time": 0.6223530769348145,
-      "adapter_response": {
-        "_message": "SUCCESS 1",
-        "code": "SUCCESS",
-        "rows_affected": 1,
-        "query_id": "01b395d6-0604-8372-0029-c00305f9fad6"
-      },
+      "execution_time": 0.001844167709350586,
+      "adapter_response": {},
       "message": null,
-      "failures": 0,
+      "failures": null,
+      "unique_id": "seed.jaffle_shop.raw_products",
+      "compiled": null,
+      "compiled_code": null,
+      "relation_name": null
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-20T21:57:02.281107Z",
+          "completed_at": "2024-05-20T21:57:02.282326Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-20T21:57:02.282524Z",
+          "completed_at": "2024-05-20T21:57:02.282527Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.00185394287109375,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
+      "unique_id": "seed.jaffle_shop.raw_stores",
+      "compiled": null,
+      "compiled_code": null,
+      "relation_name": null
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-20T21:57:02.283438Z",
+          "completed_at": "2024-05-20T21:57:02.285516Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-20T21:57:02.285718Z",
+          "completed_at": "2024-05-20T21:57:02.285721Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.002714872360229492,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
+      "unique_id": "seed.jaffle_shop.raw_supplies",
+      "compiled": null,
+      "compiled_code": null,
+      "relation_name": null
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-20T21:57:02.286659Z",
+          "completed_at": "2024-05-20T21:57:02.292281Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-20T21:57:02.292482Z",
+          "completed_at": "2024-05-20T21:57:02.292486Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.006269931793212891,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
       "unique_id": "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa",
       "compiled": true,
       "compiled_code": "\n    \n    \n\n\n\nselect customer_id\nfrom DEV_DB.DBT_DEV.stg_customers\nwhere customer_id is null\n\n\n",
       "relation_name": null
     },
     {
-      "status": "pass",
+      "status": "success",
       "timing": [
         {
           "name": "compile",
-          "started_at": "2024-04-10T23:18:38.581180Z",
-          "completed_at": "2024-04-10T23:18:38.587647Z"
+          "started_at": "2024-05-20T21:57:02.293437Z",
+          "completed_at": "2024-05-20T21:57:02.297613Z"
         },
         {
           "name": "execute",
-          "started_at": "2024-04-10T23:18:38.588513Z",
-          "completed_at": "2024-04-10T23:18:39.056066Z"
+          "started_at": "2024-05-20T21:57:02.297810Z",
+          "completed_at": "2024-05-20T21:57:02.297814Z"
         }
       ],
       "thread_id": "Thread-1",
-      "execution_time": 0.5954349040985107,
-      "adapter_response": {
-        "_message": "SUCCESS 1",
-        "code": "SUCCESS",
-        "rows_affected": 1,
-        "query_id": "01b395d6-0604-8372-0029-c00305f9fada"
-      },
+      "execution_time": 0.004821062088012695,
+      "adapter_response": {},
       "message": null,
-      "failures": 0,
-      "unique_id": "test.jaffle_shop.not_null_stg_locations_location_id.3d237927d2",
-      "compiled": true,
-      "compiled_code": "\n    \n    \n\n\n\nselect location_id\nfrom DEV_DB.DBT_DEV.stg_locations\nwhere location_id is null\n\n\n",
-      "relation_name": null
-    },
-    {
-      "status": "pass",
-      "timing": [
-        {
-          "name": "compile",
-          "started_at": "2024-04-10T23:18:39.178388Z",
-          "completed_at": "2024-04-10T23:18:39.182994Z"
-        },
-        {
-          "name": "execute",
-          "started_at": "2024-04-10T23:18:39.183585Z",
-          "completed_at": "2024-04-10T23:18:39.768664Z"
-        }
-      ],
-      "thread_id": "Thread-1",
-      "execution_time": 0.7129452228546143,
-      "adapter_response": {
-        "_message": "SUCCESS 1",
-        "code": "SUCCESS",
-        "rows_affected": 1,
-        "query_id": "01b395d6-0604-836d-0029-c00305fa067a"
-      },
-      "message": null,
-      "failures": 0,
-      "unique_id": "test.jaffle_shop.not_null_stg_order_items_order_item_id.26a7e2bc35",
-      "compiled": true,
-      "compiled_code": "\n    \n    \n\n\n\nselect order_item_id\nfrom DEV_DB.DBT_DEV.stg_order_items\nwhere order_item_id is null\n\n\n",
-      "relation_name": null
-    },
-    {
-      "status": "pass",
-      "timing": [
-        {
-          "name": "compile",
-          "started_at": "2024-04-10T23:18:39.896724Z",
-          "completed_at": "2024-04-10T23:18:39.906009Z"
-        },
-        {
-          "name": "execute",
-          "started_at": "2024-04-10T23:18:39.906992Z",
-          "completed_at": "2024-04-10T23:18:40.370149Z"
-        }
-      ],
-      "thread_id": "Thread-1",
-      "execution_time": 0.5955379009246826,
-      "adapter_response": {
-        "_message": "SUCCESS 1",
-        "code": "SUCCESS",
-        "rows_affected": 1,
-        "query_id": "01b395d6-0604-8372-0029-c00305f9fade"
-      },
-      "message": null,
-      "failures": 0,
-      "unique_id": "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64",
-      "compiled": true,
-      "compiled_code": "\n    \n    \n\n\n\nselect order_id\nfrom DEV_DB.DBT_DEV.stg_orders\nwhere order_id is null\n\n\n",
-      "relation_name": null
-    },
-    {
-      "status": "pass",
-      "timing": [
-        {
-          "name": "compile",
-          "started_at": "2024-04-10T23:18:40.496925Z",
-          "completed_at": "2024-04-10T23:18:40.506317Z"
-        },
-        {
-          "name": "execute",
-          "started_at": "2024-04-10T23:18:40.507294Z",
-          "completed_at": "2024-04-10T23:18:41.059392Z"
-        }
-      ],
-      "thread_id": "Thread-1",
-      "execution_time": 0.6857922077178955,
-      "adapter_response": {
-        "_message": "SUCCESS 1",
-        "code": "SUCCESS",
-        "rows_affected": 1,
-        "query_id": "01b395d6-0604-836d-0029-c00305fa067e"
-      },
-      "message": null,
-      "failures": 0,
-      "unique_id": "test.jaffle_shop.not_null_stg_products_product_id.6373b0acf3",
-      "compiled": true,
-      "compiled_code": "\n    \n    \n\n\n\nselect product_id\nfrom DEV_DB.DBT_DEV.stg_products\nwhere product_id is null\n\n\n",
-      "relation_name": null
-    },
-    {
-      "status": "pass",
-      "timing": [
-        {
-          "name": "compile",
-          "started_at": "2024-04-10T23:18:41.187202Z",
-          "completed_at": "2024-04-10T23:18:41.196296Z"
-        },
-        {
-          "name": "execute",
-          "started_at": "2024-04-10T23:18:41.197179Z",
-          "completed_at": "2024-04-10T23:18:41.891388Z"
-        }
-      ],
-      "thread_id": "Thread-1",
-      "execution_time": 0.8300607204437256,
-      "adapter_response": {
-        "_message": "SUCCESS 1",
-        "code": "SUCCESS",
-        "rows_affected": 1,
-        "query_id": "01b395d6-0604-8372-0029-c00305f9fae2"
-      },
-      "message": null,
-      "failures": 0,
-      "unique_id": "test.jaffle_shop.not_null_stg_supplies_supply_uuid.515c6eda6d",
-      "compiled": true,
-      "compiled_code": "\n    \n    \n\n\n\nselect supply_uuid\nfrom DEV_DB.DBT_DEV.stg_supplies\nwhere supply_uuid is null\n\n\n",
-      "relation_name": null
-    },
-    {
-      "status": "pass",
-      "timing": [
-        {
-          "name": "compile",
-          "started_at": "2024-04-10T23:18:42.022059Z",
-          "completed_at": "2024-04-10T23:18:42.036534Z"
-        },
-        {
-          "name": "execute",
-          "started_at": "2024-04-10T23:18:42.037554Z",
-          "completed_at": "2024-04-10T23:18:42.823129Z"
-        }
-      ],
-      "thread_id": "Thread-1",
-      "execution_time": 0.9243779182434082,
-      "adapter_response": {
-        "_message": "SUCCESS 1",
-        "code": "SUCCESS",
-        "rows_affected": 1,
-        "query_id": "01b395d6-0604-836d-0029-c00305fa0682"
-      },
-      "message": null,
-      "failures": 0,
-      "unique_id": "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_stg_customers_.918495ce16",
-      "compiled": true,
-      "compiled_code": "\n    \n    \n\nwith child as (\n    select customer_id as from_field\n    from DEV_DB.DBT_DEV.orders\n    where customer_id is not null\n),\n\nparent as (\n    select customer_id as to_field\n    from DEV_DB.DBT_DEV.stg_customers\n)\n\nselect\n    from_field\n\nfrom child\nleft join parent\n    on child.from_field = parent.to_field\n\nwhere parent.to_field is null\n\n\n",
-      "relation_name": null
-    },
-    {
-      "status": "pass",
-      "timing": [
-        {
-          "name": "compile",
-          "started_at": "2024-04-10T23:18:42.951104Z",
-          "completed_at": "2024-04-10T23:18:42.963016Z"
-        },
-        {
-          "name": "execute",
-          "started_at": "2024-04-10T23:18:42.964044Z",
-          "completed_at": "2024-04-10T23:18:43.562033Z"
-        }
-      ],
-      "thread_id": "Thread-1",
-      "execution_time": 0.7241389751434326,
-      "adapter_response": {
-        "_message": "SUCCESS 1",
-        "code": "SUCCESS",
-        "rows_affected": 1,
-        "query_id": "01b395d6-0604-8372-0029-c00305f9fae6"
-      },
-      "message": null,
-      "failures": 0,
-      "unique_id": "test.jaffle_shop.unique_customers_customer_id.c5af1ff4b1",
-      "compiled": true,
-      "compiled_code": "\n    \n    \n\nselect\n    customer_id as unique_field,\n    count(*) as n_records\n\nfrom DEV_DB.DBT_DEV.customers\nwhere customer_id is not null\ngroup by customer_id\nhaving count(*) > 1\n\n\n",
-      "relation_name": null
-    },
-    {
-      "status": "pass",
-      "timing": [
-        {
-          "name": "compile",
-          "started_at": "2024-04-10T23:18:43.683862Z",
-          "completed_at": "2024-04-10T23:18:43.694148Z"
-        },
-        {
-          "name": "execute",
-          "started_at": "2024-04-10T23:18:43.695295Z",
-          "completed_at": "2024-04-10T23:18:44.538812Z"
-        }
-      ],
-      "thread_id": "Thread-1",
-      "execution_time": 0.9952831268310547,
-      "adapter_response": {
-        "_message": "SUCCESS 1",
-        "code": "SUCCESS",
-        "rows_affected": 1,
-        "query_id": "01b395d6-0604-8372-0029-c00305f9faea"
-      },
-      "message": null,
-      "failures": 0,
-      "unique_id": "test.jaffle_shop.unique_orders_order_id.fed79b3a6e",
-      "compiled": true,
-      "compiled_code": "\n    \n    \n\nselect\n    order_id as unique_field,\n    count(*) as n_records\n\nfrom DEV_DB.DBT_DEV.orders\nwhere order_id is not null\ngroup by order_id\nhaving count(*) > 1\n\n\n",
-      "relation_name": null
-    },
-    {
-      "status": "pass",
-      "timing": [
-        {
-          "name": "compile",
-          "started_at": "2024-04-10T23:18:44.683225Z",
-          "completed_at": "2024-04-10T23:18:44.692914Z"
-        },
-        {
-          "name": "execute",
-          "started_at": "2024-04-10T23:18:44.694125Z",
-          "completed_at": "2024-04-10T23:18:45.111779Z"
-        }
-      ],
-      "thread_id": "Thread-1",
-      "execution_time": 0.5517499446868896,
-      "adapter_response": {
-        "_message": "SUCCESS 1",
-        "code": "SUCCESS",
-        "rows_affected": 1,
-        "query_id": "01b395d6-0604-836d-0029-c00305fa0686"
-      },
-      "message": null,
-      "failures": 0,
+      "failures": null,
       "unique_id": "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada",
       "compiled": true,
       "compiled_code": "\n    \n    \n\nselect\n    customer_id as unique_field,\n    count(*) as n_records\n\nfrom DEV_DB.DBT_DEV.stg_customers\nwhere customer_id is not null\ngroup by customer_id\nhaving count(*) > 1\n\n\n",
       "relation_name": null
     },
     {
-      "status": "pass",
+      "status": "success",
       "timing": [
         {
           "name": "compile",
-          "started_at": "2024-04-10T23:18:45.239444Z",
-          "completed_at": "2024-04-10T23:18:45.249569Z"
+          "started_at": "2024-05-20T21:57:02.298750Z",
+          "completed_at": "2024-05-20T21:57:02.301387Z"
         },
         {
           "name": "execute",
-          "started_at": "2024-04-10T23:18:45.250491Z",
-          "completed_at": "2024-04-10T23:18:45.834610Z"
+          "started_at": "2024-05-20T21:57:02.301580Z",
+          "completed_at": "2024-05-20T21:57:02.301583Z"
         }
       ],
       "thread_id": "Thread-1",
-      "execution_time": 0.7117998600006104,
-      "adapter_response": {
-        "_message": "SUCCESS 1",
-        "code": "SUCCESS",
-        "rows_affected": 1,
-        "query_id": "01b395d6-0604-8372-0029-c00305f9faee"
-      },
+      "execution_time": 0.0032739639282226562,
+      "adapter_response": {},
       "message": null,
-      "failures": 0,
+      "failures": null,
+      "unique_id": "test.jaffle_shop.not_null_stg_locations_location_id.3d237927d2",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\n\n\nselect location_id\nfrom DEV_DB.DBT_DEV.stg_locations\nwhere location_id is null\n\n\n",
+      "relation_name": null
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-20T21:57:02.302511Z",
+          "completed_at": "2024-05-20T21:57:02.305145Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-20T21:57:02.305384Z",
+          "completed_at": "2024-05-20T21:57:02.305388Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.0033159255981445312,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
       "unique_id": "test.jaffle_shop.unique_stg_locations_location_id.2e2fc58ecc",
       "compiled": true,
       "compiled_code": "\n    \n    \n\nselect\n    location_id as unique_field,\n    count(*) as n_records\n\nfrom DEV_DB.DBT_DEV.stg_locations\nwhere location_id is not null\ngroup by location_id\nhaving count(*) > 1\n\n\n",
       "relation_name": null
     },
     {
-      "status": "pass",
+      "status": "success",
       "timing": [
         {
           "name": "compile",
-          "started_at": "2024-04-10T23:18:45.955337Z",
-          "completed_at": "2024-04-10T23:18:45.963731Z"
+          "started_at": "2024-05-20T21:57:02.306384Z",
+          "completed_at": "2024-05-20T21:57:02.310178Z"
         },
         {
           "name": "execute",
-          "started_at": "2024-04-10T23:18:45.964640Z",
-          "completed_at": "2024-04-10T23:18:46.478499Z"
+          "started_at": "2024-05-20T21:57:02.310416Z",
+          "completed_at": "2024-05-20T21:57:02.310420Z"
         }
       ],
       "thread_id": "Thread-1",
-      "execution_time": 0.6393399238586426,
-      "adapter_response": {
-        "_message": "SUCCESS 1",
-        "code": "SUCCESS",
-        "rows_affected": 1,
-        "query_id": "01b395d6-0604-8372-0029-c00305f9faf2"
-      },
+      "execution_time": 0.004499912261962891,
+      "adapter_response": {},
       "message": null,
-      "failures": 0,
+      "failures": null,
+      "unique_id": "test.jaffle_shop.not_null_stg_order_items_order_item_id.26a7e2bc35",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\n\n\nselect order_item_id\nfrom DEV_DB.DBT_DEV.stg_order_items\nwhere order_item_id is null\n\n\n",
+      "relation_name": null
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-20T21:57:02.311520Z",
+          "completed_at": "2024-05-20T21:57:02.314595Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-20T21:57:02.314824Z",
+          "completed_at": "2024-05-20T21:57:02.314828Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.003838062286376953,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
       "unique_id": "test.jaffle_shop.unique_stg_order_items_order_item_id.90e333a108",
       "compiled": true,
       "compiled_code": "\n    \n    \n\nselect\n    order_item_id as unique_field,\n    count(*) as n_records\n\nfrom DEV_DB.DBT_DEV.stg_order_items\nwhere order_item_id is not null\ngroup by order_item_id\nhaving count(*) > 1\n\n\n",
       "relation_name": null
     },
     {
-      "status": "pass",
+      "status": "success",
       "timing": [
         {
           "name": "compile",
-          "started_at": "2024-04-10T23:18:46.597371Z",
-          "completed_at": "2024-04-10T23:18:46.604285Z"
+          "started_at": "2024-05-20T21:57:02.315965Z",
+          "completed_at": "2024-05-20T21:57:02.319005Z"
         },
         {
           "name": "execute",
-          "started_at": "2024-04-10T23:18:46.605077Z",
-          "completed_at": "2024-04-10T23:18:47.729630Z"
+          "started_at": "2024-05-20T21:57:02.319235Z",
+          "completed_at": "2024-05-20T21:57:02.319238Z"
         }
       ],
       "thread_id": "Thread-1",
-      "execution_time": 1.247967004776001,
-      "adapter_response": {
-        "_message": "SUCCESS 1",
-        "code": "SUCCESS",
-        "rows_affected": 1,
-        "query_id": "01b395d6-0604-8372-0029-c00305f9faf6"
-      },
+      "execution_time": 0.003862142562866211,
+      "adapter_response": {},
       "message": null,
-      "failures": 0,
+      "failures": null,
+      "unique_id": "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\n\n\nselect order_id\nfrom DEV_DB.DBT_DEV.stg_orders\nwhere order_id is null\n\n\n",
+      "relation_name": null
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-20T21:57:02.320488Z",
+          "completed_at": "2024-05-20T21:57:02.324317Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-20T21:57:02.324521Z",
+          "completed_at": "2024-05-20T21:57:02.324525Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.0046100616455078125,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
       "unique_id": "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a",
       "compiled": true,
       "compiled_code": "\n    \n    \n\nselect\n    order_id as unique_field,\n    count(*) as n_records\n\nfrom DEV_DB.DBT_DEV.stg_orders\nwhere order_id is not null\ngroup by order_id\nhaving count(*) > 1\n\n\n",
       "relation_name": null
     },
     {
-      "status": "pass",
+      "status": "success",
       "timing": [
         {
           "name": "compile",
-          "started_at": "2024-04-10T23:18:47.850002Z",
-          "completed_at": "2024-04-10T23:18:47.859114Z"
+          "started_at": "2024-05-20T21:57:02.325572Z",
+          "completed_at": "2024-05-20T21:57:02.328443Z"
         },
         {
           "name": "execute",
-          "started_at": "2024-04-10T23:18:47.860413Z",
-          "completed_at": "2024-04-10T23:18:48.478507Z"
+          "started_at": "2024-05-20T21:57:02.328639Z",
+          "completed_at": "2024-05-20T21:57:02.328643Z"
         }
       ],
       "thread_id": "Thread-1",
-      "execution_time": 0.7403140068054199,
-      "adapter_response": {
-        "_message": "SUCCESS 1",
-        "code": "SUCCESS",
-        "rows_affected": 1,
-        "query_id": "01b395d6-0604-836d-0029-c00305fa068a"
-      },
+      "execution_time": 0.003568887710571289,
+      "adapter_response": {},
       "message": null,
-      "failures": 0,
+      "failures": null,
+      "unique_id": "model.jaffle_shop.order_items",
+      "compiled": true,
+      "compiled_code": "\n\nwith order_items as (\n\n    select * from DEV_DB.DBT_DEV.stg_order_items\n\n),\n\n\norders as (\n    \n    select * from DEV_DB.DBT_DEV.stg_orders\n),\n\nproducts as (\n\n    select * from DEV_DB.DBT_DEV.stg_products\n\n),\n\n\nfinal as (\n    select\n        order_items.*,\n        orders.ordered_at,\n        products.product_price as subtotal,\n        products.is_food_item,\n        products.is_drink_item\n    from order_items\n\n    left join products on order_items.product_id = products.product_id\n    -- left join order_supplies_summary on order_items.order_id = order_supplies_summary.product_id\n    left join orders on order_items.order_id  = orders.order_id\n)\n\nselect * from final",
+      "relation_name": "DEV_DB.DBT_DEV.order_items"
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-20T21:57:02.329614Z",
+          "completed_at": "2024-05-20T21:57:02.332922Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-20T21:57:02.333123Z",
+          "completed_at": "2024-05-20T21:57:02.333126Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.003968000411987305,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
+      "unique_id": "test.jaffle_shop.not_null_stg_products_product_id.6373b0acf3",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\n\n\nselect product_id\nfrom DEV_DB.DBT_DEV.stg_products\nwhere product_id is null\n\n\n",
+      "relation_name": null
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-20T21:57:02.334081Z",
+          "completed_at": "2024-05-20T21:57:02.336631Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-20T21:57:02.336852Z",
+          "completed_at": "2024-05-20T21:57:02.336856Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.003220081329345703,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
       "unique_id": "test.jaffle_shop.unique_stg_products_product_id.7d950a1467",
       "compiled": true,
       "compiled_code": "\n    \n    \n\nselect\n    product_id as unique_field,\n    count(*) as n_records\n\nfrom DEV_DB.DBT_DEV.stg_products\nwhere product_id is not null\ngroup by product_id\nhaving count(*) > 1\n\n\n",
       "relation_name": null
     },
     {
-      "status": "pass",
+      "status": "success",
       "timing": [
         {
           "name": "compile",
-          "started_at": "2024-04-10T23:18:48.593272Z",
-          "completed_at": "2024-04-10T23:18:48.599366Z"
+          "started_at": "2024-05-20T21:57:02.337840Z",
+          "completed_at": "2024-05-20T21:57:02.340375Z"
         },
         {
           "name": "execute",
-          "started_at": "2024-04-10T23:18:48.600216Z",
-          "completed_at": "2024-04-10T23:18:49.004431Z"
+          "started_at": "2024-05-20T21:57:02.340562Z",
+          "completed_at": "2024-05-20T21:57:02.340566Z"
         }
       ],
       "thread_id": "Thread-1",
-      "execution_time": 0.536067008972168,
-      "adapter_response": {
-        "_message": "SUCCESS 1",
-        "code": "SUCCESS",
-        "rows_affected": 1,
-        "query_id": "01b395d6-0604-8372-0029-c00305f9fafa"
-      },
+      "execution_time": 0.0031812191009521484,
+      "adapter_response": {},
       "message": null,
-      "failures": 0,
+      "failures": null,
+      "unique_id": "model.jaffle_shop.orders",
+      "compiled": true,
+      "compiled_code": "\n\n\nwith orders as (\n    \n    select * from DEV_DB.DBT_DEV.stg_orders\n\n),\n\norder_items as (\n    \n    select * from DEV_DB.DBT_DEV.stg_order_items\n\n),\n\nproducts as (\n\n    select * from DEV_DB.DBT_DEV.stg_products\n),\n\nsupplies as (\n\n    select * from DEV_DB.DBT_DEV.stg_supplies\n\n),\n\n\norder_items_summary as (\n\n    select\n\n        order_items.order_id,\n\n        sum(supplies.supply_cost) as order_cost,\n        sum(is_food_item) as count_food_items,\n        sum(is_drink_item) as count_drink_items\n\n\n    from order_items\n\n    left join supplies on order_items.product_id = supplies.product_id\n    left join products on order_items.product_id = products.product_id\n\n    group by 1\n\n),\n\n\nfinal as (\n    select\n\n        orders.*,\n        count_food_items > 0 as is_food_order,\n        count_drink_items > 0 as is_drink_order,\n        order_cost\n\n    from orders\n    \n    left join order_items_summary on orders.order_id = order_items_summary.order_id\n)\n\nselect * from final",
+      "relation_name": "DEV_DB.DBT_DEV.orders"
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-20T21:57:02.341669Z",
+          "completed_at": "2024-05-20T21:57:02.344353Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-20T21:57:02.344560Z",
+          "completed_at": "2024-05-20T21:57:02.344564Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.0034232139587402344,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
+      "unique_id": "test.jaffle_shop.not_null_stg_supplies_supply_uuid.515c6eda6d",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\n\n\nselect supply_uuid\nfrom DEV_DB.DBT_DEV.stg_supplies\nwhere supply_uuid is null\n\n\n",
+      "relation_name": null
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-20T21:57:02.345522Z",
+          "completed_at": "2024-05-20T21:57:02.348220Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-20T21:57:02.348423Z",
+          "completed_at": "2024-05-20T21:57:02.348427Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.0033521652221679688,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
       "unique_id": "test.jaffle_shop.unique_stg_supplies_supply_uuid.c9e3edcfed",
       "compiled": true,
       "compiled_code": "\n    \n    \n\nselect\n    supply_uuid as unique_field,\n    count(*) as n_records\n\nfrom DEV_DB.DBT_DEV.stg_supplies\nwhere supply_uuid is not null\ngroup by supply_uuid\nhaving count(*) > 1\n\n\n",
       "relation_name": null
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-20T21:57:02.349441Z",
+          "completed_at": "2024-05-20T21:57:02.352742Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-20T21:57:02.352935Z",
+          "completed_at": "2024-05-20T21:57:02.352939Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.003983020782470703,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
+      "unique_id": "model.jaffle_shop.customers",
+      "compiled": true,
+      "compiled_code": "\n\nwith\n\ncustomers as (\n\n    select * from DEV_DB.DBT_DEV.stg_customers\n\n),\n\norders_mart as (\n\n    select * from DEV_DB.DBT_DEV.orders\n\n),\n\norder_items_mart as (\n\n    select * from DEV_DB.DBT_DEV.order_items\n),\n\norder_summary as (\n\n    select\n        customer_id,\n\n        count(distinct om.order_id) as count_lifetime_orders,\n        count(distinct om.order_id) > 1 as is_repeat_buyer,\n        min(om.ordered_at) as first_ordered_at,\n        max(om.ordered_at) as last_ordered_at,\n        sum(oi.subtotal) as lifetime_spend_pretax,\n        sum(om.order_total) as lifetime_spend\n\n    from orders_mart om\n    \n    left join order_items_mart oi on om.order_id = oi.order_id\n    \n    group by 1\n\n),\n\njoined as (\n\n    select\n        customers.*,\n        order_summary.count_lifetime_orders,\n        order_summary.first_ordered_at,\n        order_summary.last_ordered_at,\n        order_summary.lifetime_spend_pretax,\n        order_summary.lifetime_spend,\n\n        case\n            when order_summary.is_repeat_buyer then 'returning'\n            else 'new'\n        end as customer_type\n\n    from customers\n\n    left join order_summary\n        on customers.customer_id = order_summary.customer_id\n\n)\n\nselect * from joined",
+      "relation_name": "DEV_DB.DBT_DEV.customers"
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-20T21:57:02.354026Z",
+          "completed_at": "2024-05-20T21:57:02.356597Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-20T21:57:02.356791Z",
+          "completed_at": "2024-05-20T21:57:02.356795Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.003258943557739258,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
+      "unique_id": "test.jaffle_shop.not_null_orders_order_id.cf6c17daed",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\n\n\nselect order_id\nfrom DEV_DB.DBT_DEV.orders\nwhere order_id is null\n\n\n",
+      "relation_name": null
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-20T21:57:02.357758Z",
+          "completed_at": "2024-05-20T21:57:02.360827Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-20T21:57:02.361031Z",
+          "completed_at": "2024-05-20T21:57:02.361035Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.0037260055541992188,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
+      "unique_id": "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_stg_customers_.918495ce16",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\nwith child as (\n    select customer_id as from_field\n    from DEV_DB.DBT_DEV.orders\n    where customer_id is not null\n),\n\nparent as (\n    select customer_id as to_field\n    from DEV_DB.DBT_DEV.stg_customers\n)\n\nselect\n    from_field\n\nfrom child\nleft join parent\n    on child.from_field = parent.to_field\n\nwhere parent.to_field is null\n\n\n",
+      "relation_name": null
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-20T21:57:02.361989Z",
+          "completed_at": "2024-05-20T21:57:02.364451Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-20T21:57:02.364645Z",
+          "completed_at": "2024-05-20T21:57:02.364648Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.0031058788299560547,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
+      "unique_id": "test.jaffle_shop.unique_orders_order_id.fed79b3a6e",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\nselect\n    order_id as unique_field,\n    count(*) as n_records\n\nfrom DEV_DB.DBT_DEV.orders\nwhere order_id is not null\ngroup by order_id\nhaving count(*) > 1\n\n\n",
+      "relation_name": null
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-20T21:57:02.365735Z",
+          "completed_at": "2024-05-20T21:57:02.368289Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-20T21:57:02.368483Z",
+          "completed_at": "2024-05-20T21:57:02.368487Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.00321197509765625,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
+      "unique_id": "test.jaffle_shop.accepted_values_customers_customer_type__new__returning.d12f0947c8",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\nwith all_values as (\n\n    select\n        customer_type as value_field,\n        count(*) as n_records\n\n    from DEV_DB.DBT_DEV.customers\n    group by customer_type\n\n)\n\nselect *\nfrom all_values\nwhere value_field not in (\n    'new','returning'\n)\n\n\n",
+      "relation_name": null
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-20T21:57:02.369429Z",
+          "completed_at": "2024-05-20T21:57:02.372675Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-20T21:57:02.372873Z",
+          "completed_at": "2024-05-20T21:57:02.372876Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.003880023956298828,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
+      "unique_id": "test.jaffle_shop.not_null_customers_customer_id.5c9bf9911d",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\n\n\nselect customer_id\nfrom DEV_DB.DBT_DEV.customers\nwhere customer_id is null\n\n\n",
+      "relation_name": null
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-20T21:57:02.373818Z",
+          "completed_at": "2024-05-20T21:57:02.376275Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-20T21:57:02.376476Z",
+          "completed_at": "2024-05-20T21:57:02.376479Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.0030961036682128906,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
+      "unique_id": "test.jaffle_shop.unique_customers_customer_id.c5af1ff4b1",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\nselect\n    customer_id as unique_field,\n    count(*) as n_records\n\nfrom DEV_DB.DBT_DEV.customers\nwhere customer_id is not null\ngroup by customer_id\nhaving count(*) > 1\n\n\n",
+      "relation_name": null
     }
   ],
-  "elapsed_time": 13.789210796356201,
+  "elapsed_time": 2.089200973510742,
   "args": {
-    "macro_debugging": false,
-    "version_check": true,
+    "introspect": true,
+    "select": [],
     "warn_error_options": {
       "include": [],
       "exclude": []
     },
+    "log_path": "/Users/marslan/Metaphor/dbt/jaffle-sl-template/logs",
     "log_format": "default",
-    "send_anonymous_usage_stats": true,
-    "profiles_dir": "/Users/marslan/.dbt",
-    "which": "test",
-    "use_colors_file": true,
+    "log_file_max_bytes": 10485760,
     "enable_legacy_logger": false,
+    "show_resource_report": false,
+    "partial_parse_file_diff": true,
+    "quiet": false,
+    "static": false,
+    "compile": true,
+    "version_check": true,
+    "log_format_file": "debug",
+    "vars": {},
+    "populate_cache": true,
+    "invocation_command": "dbt docs generate",
+    "exclude": [],
+    "macro_debugging": false,
     "indirect_selection": "eager",
-    "introspect": true,
-    "source_freshness_run_project_hooks": false,
+    "partial_parse": true,
+    "empty_catalog": false,
+    "log_level": "info",
+    "printer_width": 80,
+    "favor_state": false,
+    "project_dir": "/Users/marslan/Metaphor/dbt/jaffle-sl-template",
     "print": true,
     "use_colors": true,
-    "invocation_command": "dbt test",
-    "log_path": "/Users/marslan/Metaphor/dbt/jaffle-sl-template/logs",
-    "show_resource_report": false,
+    "require_resource_names_without_spaces": false,
+    "require_explicit_package_overrides_for_builtin_materializations": true,
+    "use_colors_file": true,
+    "profiles_dir": "/Users/marslan/.dbt",
+    "write_json": true,
+    "send_anonymous_usage_stats": true,
+    "cache_selected_only": false,
+    "strict_mode": false,
+    "which": "generate",
+    "log_level_file": "debug",
     "static_parser": true,
     "defer": false,
-    "vars": {},
-    "log_format_file": "debug",
-    "printer_width": 80,
-    "partial_parse_file_diff": true,
-    "project_dir": "/Users/marslan/Metaphor/dbt/jaffle-sl-template",
-    "strict_mode": false,
-    "log_file_max_bytes": 10485760,
-    "quiet": false,
-    "select": [],
-    "write_json": true,
-    "populate_cache": true,
-    "cache_selected_only": false,
-    "favor_state": false,
-    "log_level_file": "debug",
-    "log_level": "info",
-    "partial_parse": true,
-    "exclude": []
+    "source_freshness_run_project_hooks": false
   }
 }


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

When processing `manifest.json` file generated by dbt 1.8.0, the connector throws parsing errors like these:

```
nodes.`model.jaffle_shop.stg_locations`.AnalysisNode.resource_type
  Input should be 'analysis' [type=literal_error, input_value='model', input_type=str]
    For further information visit https://errors.pydantic.dev/2.6/v/literal_error
nodes.`model.jaffle_shop.stg_locations`.AnalysisNode.access
  Extra inputs are not permitted [type=extra_forbidden, input_value='protected', input_type=str]
    For further information visit https://errors.pydantic.dev/2.6/v/extra_forbidden
```

Turns out that some breaking changes have been introduced to the schema between dbt 1.8.0a1 & 1.8.0. 

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Re-generated the data model using the [latest v12 JSON schema](https://schemas.getdbt.com/dbt/manifest/v12.json) and updated the test files.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified against a production instance.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
