### PR TITLE
Allow assigning additional dbt tags via meta field

### DIFF
--- a/metaphor/dbt/config.py
+++ b/metaphor/dbt/config.py
@@ -55,5 +55,8 @@ class DbtRunConfig(BaseConfig):
     # map meta field to ownerships
     meta_ownerships: List[MetaOwnership] = dataclass_field(default_factory=lambda: [])
 
-    # map meta field to tags
+    # Deprecated. Use meta_key_tags instead
     meta_tags: List[MetaTag] = dataclass_field(default_factory=lambda: [])
+
+    # Maps meta field to additional dbt tags
+    meta_key_tags: Optional[str] = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.12"
+version = "0.14.13"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/dbt/data/ride_share/expected.json
+++ b/tests/dbt/data/ride_share/expected.json
@@ -11,7 +11,7 @@
     },
     "logicalId": {
       "account": "metaphor",
-      "name": "demo_db.metaphor.cycle_hire",
+      "name": "demo_db.berlin_bicycles.cycle_hire",
       "platform": "SNOWFLAKE"
     }
   },
@@ -22,8 +22,164 @@
     },
     "logicalId": {
       "account": "metaphor",
-      "name": "demo_db.metaphor.cycle_stations",
+      "name": "demo_db.berlin_bicycles.cycle_stations",
       "platform": "SNOWFLAKE"
+    }
+  },
+  {
+    "dataQuality": {
+      "monitors": [
+        {
+          "status": "PASSED",
+          "targets": [
+            {
+              "dataset": "DATASET~D8451F8FD7C62A5AB484C9C9C9131604"
+            }
+          ],
+          "title": "dbt_utils_fewer_rows_than_raw_bike_hires_ref_raw_bike_stations_"
+        }
+      ],
+      "provider": "DBT"
+    },
+    "logicalId": {
+      "account": "metaphor",
+      "name": "demo_db.metaphor.raw_bike_hires",
+      "platform": "SNOWFLAKE"
+    }
+  },
+  {
+    "dataQuality": {
+      "monitors": [
+        {
+          "status": "PASSED",
+          "targets": [
+            {
+              "column": "total_minutes",
+              "dataset": "DATASET~20C7C3A6025292FE2E75A471C31657F9"
+            }
+          ],
+          "title": "not_null_cleaned_bike_rides_total_minutes"
+        },
+        {
+          "status": "PASSED",
+          "targets": [
+            {
+              "column": "total_minutes",
+              "dataset": "DATASET~20C7C3A6025292FE2E75A471C31657F9"
+            }
+          ],
+          "title": "dbt_utils_at_least_one_cleaned_bike_rides_total_minutes"
+        },
+        {
+          "status": "PASSED",
+          "targets": [
+            {
+              "column": "total_bike_hires",
+              "dataset": "DATASET~20C7C3A6025292FE2E75A471C31657F9"
+            }
+          ],
+          "title": "not_null_cleaned_bike_rides_total_bike_hires"
+        },
+        {
+          "status": "PASSED",
+          "targets": [
+            {
+              "column": "total_bike_hires",
+              "dataset": "DATASET~20C7C3A6025292FE2E75A471C31657F9"
+            }
+          ],
+          "title": "dbt_utils_at_least_one_cleaned_bike_rides_total_bike_hires"
+        },
+        {
+          "status": "PASSED",
+          "targets": [
+            {
+              "column": "month",
+              "dataset": "DATASET~20C7C3A6025292FE2E75A471C31657F9"
+            }
+          ],
+          "title": "not_null_cleaned_bike_rides_month"
+        },
+        {
+          "status": "PASSED",
+          "targets": [
+            {
+              "column": "month",
+              "dataset": "DATASET~20C7C3A6025292FE2E75A471C31657F9"
+            }
+          ],
+          "title": "dbt_utils_at_least_one_cleaned_bike_rides_month"
+        },
+        {
+          "status": "PASSED",
+          "targets": [
+            {
+              "column": "start_peak_travel",
+              "dataset": "DATASET~20C7C3A6025292FE2E75A471C31657F9"
+            }
+          ],
+          "title": "accepted_values_cleaned_bike_rides_start_peak_travel__Evening_Peak__Off_Peak__Morning_Peak"
+        },
+        {
+          "status": "PASSED",
+          "targets": [
+            {
+              "column": "same_station_flag",
+              "dataset": "DATASET~20C7C3A6025292FE2E75A471C31657F9"
+            }
+          ],
+          "title": "not_null_cleaned_bike_rides_same_station_flag"
+        },
+        {
+          "status": "PASSED",
+          "targets": [
+            {
+              "column": "start_station_name",
+              "dataset": "DATASET~20C7C3A6025292FE2E75A471C31657F9"
+            }
+          ],
+          "title": "not_null_cleaned_bike_rides_start_station_name"
+        }
+      ],
+      "provider": "DBT"
+    },
+    "logicalId": {
+      "account": "metaphor",
+      "name": "demo_db.metaphor.cleaned_bike_rides",
+      "platform": "SNOWFLAKE"
+    }
+  },
+  {
+    "dbtModel": {
+      "compiledSql": "-- Adding extra fields including if the bike was rented during peak time \nSELECT\n    SUM(duration) as total_seconds\n    , COUNT(rental_id) as total_bike_hires\n    , ROUND(SUM(duration) / COUNT(rental_id), 2) AS average_duration\n    , EXTRACT(month from start_date) as month\n    , CASE\n        WHEN EXTRACT(HOUR from TO_TIMESTAMP(start_date)) >= 6 AND EXTRACT(HOUR from TO_TIMESTAMP(start_date)) <= 10 THEN 'Morning Peak'\n        WHEN EXTRACT(HOUR from TO_TIMESTAMP(start_date)) >= 16 AND EXTRACT(HOUR from TO_TIMESTAMP(start_date)) <= 19 THEN 'Evening Peak'\n        ELSE 'Off-Peak'\n      END AS start_peak_travel\n    , IFF(start_station_id = end_station_id, True, False) as same_station_flag\n    , start_station_id\n    , start_station_name\n    , end_station_id\n    , end_station_name\nFROM DEMO_DB.snapshots.cycle_hire_snapshot\nGROUP BY 4,5,6,7,8,9,10\nORDER BY total_seconds DESC",
+      "docsUrl": "http://localhost:8080/#!/model/model.london_bike_analysis.cleaned_bike_rides_from_snapshot",
+      "fields": [],
+      "materialization": {
+        "targetDataset": "DATASET~9EC8C9186E2155503243FED495387698",
+        "type": "TABLE"
+      },
+      "packageName": "london_bike_analysis",
+      "rawSql": "-- Adding extra fields including if the bike was rented during peak time \r\nSELECT\r\n    SUM(duration) as total_seconds\r\n    , COUNT(rental_id) as total_bike_hires\r\n    , ROUND(SUM(duration) / COUNT(rental_id), 2) AS average_duration\r\n    , EXTRACT(month from start_date) as month\r\n    , CASE\r\n        WHEN EXTRACT(HOUR from TO_TIMESTAMP(start_date)) >= 6 AND EXTRACT(HOUR from TO_TIMESTAMP(start_date)) <= 10 THEN 'Morning Peak'\r\n        WHEN EXTRACT(HOUR from TO_TIMESTAMP(start_date)) >= 16 AND EXTRACT(HOUR from TO_TIMESTAMP(start_date)) <= 19 THEN 'Evening Peak'\r\n        ELSE 'Off-Peak'\r\n      END AS start_peak_travel\r\n    , IFF(start_station_id = end_station_id, True, False) as same_station_flag\r\n    , start_station_id\r\n    , start_station_name\r\n    , end_station_id\r\n    , end_station_name\r\nFROM {{ ref('cycle_hire_snapshot') }}\r\nGROUP BY 4,5,6,7,8,9,10\r\nORDER BY total_seconds DESC",
+      "sourceDatasets": [],
+      "sourceModels": [
+        "VIRTUAL_VIEW~FEE8405461EBC519C4D9B3A20C4E251C"
+      ],
+      "url": "https://github.com/MetaphorData/dbt/tree/main/ride_share/models/rides/cleaned_bike_rides_from_snapshot.sql"
+    },
+    "entityUpstream": {
+      "sourceEntities": [
+        "VIRTUAL_VIEW~FEE8405461EBC519C4D9B3A20C4E251C"
+      ]
+    },
+    "logicalId": {
+      "name": "london_bike_analysis.cleaned_bike_rides_from_snapshot",
+      "type": "DBT_MODEL"
+    },
+    "structure": {
+      "directories": [
+        "london_bike_analysis"
+      ],
+      "name": "cleaned_bike_rides_from_snapshot"
     }
   },
   {
@@ -64,7 +220,7 @@
   {
     "dbtModel": {
       "compiledSql": "-- Adding extra fields including if the bike was rented during peak time \nSELECT\n    SUM(duration_minutes) as total_minutes\n    , COUNT(rental_id) as total_bike_hires\n    , ROUND(SUM(duration_minutes) / COUNT(rental_id), 2) AS average_duration\n    , EXTRACT(month from start_date) as month\n    , CASE\n        WHEN EXTRACT(HOUR from TO_TIMESTAMP(start_date)) >= 6 AND EXTRACT(HOUR from TO_TIMESTAMP(start_date)) <= 10 THEN 'Morning Peak'\n        WHEN EXTRACT(HOUR from TO_TIMESTAMP(start_date)) >= 16 AND EXTRACT(HOUR from TO_TIMESTAMP(start_date)) <= 19 THEN 'Evening Peak'\n        ELSE 'Off-Peak'\n      END AS start_peak_travel\n    , IFF(start_station_id = end_station_id, True, False) as same_station_flag\n    , start_station_id\n    , start_station_name\n    , end_station_id\n    , end_station_name\nFROM DEMO_DB.METAPHOR.raw_bike_hires\nGROUP BY 4,5,6,7,8,9,10\nORDER BY total_minutes DESC",
-      "description": "This table contains a transformed version of the raw_bike_hires table, which includes additional calculated fields such as creating a duration in minutes field.  Each ride has been aggregated so any journey that starts and ends at the same station, in the same month and roughly time of day are  aggregated together to get the total minutes similar journeys have taken.\n",
+      "description": "This table contains a transformed version of the raw_bike_hires table, which includes additional calculated fields such as creating a duration in minutes field.  Each ride has been aggregated so any journey that starts and ends at the same station, in the same month and roughly time of day are  aggregated together to get the total minutes similar journeys have taken\n",
       "docsUrl": "http://localhost:8080/#!/model/model.london_bike_analysis.cleaned_bike_rides",
       "fields": [
         {
@@ -72,14 +228,18 @@
           "fieldName": "total_minutes",
           "fieldPath": "total_minutes",
           "nativeType": "Not Set",
-          "tags": []
+          "tags": [
+            "aggregates"
+          ]
         },
         {
           "description": "Total number of bike hires of the same journey in a particular month and time of day",
           "fieldName": "total_bike_hires",
           "fieldPath": "total_bike_hires",
           "nativeType": "Not Set",
-          "tags": []
+          "tags": [
+            "aggregates"
+          ]
         },
         {
           "description": "Month the bike hire was in",
@@ -114,6 +274,16 @@
         "targetDataset": "DATASET~20C7C3A6025292FE2E75A471C31657F9",
         "type": "TABLE"
       },
+      "meta": [
+        {
+          "key": "dbt_tags",
+          "value": "[\"pii\", \"marketplace\", \"apps\"]"
+        },
+        {
+          "key": "data_product_manager",
+          "value": "\"kirit\""
+        }
+      ],
       "packageName": "london_bike_analysis",
       "rawSql": "-- Adding extra fields including if the bike was rented during peak time \r\nSELECT\r\n    SUM(duration_minutes) as total_minutes\r\n    , COUNT(rental_id) as total_bike_hires\r\n    , ROUND(SUM(duration_minutes) / COUNT(rental_id), 2) AS average_duration\r\n    , EXTRACT(month from start_date) as month\r\n    , CASE\r\n        WHEN EXTRACT(HOUR from TO_TIMESTAMP(start_date)) >= 6 AND EXTRACT(HOUR from TO_TIMESTAMP(start_date)) <= 10 THEN 'Morning Peak'\r\n        WHEN EXTRACT(HOUR from TO_TIMESTAMP(start_date)) >= 16 AND EXTRACT(HOUR from TO_TIMESTAMP(start_date)) <= 19 THEN 'Evening Peak'\r\n        ELSE 'Off-Peak'\r\n      END AS start_peak_travel\r\n    , IFF(start_station_id = end_station_id, True, False) as same_station_flag\r\n    , start_station_id\r\n    , start_station_name\r\n    , end_station_id\r\n    , end_station_name\r\nFROM {{ ref('raw_bike_hires') }}\r\nGROUP BY 4,5,6,7,8,9,10\r\nORDER BY total_minutes DESC",
       "sourceDatasets": [],
@@ -126,9 +296,11 @@
             "total_minutes"
           ],
           "dependsOnMacros": [
-            "macro.dbt.test_not_null"
+            "macro.dbt.test_not_null",
+            "macro.dbt.get_where_subquery"
           ],
           "name": "not_null_cleaned_bike_rides_total_minutes",
+          "sql": "\n    \n    \n\n\n\nselect total_minutes\nfrom DEMO_DB.METAPHOR.cleaned_bike_rides\nwhere total_minutes is null\n\n\n",
           "uniqueId": "test.london_bike_analysis.not_null_cleaned_bike_rides_total_minutes.1c7c80a2d6"
         },
         {
@@ -140,6 +312,7 @@
             "macro.dbt.get_where_subquery"
           ],
           "name": "dbt_utils_at_least_one_cleaned_bike_rides_total_minutes",
+          "sql": "\n\nselect *\nfrom (\n    select\n        \n        \n      count(total_minutes) as filler_column\n\n    from DEMO_DB.METAPHOR.cleaned_bike_rides\n\n    having count(total_minutes) = 0\n\n) validation_errors\n\n",
           "uniqueId": "test.london_bike_analysis.dbt_utils_at_least_one_cleaned_bike_rides_total_minutes.8432437e46"
         },
         {
@@ -147,9 +320,11 @@
             "total_bike_hires"
           ],
           "dependsOnMacros": [
-            "macro.dbt.test_not_null"
+            "macro.dbt.test_not_null",
+            "macro.dbt.get_where_subquery"
           ],
           "name": "not_null_cleaned_bike_rides_total_bike_hires",
+          "sql": "\n    \n    \n\n\n\nselect total_bike_hires\nfrom DEMO_DB.METAPHOR.cleaned_bike_rides\nwhere total_bike_hires is null\n\n\n",
           "uniqueId": "test.london_bike_analysis.not_null_cleaned_bike_rides_total_bike_hires.848927fb8f"
         },
         {
@@ -161,6 +336,7 @@
             "macro.dbt.get_where_subquery"
           ],
           "name": "dbt_utils_at_least_one_cleaned_bike_rides_total_bike_hires",
+          "sql": "\n\nselect *\nfrom (\n    select\n        \n        \n      count(total_bike_hires) as filler_column\n\n    from DEMO_DB.METAPHOR.cleaned_bike_rides\n\n    having count(total_bike_hires) = 0\n\n) validation_errors\n\n",
           "uniqueId": "test.london_bike_analysis.dbt_utils_at_least_one_cleaned_bike_rides_total_bike_hires.db70dcef4a"
         },
         {
@@ -168,9 +344,11 @@
             "month"
           ],
           "dependsOnMacros": [
-            "macro.dbt.test_not_null"
+            "macro.dbt.test_not_null",
+            "macro.dbt.get_where_subquery"
           ],
           "name": "not_null_cleaned_bike_rides_month",
+          "sql": "\n    \n    \n\n\n\nselect month\nfrom DEMO_DB.METAPHOR.cleaned_bike_rides\nwhere month is null\n\n\n",
           "uniqueId": "test.london_bike_analysis.not_null_cleaned_bike_rides_month.e937c898a1"
         },
         {
@@ -182,6 +360,7 @@
             "macro.dbt.get_where_subquery"
           ],
           "name": "dbt_utils_at_least_one_cleaned_bike_rides_month",
+          "sql": "\n\nselect *\nfrom (\n    select\n        \n        \n      count(month) as filler_column\n\n    from DEMO_DB.METAPHOR.cleaned_bike_rides\n\n    having count(month) = 0\n\n) validation_errors\n\n",
           "uniqueId": "test.london_bike_analysis.dbt_utils_at_least_one_cleaned_bike_rides_month.909766ad33"
         },
         {
@@ -193,6 +372,7 @@
             "macro.dbt.get_where_subquery"
           ],
           "name": "accepted_values_cleaned_bike_rides_start_peak_travel__Evening_Peak__Off_Peak__Morning_Peak",
+          "sql": "\n    \n    \n\nwith all_values as (\n\n    select\n        start_peak_travel as value_field,\n        count(*) as n_records\n\n    from DEMO_DB.METAPHOR.cleaned_bike_rides\n    group by start_peak_travel\n\n)\n\nselect *\nfrom all_values\nwhere value_field not in (\n    'Evening Peak','Off-Peak','Morning Peak'\n)\n\n\n",
           "uniqueId": "test.london_bike_analysis.accepted_values_cleaned_bike_rides_start_peak_travel__Evening_Peak__Off_Peak__Morning_Peak.014130c1a3"
         },
         {
@@ -200,9 +380,11 @@
             "same_station_flag"
           ],
           "dependsOnMacros": [
-            "macro.dbt.test_not_null"
+            "macro.dbt.test_not_null",
+            "macro.dbt.get_where_subquery"
           ],
           "name": "not_null_cleaned_bike_rides_same_station_flag",
+          "sql": "\n    \n    \n\n\n\nselect same_station_flag\nfrom DEMO_DB.METAPHOR.cleaned_bike_rides\nwhere same_station_flag is null\n\n\n",
           "uniqueId": "test.london_bike_analysis.not_null_cleaned_bike_rides_same_station_flag.6293c4e2a8"
         },
         {
@@ -210,9 +392,11 @@
             "start_station_name"
           ],
           "dependsOnMacros": [
-            "macro.dbt.test_not_null"
+            "macro.dbt.test_not_null",
+            "macro.dbt.get_where_subquery"
           ],
           "name": "not_null_cleaned_bike_rides_start_station_name",
+          "sql": "\n    \n    \n\n\n\nselect start_station_name\nfrom DEMO_DB.METAPHOR.cleaned_bike_rides\nwhere start_station_name is null\n\n\n",
           "uniqueId": "test.london_bike_analysis.not_null_cleaned_bike_rides_start_station_name.4eec63218d"
         }
       ],
@@ -232,6 +416,26 @@
         "london_bike_analysis"
       ],
       "name": "cleaned_bike_rides"
+    },
+    "systemTags": {
+      "tags": [
+        {
+          "systemTagSource": "DBT",
+          "value": "pii"
+        },
+        {
+          "systemTagSource": "DBT",
+          "value": "marketplace"
+        },
+        {
+          "systemTagSource": "DBT",
+          "value": "apps"
+        },
+        {
+          "systemTagSource": "DBT",
+          "value": "bike_ride_data"
+        }
+      ]
     }
   },
   {
@@ -269,7 +473,7 @@
   },
   {
     "dbtModel": {
-      "compiledSql": "SELECT \n    rental_id\n    , duration as duration_seconds\n    , duration / 60 as duration_minutes\n    , bike_id\n    , start_date\n    , start_station_id\n    , start_station_name\n    , end_date\n    , end_station_id\n    , end_station_name\nFROM  DEMO_DB.metaphor.cycle_hire\nWHERE EXTRACT(year from start_date) = 2017",
+      "compiledSql": "SELECT \n    rental_id\n    , duration as duration_seconds\n    , duration / 60 as duration_minutes\n    , bike_id\n    , start_date\n    , start_station_id\n    , start_station_name\n    , end_date\n    , end_station_id\n    , end_station_name\nFROM  DEMO_DB.berlin_bicycles.cycle_hire\nWHERE EXTRACT(year from start_date) = 2017",
       "description": "This table contains all bike hires in London in 2017. This is the raw dataset so no cleaning or transformation.",
       "docsUrl": "http://localhost:8080/#!/model/model.london_bike_analysis.raw_bike_hires",
       "fields": [],
@@ -278,9 +482,9 @@
         "type": "TABLE"
       },
       "packageName": "london_bike_analysis",
-      "rawSql": "SELECT \r\n    rental_id\r\n    , duration as duration_seconds\r\n    , duration / 60 as duration_minutes\r\n    , bike_id\r\n    , start_date\r\n    , start_station_id\r\n    , start_station_name\r\n    , end_date\r\n    , end_station_id\r\n    , end_station_name\r\nFROM  {{ source('metaphor', 'cycle_hire') }}\r\nWHERE EXTRACT(year from start_date) = 2017",
+      "rawSql": "SELECT \r\n    rental_id\r\n    , duration as duration_seconds\r\n    , duration / 60 as duration_minutes\r\n    , bike_id\r\n    , start_date\r\n    , start_station_id\r\n    , start_station_name\r\n    , end_date\r\n    , end_station_id\r\n    , end_station_name\r\nFROM  {{ source('berlin_bicycles', 'cycle_hire') }}\r\nWHERE EXTRACT(year from start_date) = 2017",
       "sourceDatasets": [
-        "DATASET~0BF8A8A87FD2B76DDAA0E3339E0C3D73"
+        "DATASET~10847DAA26704BCA82A4BBC33108AA4A"
       ],
       "sourceModels": [],
       "tests": [
@@ -291,6 +495,7 @@
             "macro.dbt.get_where_subquery"
           ],
           "name": "dbt_utils_fewer_rows_than_raw_bike_hires_ref_raw_bike_stations_",
+          "sql": "\n\n\n\nwith a as (\n\n    select count(*) as count_our_model from DEMO_DB.METAPHOR.raw_bike_hires\n\n),\nb as (\n\n    select count(*) as count_comparison_model from DEMO_DB.METAPHOR.raw_bike_stations\n\n),\ncounts as (\n\n    select\n        count_our_model,\n        count_comparison_model\n    from a\n    cross join b\n\n),\nfinal as (\n\n    select *,\n        case\n            -- fail the test if we have more rows than the reference model and return the row count delta\n            when count_our_model > count_comparison_model then (count_our_model - count_comparison_model)\n            -- fail the test if they are the same number\n            when count_our_model = count_comparison_model then 1\n            -- pass the test if the delta is positive (i.e. return the number 0)\n            else 0\n    end as row_count_delta\n    from counts\n\n)\n\nselect * from final\n\n",
           "uniqueId": "test.london_bike_analysis.dbt_utils_fewer_rows_than_raw_bike_hires_ref_raw_bike_stations_.ffa7ccfb39"
         }
       ],
@@ -298,7 +503,7 @@
     },
     "entityUpstream": {
       "sourceEntities": [
-        "DATASET~0BF8A8A87FD2B76DDAA0E3339E0C3D73"
+        "DATASET~10847DAA26704BCA82A4BBC33108AA4A"
       ]
     },
     "logicalId": {
@@ -314,7 +519,7 @@
   },
   {
     "dbtModel": {
-      "compiledSql": "SELECT \n    id\n    , name as station_name\n    , bikes_count\n    , docks_count\n    , install_date\n    , removal_date\nFROM  DEMO_DB.metaphor.cycle_stations\nWHERE install_date < '2017-01-01' and (removal_date < '2018-01-01' or removal_date is null)",
+      "compiledSql": "SELECT \n    id\n    , name as station_name\n    , bikes_count\n    , docks_count\n    , install_date\n    , removal_date\nFROM  DEMO_DB.berlin_bicycles.cycle_stations\nWHERE install_date < '2017-01-01' and (removal_date < '2018-01-01' or removal_date is null)",
       "description": "This table contains all bike stations in the London area. This only includes stations intalled before January 1, 2017 and doesn't include stations that were removed in 2017 (before Jan 1 2018). This is the raw data so no cleaning or transformation.",
       "docsUrl": "http://localhost:8080/#!/model/model.london_bike_analysis.raw_bike_stations",
       "fields": [
@@ -331,16 +536,16 @@
         "type": "TABLE"
       },
       "packageName": "london_bike_analysis",
-      "rawSql": "SELECT \r\n    id\r\n    , name as station_name\r\n    , bikes_count\r\n    , docks_count\r\n    , install_date\r\n    , removal_date\r\nFROM  {{ source('metaphor', 'cycle_stations') }}\r\nWHERE install_date < '2017-01-01' and (removal_date < '2018-01-01' or removal_date is null)",
+      "rawSql": "SELECT \r\n    id\r\n    , name as station_name\r\n    , bikes_count\r\n    , docks_count\r\n    , install_date\r\n    , removal_date\r\nFROM  {{ source('berlin_bicycles', 'cycle_stations') }}\r\nWHERE install_date < '2017-01-01' and (removal_date < '2018-01-01' or removal_date is null)",
       "sourceDatasets": [
-        "DATASET~DC0498D11FBD059730F0454C60B616D2"
+        "DATASET~BBE1F8323E1B4A60AA233BF14BA42544"
       ],
       "sourceModels": [],
       "url": "https://github.com/MetaphorData/dbt/tree/main/ride_share/models/rides/raw_bike_stations.sql"
     },
     "entityUpstream": {
       "sourceEntities": [
-        "DATASET~DC0498D11FBD059730F0454C60B616D2"
+        "DATASET~BBE1F8323E1B4A60AA233BF14BA42544"
       ]
     },
     "logicalId": {
@@ -356,39 +561,7 @@
   },
   {
     "dbtModel": {
-      "compiledSql": "-- Adding extra fields including if the bike was rented during peak time \nSELECT\n    SUM(duration) as total_seconds\n    , COUNT(rental_id) as total_bike_hires\n    , ROUND(SUM(duration) / COUNT(rental_id), 2) AS average_duration\n    , EXTRACT(month from start_date) as month\n    , CASE\n        WHEN EXTRACT(HOUR from TO_TIMESTAMP(start_date)) >= 6 AND EXTRACT(HOUR from TO_TIMESTAMP(start_date)) <= 10 THEN 'Morning Peak'\n        WHEN EXTRACT(HOUR from TO_TIMESTAMP(start_date)) >= 16 AND EXTRACT(HOUR from TO_TIMESTAMP(start_date)) <= 19 THEN 'Evening Peak'\n        ELSE 'Off-Peak'\n      END AS start_peak_travel\n    , IFF(start_station_id = end_station_id, True, False) as same_station_flag\n    , start_station_id\n    , start_station_name\n    , end_station_id\n    , end_station_name\nFROM DEMO_DB.snapshots.cycle_hire_snapshot\nGROUP BY 4,5,6,7,8,9,10\nORDER BY total_seconds DESC",
-      "docsUrl": "http://localhost:8080/#!/model/model.london_bike_analysis.cleaned_bike_rides_from_snapshot",
-      "fields": [],
-      "materialization": {
-        "targetDataset": "DATASET~9EC8C9186E2155503243FED495387698",
-        "type": "TABLE"
-      },
-      "packageName": "london_bike_analysis",
-      "rawSql": "-- Adding extra fields including if the bike was rented during peak time \r\nSELECT\r\n    SUM(duration) as total_seconds\r\n    , COUNT(rental_id) as total_bike_hires\r\n    , ROUND(SUM(duration) / COUNT(rental_id), 2) AS average_duration\r\n    , EXTRACT(month from start_date) as month\r\n    , CASE\r\n        WHEN EXTRACT(HOUR from TO_TIMESTAMP(start_date)) >= 6 AND EXTRACT(HOUR from TO_TIMESTAMP(start_date)) <= 10 THEN 'Morning Peak'\r\n        WHEN EXTRACT(HOUR from TO_TIMESTAMP(start_date)) >= 16 AND EXTRACT(HOUR from TO_TIMESTAMP(start_date)) <= 19 THEN 'Evening Peak'\r\n        ELSE 'Off-Peak'\r\n      END AS start_peak_travel\r\n    , IFF(start_station_id = end_station_id, True, False) as same_station_flag\r\n    , start_station_id\r\n    , start_station_name\r\n    , end_station_id\r\n    , end_station_name\r\nFROM {{ ref('cycle_hire_snapshot') }}\r\nGROUP BY 4,5,6,7,8,9,10\r\nORDER BY total_seconds DESC",
-      "sourceDatasets": [],
-      "sourceModels": [
-        "VIRTUAL_VIEW~FEE8405461EBC519C4D9B3A20C4E251C"
-      ],
-      "url": "https://github.com/MetaphorData/dbt/tree/main/ride_share/models/rides/cleaned_bike_rides_from_snapshot.sql"
-    },
-    "entityUpstream": {
-      "sourceEntities": [
-        "VIRTUAL_VIEW~FEE8405461EBC519C4D9B3A20C4E251C"
-      ]
-    },
-    "logicalId": {
-      "name": "london_bike_analysis.cleaned_bike_rides_from_snapshot",
-      "type": "DBT_MODEL"
-    },
-    "structure": {
-      "directories": [
-        "london_bike_analysis"
-      ],
-      "name": "cleaned_bike_rides_from_snapshot"
-    }
-  },
-  {
-    "dbtModel": {
+      "compiledSql": "\n\n\nselect * from DEMO_DB.berlin_bicycles.cycle_hire",
       "docsUrl": "http://localhost:8080/#!/model/snapshot.london_bike_analysis.cycle_hire_snapshot",
       "fields": [],
       "materialization": {
@@ -396,16 +569,16 @@
         "type": "SNAPSHOT"
       },
       "packageName": "london_bike_analysis",
-      "rawSql": "\n{{\n    config(\n      target_schema='snapshots',\n      strategy='check',\n      unique_key='bike_id',\n      check_cols=['start_date', 'end_date']\n    )\n}}\n\nselect * from {{ source('metaphor', 'cycle_hire') }}\n",
+      "rawSql": "\n{{\n    config(\n      target_schema='snapshots',\n      strategy='check',\n      unique_key='bike_id',\n      check_cols=['start_date', 'end_date']\n    )\n}}\n\nselect * from {{ source('berlin_bicycles', 'cycle_hire') }}\n",
       "sourceDatasets": [
-        "DATASET~0BF8A8A87FD2B76DDAA0E3339E0C3D73"
+        "DATASET~10847DAA26704BCA82A4BBC33108AA4A"
       ],
       "sourceModels": [],
       "url": "https://github.com/MetaphorData/dbt/tree/main/ride_share/snapshots/cycle_hire_snapshot.sql"
     },
     "entityUpstream": {
       "sourceEntities": [
-        "DATASET~0BF8A8A87FD2B76DDAA0E3339E0C3D73"
+        "DATASET~10847DAA26704BCA82A4BBC33108AA4A"
       ]
     },
     "logicalId": {

--- a/tests/dbt/data/ride_share/manifest.json
+++ b/tests/dbt/data/ride_share/manifest.json
@@ -1,17 +1,123 @@
 {
   "metadata": {
-    "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-    "dbt_version": "1.7.3",
-    "generated_at": "2024-01-09T08:21:52.625121Z",
-    "invocation_id": "4c002312-d619-45e7-9208-49e8751dc20e",
+    "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+    "dbt_version": "1.8.0",
+    "generated_at": "2024-05-28T21:23:17.077001Z",
+    "invocation_id": "3a7cd1e1-3f19-4a52-b28b-bbc3645768de",
     "env": {},
     "project_name": "london_bike_analysis",
     "project_id": "93e9f03e91c8b3ac4a3bded8659f996c",
-    "user_id": "6d64dfbb-bebf-41bb-93ff-36e4ad7105ce",
+    "user_id": "13e27f54-ae38-4532-a885-cdc25090239e",
     "send_anonymous_usage_stats": true,
     "adapter_type": "snowflake"
   },
   "nodes": {
+    "model.london_bike_analysis.cleaned_bike_rides_from_snapshot": {
+      "database": "DEMO_DB",
+      "schema": "METAPHOR",
+      "name": "cleaned_bike_rides_from_snapshot",
+      "resource_type": "model",
+      "package_name": "london_bike_analysis",
+      "path": "rides/cleaned_bike_rides_from_snapshot.sql",
+      "original_file_path": "models/rides/cleaned_bike_rides_from_snapshot.sql",
+      "unique_id": "model.london_bike_analysis.cleaned_bike_rides_from_snapshot",
+      "fqn": [
+        "london_bike_analysis",
+        "rides",
+        "cleaned_bike_rides_from_snapshot"
+      ],
+      "alias": "cleaned_bike_rides_from_snapshot",
+      "checksum": {
+        "name": "sha256",
+        "checksum": "b0bcd7b04003e507997938f8fd62211d783a425b0dec21b040ccd980e760de3f"
+      },
+      "config": {
+        "enabled": true,
+        "alias": null,
+        "schema": null,
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "group": null,
+        "materialized": "table",
+        "incremental_strategy": null,
+        "persist_docs": {
+          "relation": true,
+          "columns": true
+        },
+        "post-hook": [],
+        "pre-hook": [],
+        "quoting": {},
+        "column_types": {},
+        "full_refresh": null,
+        "unique_key": null,
+        "on_schema_change": "ignore",
+        "on_configuration_change": "apply",
+        "grants": {},
+        "packages": [],
+        "docs": {
+          "show": true,
+          "node_color": null
+        },
+        "contract": {
+          "enforced": false,
+          "alias_types": true
+        },
+        "access": "protected"
+      },
+      "tags": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "group": null,
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "build_path": null,
+      "unrendered_config": {
+        "persist_docs": {
+          "relation": true,
+          "columns": true
+        },
+        "materialized": "table"
+      },
+      "created_at": 1716931397.867678,
+      "relation_name": "DEMO_DB.METAPHOR.cleaned_bike_rides_from_snapshot",
+      "raw_code": "-- Adding extra fields including if the bike was rented during peak time \r\nSELECT\r\n    SUM(duration) as total_seconds\r\n    , COUNT(rental_id) as total_bike_hires\r\n    , ROUND(SUM(duration) / COUNT(rental_id), 2) AS average_duration\r\n    , EXTRACT(month from start_date) as month\r\n    , CASE\r\n        WHEN EXTRACT(HOUR from TO_TIMESTAMP(start_date)) >= 6 AND EXTRACT(HOUR from TO_TIMESTAMP(start_date)) <= 10 THEN 'Morning Peak'\r\n        WHEN EXTRACT(HOUR from TO_TIMESTAMP(start_date)) >= 16 AND EXTRACT(HOUR from TO_TIMESTAMP(start_date)) <= 19 THEN 'Evening Peak'\r\n        ELSE 'Off-Peak'\r\n      END AS start_peak_travel\r\n    , IFF(start_station_id = end_station_id, True, False) as same_station_flag\r\n    , start_station_id\r\n    , start_station_name\r\n    , end_station_id\r\n    , end_station_name\r\nFROM {{ ref('cycle_hire_snapshot') }}\r\nGROUP BY 4,5,6,7,8,9,10\r\nORDER BY total_seconds DESC",
+      "language": "sql",
+      "refs": [
+        {
+          "name": "cycle_hire_snapshot",
+          "package": null,
+          "version": null
+        }
+      ],
+      "sources": [],
+      "metrics": [],
+      "depends_on": {
+        "macros": [],
+        "nodes": [
+          "snapshot.london_bike_analysis.cycle_hire_snapshot"
+        ]
+      },
+      "compiled_path": "target/compiled/london_bike_analysis/models/rides/cleaned_bike_rides_from_snapshot.sql",
+      "compiled": true,
+      "compiled_code": "-- Adding extra fields including if the bike was rented during peak time \nSELECT\n    SUM(duration) as total_seconds\n    , COUNT(rental_id) as total_bike_hires\n    , ROUND(SUM(duration) / COUNT(rental_id), 2) AS average_duration\n    , EXTRACT(month from start_date) as month\n    , CASE\n        WHEN EXTRACT(HOUR from TO_TIMESTAMP(start_date)) >= 6 AND EXTRACT(HOUR from TO_TIMESTAMP(start_date)) <= 10 THEN 'Morning Peak'\n        WHEN EXTRACT(HOUR from TO_TIMESTAMP(start_date)) >= 16 AND EXTRACT(HOUR from TO_TIMESTAMP(start_date)) <= 19 THEN 'Evening Peak'\n        ELSE 'Off-Peak'\n      END AS start_peak_travel\n    , IFF(start_station_id = end_station_id, True, False) as same_station_flag\n    , start_station_id\n    , start_station_name\n    , end_station_id\n    , end_station_name\nFROM DEMO_DB.snapshots.cycle_hire_snapshot\nGROUP BY 4,5,6,7,8,9,10\nORDER BY total_seconds DESC",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "contract": {
+        "enforced": false,
+        "alias_types": true,
+        "checksum": null
+      },
+      "access": "protected",
+      "constraints": [],
+      "version": null,
+      "latest_version": null,
+      "deprecation_date": null
+    },
     "model.london_bike_analysis.rides_by_month_2017": {
       "database": "DEMO_DB",
       "schema": "METAPHOR",
@@ -75,8 +181,7 @@
         "node_color": null
       },
       "patch_path": null,
-      "build_path": "target/run/london_bike_analysis/models/rides/rides_by_month_2017.sql",
-      "deferred": false,
+      "build_path": null,
       "unrendered_config": {
         "persist_docs": {
           "relation": true,
@@ -84,7 +189,7 @@
         },
         "materialized": "table"
       },
-      "created_at": 1704787952.617712,
+      "created_at": 1716931397.880003,
       "relation_name": "DEMO_DB.METAPHOR.rides_by_month_2017",
       "raw_code": "WITH stations AS (\r\n\r\n    SELECT *\r\n    FROM {{ ref('raw_bike_stations') }}\r\n\r\n),\r\n\r\nrides AS (\r\n\r\n    SELECT *\r\n    FROM {{ ref('cleaned_bike_rides') }}\r\n\r\n),\r\n\r\nstart_stat_join AS (\r\n\r\n    SELECT rides.*\r\n    , stations.bikes_count as start_station_bikes_count\r\n    , stations.docks_count as start_station_docks_count\r\n    , stations.install_date as start_station_install_date\r\n    FROM rides\r\n    LEFT JOIN stations\r\n    ON rides.start_station_id = stations.id\r\n)\r\n\r\nSELECT \r\n    total_minutes \r\n    , total_bike_hires \r\n    , average_duration \r\n    , month \r\n    , start_peak_travel\r\n    , same_station_flag\r\n    , start_station_id\r\n    , start_station_name\r\n    , start_station_bikes_count \r\n    , start_station_docks_count \r\n    , start_station_install_date \r\n    , end_station_id\r\n    , end_station_name\r\n    , stations.bikes_count as end_station_bikes_count\r\n    , stations.docks_count as end_station_docks_count\r\n    , stations.install_date as end_station_install_date\r\nFROM start_stat_join\r\nLEFT JOIN stations\r\nON start_stat_join.end_station_id = stations.id",
       "language": "sql",
@@ -149,8 +254,17 @@
         "alias": null,
         "schema": null,
         "database": null,
-        "tags": [],
-        "meta": {},
+        "tags": [
+          "bike_ride_data"
+        ],
+        "meta": {
+          "dbt_tags": [
+            "pii",
+            "marketplace",
+            "apps"
+          ],
+          "data_product_manager": "kirit"
+        },
         "group": null,
         "materialized": "table",
         "incremental_strategy": null,
@@ -178,8 +292,10 @@
         },
         "access": "protected"
       },
-      "tags": [],
-      "description": "This table contains a transformed version of the raw_bike_hires table, which includes additional calculated fields such as creating a duration in minutes field.  Each ride has been aggregated so any journey that starts and ends at the same station, in the same month and roughly time of day are  aggregated together to get the total minutes similar journeys have taken.\n",
+      "tags": [
+        "bike_ride_data"
+      ],
+      "description": "This table contains a transformed version of the raw_bike_hires table, which includes additional calculated fields such as creating a duration in minutes field.  Each ride has been aggregated so any journey that starts and ends at the same station, in the same month and roughly time of day are  aggregated together to get the total minutes similar journeys have taken\n",
       "columns": {
         "total_minutes": {
           "name": "total_minutes",
@@ -188,7 +304,9 @@
           "data_type": null,
           "constraints": [],
           "quote": null,
-          "tags": []
+          "tags": [
+            "aggregates"
+          ]
         },
         "total_bike_hires": {
           "name": "total_bike_hires",
@@ -197,7 +315,9 @@
           "data_type": null,
           "constraints": [],
           "quote": null,
-          "tags": []
+          "tags": [
+            "aggregates"
+          ]
         },
         "month": {
           "name": "month",
@@ -236,23 +356,40 @@
           "tags": []
         }
       },
-      "meta": {},
+      "meta": {
+        "dbt_tags": [
+          "pii",
+          "marketplace",
+          "apps"
+        ],
+        "data_product_manager": "kirit"
+      },
       "group": null,
       "docs": {
         "show": true,
         "node_color": null
       },
       "patch_path": "london_bike_analysis://models/rides/schema.yml",
-      "build_path": "target/run/london_bike_analysis/models/rides/cleaned_bike_rides.sql",
-      "deferred": false,
+      "build_path": null,
       "unrendered_config": {
         "persist_docs": {
           "relation": true,
           "columns": true
         },
-        "materialized": "table"
+        "materialized": "table",
+        "tags": [
+          "bike_ride_data"
+        ],
+        "meta": {
+          "dbt_tags": [
+            "pii",
+            "marketplace",
+            "apps"
+          ],
+          "data_product_manager": "kirit"
+        }
       },
-      "created_at": 1704787952.8229089,
+      "created_at": 1716931398.088865,
       "relation_name": "DEMO_DB.METAPHOR.cleaned_bike_rides",
       "raw_code": "-- Adding extra fields including if the bike was rented during peak time \r\nSELECT\r\n    SUM(duration_minutes) as total_minutes\r\n    , COUNT(rental_id) as total_bike_hires\r\n    , ROUND(SUM(duration_minutes) / COUNT(rental_id), 2) AS average_duration\r\n    , EXTRACT(month from start_date) as month\r\n    , CASE\r\n        WHEN EXTRACT(HOUR from TO_TIMESTAMP(start_date)) >= 6 AND EXTRACT(HOUR from TO_TIMESTAMP(start_date)) <= 10 THEN 'Morning Peak'\r\n        WHEN EXTRACT(HOUR from TO_TIMESTAMP(start_date)) >= 16 AND EXTRACT(HOUR from TO_TIMESTAMP(start_date)) <= 19 THEN 'Evening Peak'\r\n        ELSE 'Off-Peak'\r\n      END AS start_peak_travel\r\n    , IFF(start_station_id = end_station_id, True, False) as same_station_flag\r\n    , start_station_id\r\n    , start_station_name\r\n    , end_station_id\r\n    , end_station_name\r\nFROM {{ ref('raw_bike_hires') }}\r\nGROUP BY 4,5,6,7,8,9,10\r\nORDER BY total_minutes DESC",
       "language": "sql",
@@ -350,8 +487,7 @@
         "node_color": null
       },
       "patch_path": null,
-      "build_path": "target/run/london_bike_analysis/models/rides/rides_by_month_start_station_2017.sql",
-      "deferred": false,
+      "build_path": null,
       "unrendered_config": {
         "persist_docs": {
           "relation": true,
@@ -359,7 +495,7 @@
         },
         "materialized": "table"
       },
-      "created_at": 1704787952.6297479,
+      "created_at": 1716931397.8827572,
       "relation_name": "DEMO_DB.METAPHOR.rides_by_month_start_station_2017",
       "raw_code": "SELECT \r\n    SUM(total_minutes) AS total_minutes\r\n    , ROUND(SUM(total_minutes) / 60 ,2) AS total_hours\r\n    , SUM(total_bike_hires) AS total_bike_hires\r\n    , ROUND(SUM(total_minutes) / SUM(total_bike_hires), 2) AS average_duration_in_minutes\r\n    , month\r\n    , start_peak_travel\r\n    , same_station_flag\r\n    , start_station_id\r\n    , start_station_name\r\n    , start_station_bikes_count\r\n    , start_station_docks_count\r\n    , start_station_install_date\r\nFROM {{ ref('rides_by_month_2017') }}\r\nGROUP BY 5,6,7,8,9,10,11,12\r\nORDER BY total_bike_hires DESC",
       "language": "sql",
@@ -411,7 +547,7 @@
       "alias": "raw_bike_hires",
       "checksum": {
         "name": "sha256",
-        "checksum": "c51e274e8dba517b7aebd5c43c0b8aeaaafcc5ea6bcd0679529863a6b0a9423a"
+        "checksum": "3d2c5ffc9cc014c6b14bd499205329f6fa94c488acda7da8c3a9498468b50357"
       },
       "config": {
         "enabled": true,
@@ -457,8 +593,7 @@
         "node_color": null
       },
       "patch_path": "london_bike_analysis://models/rides/schema.yml",
-      "build_path": "target/run/london_bike_analysis/models/rides/raw_bike_hires.sql",
-      "deferred": false,
+      "build_path": null,
       "unrendered_config": {
         "persist_docs": {
           "relation": true,
@@ -466,14 +601,14 @@
         },
         "materialized": "table"
       },
-      "created_at": 1704787952.821089,
+      "created_at": 1716931398.082428,
       "relation_name": "DEMO_DB.METAPHOR.raw_bike_hires",
-      "raw_code": "SELECT \r\n    rental_id\r\n    , duration as duration_seconds\r\n    , duration / 60 as duration_minutes\r\n    , bike_id\r\n    , start_date\r\n    , start_station_id\r\n    , start_station_name\r\n    , end_date\r\n    , end_station_id\r\n    , end_station_name\r\nFROM  {{ source('metaphor', 'cycle_hire') }}\r\nWHERE EXTRACT(year from start_date) = 2017",
+      "raw_code": "SELECT \r\n    rental_id\r\n    , duration as duration_seconds\r\n    , duration / 60 as duration_minutes\r\n    , bike_id\r\n    , start_date\r\n    , start_station_id\r\n    , start_station_name\r\n    , end_date\r\n    , end_station_id\r\n    , end_station_name\r\nFROM  {{ source('berlin_bicycles', 'cycle_hire') }}\r\nWHERE EXTRACT(year from start_date) = 2017",
       "language": "sql",
       "refs": [],
       "sources": [
         [
-          "metaphor",
+          "berlin_bicycles",
           "cycle_hire"
         ]
       ],
@@ -481,12 +616,12 @@
       "depends_on": {
         "macros": [],
         "nodes": [
-          "source.london_bike_analysis.metaphor.cycle_hire"
+          "source.london_bike_analysis.berlin_bicycles.cycle_hire"
         ]
       },
       "compiled_path": "target/compiled/london_bike_analysis/models/rides/raw_bike_hires.sql",
       "compiled": true,
-      "compiled_code": "SELECT \n    rental_id\n    , duration as duration_seconds\n    , duration / 60 as duration_minutes\n    , bike_id\n    , start_date\n    , start_station_id\n    , start_station_name\n    , end_date\n    , end_station_id\n    , end_station_name\nFROM  DEMO_DB.metaphor.cycle_hire\nWHERE EXTRACT(year from start_date) = 2017",
+      "compiled_code": "SELECT \n    rental_id\n    , duration as duration_seconds\n    , duration / 60 as duration_minutes\n    , bike_id\n    , start_date\n    , start_station_id\n    , start_station_name\n    , end_date\n    , end_station_id\n    , end_station_name\nFROM  DEMO_DB.berlin_bicycles.cycle_hire\nWHERE EXTRACT(year from start_date) = 2017",
       "extra_ctes_injected": true,
       "extra_ctes": [],
       "contract": {
@@ -517,7 +652,7 @@
       "alias": "raw_bike_stations",
       "checksum": {
         "name": "sha256",
-        "checksum": "f2fddc3c490d40e45314567be849c98f9db701319fe3c60c43a2bc442557925f"
+        "checksum": "223b4e3af5eb88c2dfec6e8f7d036a301fe0926bab38c31eb33e0d1630913df3"
       },
       "config": {
         "enabled": true,
@@ -573,8 +708,7 @@
         "node_color": null
       },
       "patch_path": "london_bike_analysis://models/rides/schema.yml",
-      "build_path": "target/run/london_bike_analysis/models/rides/raw_bike_stations.sql",
-      "deferred": false,
+      "build_path": null,
       "unrendered_config": {
         "persist_docs": {
           "relation": true,
@@ -582,14 +716,14 @@
         },
         "materialized": "table"
       },
-      "created_at": 1704787952.8216069,
+      "created_at": 1716931398.0856571,
       "relation_name": "DEMO_DB.METAPHOR.raw_bike_stations",
-      "raw_code": "SELECT \r\n    id\r\n    , name as station_name\r\n    , bikes_count\r\n    , docks_count\r\n    , install_date\r\n    , removal_date\r\nFROM  {{ source('metaphor', 'cycle_stations') }}\r\nWHERE install_date < '2017-01-01' and (removal_date < '2018-01-01' or removal_date is null)",
+      "raw_code": "SELECT \r\n    id\r\n    , name as station_name\r\n    , bikes_count\r\n    , docks_count\r\n    , install_date\r\n    , removal_date\r\nFROM  {{ source('berlin_bicycles', 'cycle_stations') }}\r\nWHERE install_date < '2017-01-01' and (removal_date < '2018-01-01' or removal_date is null)",
       "language": "sql",
       "refs": [],
       "sources": [
         [
-          "metaphor",
+          "berlin_bicycles",
           "cycle_stations"
         ]
       ],
@@ -597,12 +731,12 @@
       "depends_on": {
         "macros": [],
         "nodes": [
-          "source.london_bike_analysis.metaphor.cycle_stations"
+          "source.london_bike_analysis.berlin_bicycles.cycle_stations"
         ]
       },
       "compiled_path": "target/compiled/london_bike_analysis/models/rides/raw_bike_stations.sql",
       "compiled": true,
-      "compiled_code": "SELECT \n    id\n    , name as station_name\n    , bikes_count\n    , docks_count\n    , install_date\n    , removal_date\nFROM  DEMO_DB.metaphor.cycle_stations\nWHERE install_date < '2017-01-01' and (removal_date < '2018-01-01' or removal_date is null)",
+      "compiled_code": "SELECT \n    id\n    , name as station_name\n    , bikes_count\n    , docks_count\n    , install_date\n    , removal_date\nFROM  DEMO_DB.berlin_bicycles.cycle_stations\nWHERE install_date < '2017-01-01' and (removal_date < '2018-01-01' or removal_date is null)",
       "extra_ctes_injected": true,
       "extra_ctes": [],
       "contract": {
@@ -611,96 +745,6 @@
         "checksum": null
       },
       "access": "protected",
-      "constraints": [],
-      "version": null,
-      "latest_version": null,
-      "deprecation_date": null
-    },
-    "model.london_bike_analysis.reference_model": {
-      "database": "DEMO_DB",
-      "schema": "METAPHOR",
-      "name": "reference_model",
-      "resource_type": "model",
-      "package_name": "other_project",
-      "path": "",
-      "original_file_path": "",
-      "unique_id": "model.london_bike_analysis.reference_model",
-      "fqn": [
-        "london_bike_analysis",
-        "rides",
-        "reference_model"
-      ],
-      "alias": "reference_model",
-      "checksum": {
-        "name": "sha256",
-        "checksum": "f2fddc3c490d40e45314567be849c98f9db701319fe3c60c43a2bc442557925f"
-      },
-      "config": {
-        "enabled": true,
-        "alias": null,
-        "schema": null,
-        "database": null,
-        "tags": [],
-        "meta": {},
-        "group": null,
-        "materialized": "view",
-        "incremental_strategy": null,
-        "persist_docs": {},
-        "post-hook": [],
-        "pre-hook": [],
-        "quoting": {},
-        "column_types": {},
-        "full_refresh": null,
-        "unique_key": null,
-        "on_schema_change": "ignore",
-        "on_configuration_change": "apply",
-        "grants": {},
-        "packages": [],
-        "docs": {
-          "show": true,
-          "node_color": null
-        },
-        "contract": {
-          "enforced": false,
-          "alias_types": true
-        },
-        "access": "protected"
-      },
-      "tags": [],
-      "description": "",
-      "columns": {},
-      "meta": {},
-      "group": null,
-      "docs": {
-        "show": true,
-        "node_color": null
-      },
-      "patch_path": null,
-      "build_path": null,
-      "deferred": false,
-      "unrendered_config": {
-        "alias": "",
-        "schema": "",
-        "database": ""
-      },
-      "created_at": 1713186099.1519442,
-      "relation_name": "",
-      "raw_code": "",
-      "language": "sql",
-      "refs": [],
-      "sources": [],
-      "metrics": [],
-      "depends_on": {
-        "macros": [],
-        "nodes": []
-      },
-      "compiled_path": null,
-      "contract": {
-        "enforced": false,
-        "alias_types": true,
-        "checksum": null
-      },
-      "access": "public",
       "constraints": [],
       "version": null,
       "latest_version": null,
@@ -723,7 +767,7 @@
       "alias": "cycle_hire_snapshot",
       "checksum": {
         "name": "sha256",
-        "checksum": "a95c9aa891d51df00c3efa78644a5f81cabf6018573d63e253fdeec87744282c"
+        "checksum": "c67fc8919c7ee5d3ad01ccf045100f3d437e8ec013a57cc4db54a7171355dc28"
       },
       "config": {
         "enabled": true,
@@ -774,7 +818,6 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {
         "target_schema": "snapshots",
         "strategy": "check",
@@ -784,14 +827,14 @@
           "end_date"
         ]
       },
-      "created_at": 1704787952.682708,
+      "created_at": 1716931397.9414,
       "relation_name": "DEMO_DB.snapshots.cycle_hire_snapshot",
-      "raw_code": "\n{{\n    config(\n      target_schema='snapshots',\n      strategy='check',\n      unique_key='bike_id',\n      check_cols=['start_date', 'end_date']\n    )\n}}\n\nselect * from {{ source('metaphor', 'cycle_hire') }}\n",
+      "raw_code": "\n{{\n    config(\n      target_schema='snapshots',\n      strategy='check',\n      unique_key='bike_id',\n      check_cols=['start_date', 'end_date']\n    )\n}}\n\nselect * from {{ source('berlin_bicycles', 'cycle_hire') }}\n",
       "language": "sql",
       "refs": [],
       "sources": [
         [
-          "metaphor",
+          "berlin_bicycles",
           "cycle_hire"
         ]
       ],
@@ -799,8 +842,84 @@
       "depends_on": {
         "macros": [],
         "nodes": [
-          "source.london_bike_analysis.metaphor.cycle_hire"
+          "source.london_bike_analysis.berlin_bicycles.cycle_hire"
         ]
+      },
+      "compiled_path": null,
+      "compiled": true,
+      "compiled_code": "\n\n\nselect * from DEMO_DB.berlin_bicycles.cycle_hire",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
+      "contract": {
+        "enforced": false,
+        "alias_types": true,
+        "checksum": null
+      }
+    },
+    "test.london_bike_analysis.assert_stations_before_2017": {
+      "database": "DEMO_DB",
+      "schema": "METAPHOR_dbt_test__audit",
+      "name": "assert_stations_before_2017",
+      "resource_type": "test",
+      "package_name": "london_bike_analysis",
+      "path": "assert_stations_before_2017.sql",
+      "original_file_path": "tests/assert_stations_before_2017.sql",
+      "unique_id": "test.london_bike_analysis.assert_stations_before_2017",
+      "fqn": [
+        "london_bike_analysis",
+        "assert_stations_before_2017"
+      ],
+      "alias": "assert_stations_before_2017",
+      "checksum": {
+        "name": "sha256",
+        "checksum": "f6d5b26c17b46e0cdfff049c986df1572cf298527d00861a531dc0af6aca4be2"
+      },
+      "config": {
+        "enabled": false,
+        "alias": null,
+        "schema": "dbt_test__audit",
+        "database": null,
+        "tags": [],
+        "meta": {},
+        "group": null,
+        "materialized": "test",
+        "severity": "ERROR",
+        "store_failures": null,
+        "store_failures_as": null,
+        "where": null,
+        "limit": null,
+        "fail_calc": "count(*)",
+        "warn_if": "!= 0",
+        "error_if": "!= 0"
+      },
+      "tags": [],
+      "description": "",
+      "columns": {},
+      "meta": {},
+      "group": null,
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "build_path": null,
+      "unrendered_config": {},
+      "created_at": 1716931398.030287,
+      "relation_name": null,
+      "raw_code": "SELECT *\r\nFROM {{ ref('rides_by_month')}}\r\nWHERE end_station_install_date >= '2017-01-01'",
+      "language": "sql",
+      "refs": [
+        {
+          "name": "rides_by_month",
+          "package": null,
+          "version": null
+        }
+      ],
+      "sources": [],
+      "metrics": [],
+      "depends_on": {
+        "macros": [],
+        "nodes": []
       },
       "compiled_path": null,
       "contract": {
@@ -810,14 +929,6 @@
       }
     },
     "test.london_bike_analysis.dbt_utils_fewer_rows_than_raw_bike_hires_ref_raw_bike_stations_.ffa7ccfb39": {
-      "test_metadata": {
-        "name": "fewer_rows_than",
-        "kwargs": {
-          "compare_model": "ref('raw_bike_stations')",
-          "model": "{{ get_where_subquery(ref('raw_bike_hires')) }}"
-        },
-        "namespace": "dbt_utils"
-      },
       "database": "DEMO_DB",
       "schema": "METAPHOR_dbt_test__audit",
       "name": "dbt_utils_fewer_rows_than_raw_bike_hires_ref_raw_bike_stations_",
@@ -865,12 +976,11 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {
         "fail_calc": "coalesce(row_count_delta, 0)",
         "severity": "warn"
       },
-      "created_at": 1704787952.8551412,
+      "created_at": 1716931398.119037,
       "relation_name": null,
       "raw_code": "{{ dbt_utils.test_fewer_rows_than(**_dbt_generic_test_kwargs) }}{{ config(severity=\"warn\") }}",
       "language": "sql",
@@ -898,7 +1008,11 @@
           "model.london_bike_analysis.raw_bike_hires"
         ]
       },
-      "compiled_path": null,
+      "compiled_path": "target/compiled/london_bike_analysis/models/rides/schema.yml/dbt_utils_fewer_rows_than_raw_bike_hires_ref_raw_bike_stations_.sql",
+      "compiled": true,
+      "compiled_code": "\n\n\n\nwith a as (\n\n    select count(*) as count_our_model from DEMO_DB.METAPHOR.raw_bike_hires\n\n),\nb as (\n\n    select count(*) as count_comparison_model from DEMO_DB.METAPHOR.raw_bike_stations\n\n),\ncounts as (\n\n    select\n        count_our_model,\n        count_comparison_model\n    from a\n    cross join b\n\n),\nfinal as (\n\n    select *,\n        case\n            -- fail the test if we have more rows than the reference model and return the row count delta\n            when count_our_model > count_comparison_model then (count_our_model - count_comparison_model)\n            -- fail the test if they are the same number\n            when count_our_model = count_comparison_model then 1\n            -- pass the test if the delta is positive (i.e. return the number 0)\n            else 0\n    end as row_count_delta\n    from counts\n\n)\n\nselect * from final\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
       "contract": {
         "enforced": false,
         "alias_types": true,
@@ -906,17 +1020,17 @@
       },
       "column_name": null,
       "file_key_name": "models.raw_bike_hires",
-      "attached_node": "model.london_bike_analysis.raw_bike_hires"
+      "attached_node": "model.london_bike_analysis.raw_bike_hires",
+      "test_metadata": {
+        "name": "fewer_rows_than",
+        "kwargs": {
+          "compare_model": "ref('raw_bike_stations')",
+          "model": "{{ get_where_subquery(ref('raw_bike_hires')) }}"
+        },
+        "namespace": "dbt_utils"
+      }
     },
     "test.london_bike_analysis.not_null_cleaned_bike_rides_total_minutes.1c7c80a2d6": {
-      "test_metadata": {
-        "name": "not_null",
-        "kwargs": {
-          "column_name": "total_minutes",
-          "model": "{{ get_where_subquery(ref('cleaned_bike_rides')) }}"
-        },
-        "namespace": null
-      },
       "database": "DEMO_DB",
       "schema": "METAPHOR_dbt_test__audit",
       "name": "not_null_cleaned_bike_rides_total_minutes",
@@ -953,7 +1067,9 @@
         "warn_if": "!= 0",
         "error_if": "!= 0"
       },
-      "tags": [],
+      "tags": [
+        "aggregates"
+      ],
       "description": "",
       "columns": {},
       "meta": {},
@@ -964,9 +1080,8 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {},
-      "created_at": 1704787952.861666,
+      "created_at": 1716931398.129718,
       "relation_name": null,
       "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -981,13 +1096,18 @@
       "metrics": [],
       "depends_on": {
         "macros": [
-          "macro.dbt.test_not_null"
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
         ],
         "nodes": [
           "model.london_bike_analysis.cleaned_bike_rides"
         ]
       },
-      "compiled_path": null,
+      "compiled_path": "target/compiled/london_bike_analysis/models/rides/schema.yml/not_null_cleaned_bike_rides_total_minutes.sql",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\n\n\nselect total_minutes\nfrom DEMO_DB.METAPHOR.cleaned_bike_rides\nwhere total_minutes is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
       "contract": {
         "enforced": false,
         "alias_types": true,
@@ -995,17 +1115,17 @@
       },
       "column_name": "total_minutes",
       "file_key_name": "models.cleaned_bike_rides",
-      "attached_node": "model.london_bike_analysis.cleaned_bike_rides"
-    },
-    "test.london_bike_analysis.dbt_utils_at_least_one_cleaned_bike_rides_total_minutes.8432437e46": {
+      "attached_node": "model.london_bike_analysis.cleaned_bike_rides",
       "test_metadata": {
-        "name": "at_least_one",
+        "name": "not_null",
         "kwargs": {
           "column_name": "total_minutes",
           "model": "{{ get_where_subquery(ref('cleaned_bike_rides')) }}"
         },
-        "namespace": "dbt_utils"
-      },
+        "namespace": null
+      }
+    },
+    "test.london_bike_analysis.dbt_utils_at_least_one_cleaned_bike_rides_total_minutes.8432437e46": {
       "database": "DEMO_DB",
       "schema": "METAPHOR_dbt_test__audit",
       "name": "dbt_utils_at_least_one_cleaned_bike_rides_total_minutes",
@@ -1042,7 +1162,9 @@
         "warn_if": "!= 0",
         "error_if": "!= 0"
       },
-      "tags": [],
+      "tags": [
+        "aggregates"
+      ],
       "description": "",
       "columns": {},
       "meta": {},
@@ -1053,9 +1175,8 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {},
-      "created_at": 1704787952.862758,
+      "created_at": 1716931398.130605,
       "relation_name": null,
       "raw_code": "{{ dbt_utils.test_at_least_one(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -1077,7 +1198,11 @@
           "model.london_bike_analysis.cleaned_bike_rides"
         ]
       },
-      "compiled_path": null,
+      "compiled_path": "target/compiled/london_bike_analysis/models/rides/schema.yml/dbt_utils_at_least_one_cleaned_bike_rides_total_minutes.sql",
+      "compiled": true,
+      "compiled_code": "\n\nselect *\nfrom (\n    select\n        \n        \n      count(total_minutes) as filler_column\n\n    from DEMO_DB.METAPHOR.cleaned_bike_rides\n\n    having count(total_minutes) = 0\n\n) validation_errors\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
       "contract": {
         "enforced": false,
         "alias_types": true,
@@ -1085,17 +1210,17 @@
       },
       "column_name": "total_minutes",
       "file_key_name": "models.cleaned_bike_rides",
-      "attached_node": "model.london_bike_analysis.cleaned_bike_rides"
-    },
-    "test.london_bike_analysis.not_null_cleaned_bike_rides_total_bike_hires.848927fb8f": {
+      "attached_node": "model.london_bike_analysis.cleaned_bike_rides",
       "test_metadata": {
-        "name": "not_null",
+        "name": "at_least_one",
         "kwargs": {
-          "column_name": "total_bike_hires",
+          "column_name": "total_minutes",
           "model": "{{ get_where_subquery(ref('cleaned_bike_rides')) }}"
         },
-        "namespace": null
-      },
+        "namespace": "dbt_utils"
+      }
+    },
+    "test.london_bike_analysis.not_null_cleaned_bike_rides_total_bike_hires.848927fb8f": {
       "database": "DEMO_DB",
       "schema": "METAPHOR_dbt_test__audit",
       "name": "not_null_cleaned_bike_rides_total_bike_hires",
@@ -1132,7 +1257,9 @@
         "warn_if": "!= 0",
         "error_if": "!= 0"
       },
-      "tags": [],
+      "tags": [
+        "aggregates"
+      ],
       "description": "",
       "columns": {},
       "meta": {},
@@ -1143,9 +1270,8 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {},
-      "created_at": 1704787952.8663921,
+      "created_at": 1716931398.1339352,
       "relation_name": null,
       "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -1160,13 +1286,18 @@
       "metrics": [],
       "depends_on": {
         "macros": [
-          "macro.dbt.test_not_null"
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
         ],
         "nodes": [
           "model.london_bike_analysis.cleaned_bike_rides"
         ]
       },
-      "compiled_path": null,
+      "compiled_path": "target/compiled/london_bike_analysis/models/rides/schema.yml/not_null_cleaned_bike_rides_total_bike_hires.sql",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\n\n\nselect total_bike_hires\nfrom DEMO_DB.METAPHOR.cleaned_bike_rides\nwhere total_bike_hires is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
       "contract": {
         "enforced": false,
         "alias_types": true,
@@ -1174,17 +1305,17 @@
       },
       "column_name": "total_bike_hires",
       "file_key_name": "models.cleaned_bike_rides",
-      "attached_node": "model.london_bike_analysis.cleaned_bike_rides"
-    },
-    "test.london_bike_analysis.dbt_utils_at_least_one_cleaned_bike_rides_total_bike_hires.db70dcef4a": {
+      "attached_node": "model.london_bike_analysis.cleaned_bike_rides",
       "test_metadata": {
-        "name": "at_least_one",
+        "name": "not_null",
         "kwargs": {
           "column_name": "total_bike_hires",
           "model": "{{ get_where_subquery(ref('cleaned_bike_rides')) }}"
         },
-        "namespace": "dbt_utils"
-      },
+        "namespace": null
+      }
+    },
+    "test.london_bike_analysis.dbt_utils_at_least_one_cleaned_bike_rides_total_bike_hires.db70dcef4a": {
       "database": "DEMO_DB",
       "schema": "METAPHOR_dbt_test__audit",
       "name": "dbt_utils_at_least_one_cleaned_bike_rides_total_bike_hires",
@@ -1221,7 +1352,9 @@
         "warn_if": "!= 0",
         "error_if": "!= 0"
       },
-      "tags": [],
+      "tags": [
+        "aggregates"
+      ],
       "description": "",
       "columns": {},
       "meta": {},
@@ -1232,9 +1365,8 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {},
-      "created_at": 1704787952.867456,
+      "created_at": 1716931398.134811,
       "relation_name": null,
       "raw_code": "{{ dbt_utils.test_at_least_one(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -1256,7 +1388,11 @@
           "model.london_bike_analysis.cleaned_bike_rides"
         ]
       },
-      "compiled_path": null,
+      "compiled_path": "target/compiled/london_bike_analysis/models/rides/schema.yml/dbt_utils_at_least_one_cleaned_bike_rides_total_bike_hires.sql",
+      "compiled": true,
+      "compiled_code": "\n\nselect *\nfrom (\n    select\n        \n        \n      count(total_bike_hires) as filler_column\n\n    from DEMO_DB.METAPHOR.cleaned_bike_rides\n\n    having count(total_bike_hires) = 0\n\n) validation_errors\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
       "contract": {
         "enforced": false,
         "alias_types": true,
@@ -1264,17 +1400,17 @@
       },
       "column_name": "total_bike_hires",
       "file_key_name": "models.cleaned_bike_rides",
-      "attached_node": "model.london_bike_analysis.cleaned_bike_rides"
-    },
-    "test.london_bike_analysis.not_null_cleaned_bike_rides_month.e937c898a1": {
+      "attached_node": "model.london_bike_analysis.cleaned_bike_rides",
       "test_metadata": {
-        "name": "not_null",
+        "name": "at_least_one",
         "kwargs": {
-          "column_name": "month",
+          "column_name": "total_bike_hires",
           "model": "{{ get_where_subquery(ref('cleaned_bike_rides')) }}"
         },
-        "namespace": null
-      },
+        "namespace": "dbt_utils"
+      }
+    },
+    "test.london_bike_analysis.not_null_cleaned_bike_rides_month.e937c898a1": {
       "database": "DEMO_DB",
       "schema": "METAPHOR_dbt_test__audit",
       "name": "not_null_cleaned_bike_rides_month",
@@ -1322,9 +1458,8 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {},
-      "created_at": 1704787952.869914,
+      "created_at": 1716931398.136974,
       "relation_name": null,
       "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -1339,13 +1474,18 @@
       "metrics": [],
       "depends_on": {
         "macros": [
-          "macro.dbt.test_not_null"
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
         ],
         "nodes": [
           "model.london_bike_analysis.cleaned_bike_rides"
         ]
       },
-      "compiled_path": null,
+      "compiled_path": "target/compiled/london_bike_analysis/models/rides/schema.yml/not_null_cleaned_bike_rides_month.sql",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\n\n\nselect month\nfrom DEMO_DB.METAPHOR.cleaned_bike_rides\nwhere month is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
       "contract": {
         "enforced": false,
         "alias_types": true,
@@ -1353,17 +1493,17 @@
       },
       "column_name": "month",
       "file_key_name": "models.cleaned_bike_rides",
-      "attached_node": "model.london_bike_analysis.cleaned_bike_rides"
-    },
-    "test.london_bike_analysis.dbt_utils_at_least_one_cleaned_bike_rides_month.909766ad33": {
+      "attached_node": "model.london_bike_analysis.cleaned_bike_rides",
       "test_metadata": {
-        "name": "at_least_one",
+        "name": "not_null",
         "kwargs": {
           "column_name": "month",
           "model": "{{ get_where_subquery(ref('cleaned_bike_rides')) }}"
         },
-        "namespace": "dbt_utils"
-      },
+        "namespace": null
+      }
+    },
+    "test.london_bike_analysis.dbt_utils_at_least_one_cleaned_bike_rides_month.909766ad33": {
       "database": "DEMO_DB",
       "schema": "METAPHOR_dbt_test__audit",
       "name": "dbt_utils_at_least_one_cleaned_bike_rides_month",
@@ -1411,9 +1551,8 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {},
-      "created_at": 1704787952.870974,
+      "created_at": 1716931398.137874,
       "relation_name": null,
       "raw_code": "{{ dbt_utils.test_at_least_one(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -1435,7 +1574,11 @@
           "model.london_bike_analysis.cleaned_bike_rides"
         ]
       },
-      "compiled_path": null,
+      "compiled_path": "target/compiled/london_bike_analysis/models/rides/schema.yml/dbt_utils_at_least_one_cleaned_bike_rides_month.sql",
+      "compiled": true,
+      "compiled_code": "\n\nselect *\nfrom (\n    select\n        \n        \n      count(month) as filler_column\n\n    from DEMO_DB.METAPHOR.cleaned_bike_rides\n\n    having count(month) = 0\n\n) validation_errors\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
       "contract": {
         "enforced": false,
         "alias_types": true,
@@ -1443,22 +1586,17 @@
       },
       "column_name": "month",
       "file_key_name": "models.cleaned_bike_rides",
-      "attached_node": "model.london_bike_analysis.cleaned_bike_rides"
-    },
-    "test.london_bike_analysis.accepted_values_cleaned_bike_rides_start_peak_travel__Evening_Peak__Off_Peak__Morning_Peak.014130c1a3": {
+      "attached_node": "model.london_bike_analysis.cleaned_bike_rides",
       "test_metadata": {
-        "name": "accepted_values",
+        "name": "at_least_one",
         "kwargs": {
-          "values": [
-            "Evening Peak",
-            "Off-Peak",
-            "Morning Peak"
-          ],
-          "column_name": "start_peak_travel",
+          "column_name": "month",
           "model": "{{ get_where_subquery(ref('cleaned_bike_rides')) }}"
         },
-        "namespace": null
-      },
+        "namespace": "dbt_utils"
+      }
+    },
+    "test.london_bike_analysis.accepted_values_cleaned_bike_rides_start_peak_travel__Evening_Peak__Off_Peak__Morning_Peak.014130c1a3": {
       "database": "DEMO_DB",
       "schema": "METAPHOR_dbt_test__audit",
       "name": "accepted_values_cleaned_bike_rides_start_peak_travel__Evening_Peak__Off_Peak__Morning_Peak",
@@ -1506,11 +1644,10 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {
         "alias": "accepted_values_cleaned_bike_r_9be401068e6aa322e17682a1024b6feb"
       },
-      "created_at": 1704787952.873431,
+      "created_at": 1716931398.140023,
       "relation_name": null,
       "raw_code": "{{ test_accepted_values(**_dbt_generic_test_kwargs) }}{{ config(alias=\"accepted_values_cleaned_bike_r_9be401068e6aa322e17682a1024b6feb\") }}",
       "language": "sql",
@@ -1532,7 +1669,11 @@
           "model.london_bike_analysis.cleaned_bike_rides"
         ]
       },
-      "compiled_path": null,
+      "compiled_path": "target/compiled/london_bike_analysis/models/rides/schema.yml/accepted_values_cleaned_bike_r_9be401068e6aa322e17682a1024b6feb.sql",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\nwith all_values as (\n\n    select\n        start_peak_travel as value_field,\n        count(*) as n_records\n\n    from DEMO_DB.METAPHOR.cleaned_bike_rides\n    group by start_peak_travel\n\n)\n\nselect *\nfrom all_values\nwhere value_field not in (\n    'Evening Peak','Off-Peak','Morning Peak'\n)\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
       "contract": {
         "enforced": false,
         "alias_types": true,
@@ -1540,17 +1681,22 @@
       },
       "column_name": "start_peak_travel",
       "file_key_name": "models.cleaned_bike_rides",
-      "attached_node": "model.london_bike_analysis.cleaned_bike_rides"
-    },
-    "test.london_bike_analysis.not_null_cleaned_bike_rides_same_station_flag.6293c4e2a8": {
+      "attached_node": "model.london_bike_analysis.cleaned_bike_rides",
       "test_metadata": {
-        "name": "not_null",
+        "name": "accepted_values",
         "kwargs": {
-          "column_name": "same_station_flag",
+          "values": [
+            "Evening Peak",
+            "Off-Peak",
+            "Morning Peak"
+          ],
+          "column_name": "start_peak_travel",
           "model": "{{ get_where_subquery(ref('cleaned_bike_rides')) }}"
         },
         "namespace": null
-      },
+      }
+    },
+    "test.london_bike_analysis.not_null_cleaned_bike_rides_same_station_flag.6293c4e2a8": {
       "database": "DEMO_DB",
       "schema": "METAPHOR_dbt_test__audit",
       "name": "not_null_cleaned_bike_rides_same_station_flag",
@@ -1598,9 +1744,8 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {},
-      "created_at": 1704787952.878273,
+      "created_at": 1716931398.14463,
       "relation_name": null,
       "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -1615,13 +1760,18 @@
       "metrics": [],
       "depends_on": {
         "macros": [
-          "macro.dbt.test_not_null"
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
         ],
         "nodes": [
           "model.london_bike_analysis.cleaned_bike_rides"
         ]
       },
-      "compiled_path": null,
+      "compiled_path": "target/compiled/london_bike_analysis/models/rides/schema.yml/not_null_cleaned_bike_rides_same_station_flag.sql",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\n\n\nselect same_station_flag\nfrom DEMO_DB.METAPHOR.cleaned_bike_rides\nwhere same_station_flag is null\n\n\n",
+      "extra_ctes_injected": true,
+      "extra_ctes": [],
       "contract": {
         "enforced": false,
         "alias_types": true,
@@ -1629,17 +1779,17 @@
       },
       "column_name": "same_station_flag",
       "file_key_name": "models.cleaned_bike_rides",
-      "attached_node": "model.london_bike_analysis.cleaned_bike_rides"
-    },
-    "test.london_bike_analysis.not_null_cleaned_bike_rides_start_station_name.4eec63218d": {
+      "attached_node": "model.london_bike_analysis.cleaned_bike_rides",
       "test_metadata": {
         "name": "not_null",
         "kwargs": {
-          "column_name": "start_station_name",
+          "column_name": "same_station_flag",
           "model": "{{ get_where_subquery(ref('cleaned_bike_rides')) }}"
         },
         "namespace": null
-      },
+      }
+    },
+    "test.london_bike_analysis.not_null_cleaned_bike_rides_start_station_name.4eec63218d": {
       "database": "DEMO_DB",
       "schema": "METAPHOR_dbt_test__audit",
       "name": "not_null_cleaned_bike_rides_start_station_name",
@@ -1687,9 +1837,8 @@
       },
       "patch_path": null,
       "build_path": null,
-      "deferred": false,
       "unrendered_config": {},
-      "created_at": 1704787952.879349,
+      "created_at": 1716931398.1455061,
       "relation_name": null,
       "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
       "language": "sql",
@@ -1704,116 +1853,16 @@
       "metrics": [],
       "depends_on": {
         "macros": [
-          "macro.dbt.test_not_null"
+          "macro.dbt.test_not_null",
+          "macro.dbt.get_where_subquery"
         ],
         "nodes": [
           "model.london_bike_analysis.cleaned_bike_rides"
         ]
       },
-      "compiled_path": null,
-      "contract": {
-        "enforced": false,
-        "alias_types": true,
-        "checksum": null
-      },
-      "column_name": "start_station_name",
-      "file_key_name": "models.cleaned_bike_rides",
-      "attached_node": "model.london_bike_analysis.cleaned_bike_rides"
-    },
-    "model.london_bike_analysis.cleaned_bike_rides_from_snapshot": {
-      "database": "DEMO_DB",
-      "schema": "METAPHOR",
-      "name": "cleaned_bike_rides_from_snapshot",
-      "resource_type": "model",
-      "package_name": "london_bike_analysis",
-      "path": "rides/cleaned_bike_rides_from_snapshot.sql",
-      "original_file_path": "models/rides/cleaned_bike_rides_from_snapshot.sql",
-      "unique_id": "model.london_bike_analysis.cleaned_bike_rides_from_snapshot",
-      "fqn": [
-        "london_bike_analysis",
-        "rides",
-        "cleaned_bike_rides_from_snapshot"
-      ],
-      "alias": "cleaned_bike_rides_from_snapshot",
-      "checksum": {
-        "name": "sha256",
-        "checksum": "b0bcd7b04003e507997938f8fd62211d783a425b0dec21b040ccd980e760de3f"
-      },
-      "config": {
-        "enabled": true,
-        "alias": null,
-        "schema": null,
-        "database": null,
-        "tags": [],
-        "meta": {},
-        "group": null,
-        "materialized": "table",
-        "incremental_strategy": null,
-        "persist_docs": {
-          "relation": true,
-          "columns": true
-        },
-        "post-hook": [],
-        "pre-hook": [],
-        "quoting": {},
-        "column_types": {},
-        "full_refresh": null,
-        "unique_key": null,
-        "on_schema_change": "ignore",
-        "on_configuration_change": "apply",
-        "grants": {},
-        "packages": [],
-        "docs": {
-          "show": true,
-          "node_color": null
-        },
-        "contract": {
-          "enforced": false,
-          "alias_types": true
-        },
-        "access": "protected"
-      },
-      "tags": [],
-      "description": "",
-      "columns": {},
-      "meta": {},
-      "group": null,
-      "docs": {
-        "show": true,
-        "node_color": null
-      },
-      "patch_path": null,
-      "build_path": "target/run/london_bike_analysis/models/rides/cleaned_bike_rides_from_snapshot.sql",
-      "deferred": false,
-      "unrendered_config": {
-        "persist_docs": {
-          "relation": true,
-          "columns": true
-        },
-        "materialized": "table"
-      },
-      "created_at": 1704788512.7159529,
-      "relation_name": "DEMO_DB.METAPHOR.cleaned_bike_rides_from_snapshot",
-      "raw_code": "-- Adding extra fields including if the bike was rented during peak time \r\nSELECT\r\n    SUM(duration) as total_seconds\r\n    , COUNT(rental_id) as total_bike_hires\r\n    , ROUND(SUM(duration) / COUNT(rental_id), 2) AS average_duration\r\n    , EXTRACT(month from start_date) as month\r\n    , CASE\r\n        WHEN EXTRACT(HOUR from TO_TIMESTAMP(start_date)) >= 6 AND EXTRACT(HOUR from TO_TIMESTAMP(start_date)) <= 10 THEN 'Morning Peak'\r\n        WHEN EXTRACT(HOUR from TO_TIMESTAMP(start_date)) >= 16 AND EXTRACT(HOUR from TO_TIMESTAMP(start_date)) <= 19 THEN 'Evening Peak'\r\n        ELSE 'Off-Peak'\r\n      END AS start_peak_travel\r\n    , IFF(start_station_id = end_station_id, True, False) as same_station_flag\r\n    , start_station_id\r\n    , start_station_name\r\n    , end_station_id\r\n    , end_station_name\r\nFROM {{ ref('cycle_hire_snapshot') }}\r\nGROUP BY 4,5,6,7,8,9,10\r\nORDER BY total_seconds DESC",
-      "language": "sql",
-      "refs": [
-        {
-          "name": "cycle_hire_snapshot",
-          "package": null,
-          "version": null
-        }
-      ],
-      "sources": [],
-      "metrics": [],
-      "depends_on": {
-        "macros": [],
-        "nodes": [
-          "snapshot.london_bike_analysis.cycle_hire_snapshot"
-        ]
-      },
-      "compiled_path": "target/compiled/london_bike_analysis/models/rides/cleaned_bike_rides_from_snapshot.sql",
+      "compiled_path": "target/compiled/london_bike_analysis/models/rides/schema.yml/not_null_cleaned_bike_rides_start_station_name.sql",
       "compiled": true,
-      "compiled_code": "-- Adding extra fields including if the bike was rented during peak time \nSELECT\n    SUM(duration) as total_seconds\n    , COUNT(rental_id) as total_bike_hires\n    , ROUND(SUM(duration) / COUNT(rental_id), 2) AS average_duration\n    , EXTRACT(month from start_date) as month\n    , CASE\n        WHEN EXTRACT(HOUR from TO_TIMESTAMP(start_date)) >= 6 AND EXTRACT(HOUR from TO_TIMESTAMP(start_date)) <= 10 THEN 'Morning Peak'\n        WHEN EXTRACT(HOUR from TO_TIMESTAMP(start_date)) >= 16 AND EXTRACT(HOUR from TO_TIMESTAMP(start_date)) <= 19 THEN 'Evening Peak'\n        ELSE 'Off-Peak'\n      END AS start_peak_travel\n    , IFF(start_station_id = end_station_id, True, False) as same_station_flag\n    , start_station_id\n    , start_station_name\n    , end_station_id\n    , end_station_name\nFROM DEMO_DB.snapshots.cycle_hire_snapshot\nGROUP BY 4,5,6,7,8,9,10\nORDER BY total_seconds DESC",
+      "compiled_code": "\n    \n    \n\n\n\nselect start_station_name\nfrom DEMO_DB.METAPHOR.cleaned_bike_rides\nwhere start_station_name is null\n\n\n",
       "extra_ctes_injected": true,
       "extra_ctes": [],
       "contract": {
@@ -1821,30 +1870,36 @@
         "alias_types": true,
         "checksum": null
       },
-      "access": "protected",
-      "constraints": [],
-      "version": null,
-      "latest_version": null,
-      "deprecation_date": null
+      "column_name": "start_station_name",
+      "file_key_name": "models.cleaned_bike_rides",
+      "attached_node": "model.london_bike_analysis.cleaned_bike_rides",
+      "test_metadata": {
+        "name": "not_null",
+        "kwargs": {
+          "column_name": "start_station_name",
+          "model": "{{ get_where_subquery(ref('cleaned_bike_rides')) }}"
+        },
+        "namespace": null
+      }
     }
   },
   "sources": {
-    "source.london_bike_analysis.metaphor.cycle_hire": {
+    "source.london_bike_analysis.berlin_bicycles.cycle_hire": {
       "database": "DEMO_DB",
-      "schema": "metaphor",
+      "schema": "berlin_bicycles",
       "name": "cycle_hire",
       "resource_type": "source",
       "package_name": "london_bike_analysis",
       "path": "models/rides/schema.yml",
       "original_file_path": "models/rides/schema.yml",
-      "unique_id": "source.london_bike_analysis.metaphor.cycle_hire",
+      "unique_id": "source.london_bike_analysis.berlin_bicycles.cycle_hire",
       "fqn": [
         "london_bike_analysis",
         "rides",
-        "metaphor",
+        "berlin_bicycles",
         "cycle_hire"
       ],
-      "source_name": "metaphor",
+      "source_name": "berlin_bicycles",
       "source_description": "Number of hires of the Santander Cycle Hire Scheme",
       "loader": "",
       "identifier": "cycle_hire",
@@ -1986,25 +2041,25 @@
       },
       "patch_path": null,
       "unrendered_config": {},
-      "relation_name": "DEMO_DB.metaphor.cycle_hire",
-      "created_at": 1704787952.918292
+      "relation_name": "DEMO_DB.berlin_bicycles.cycle_hire",
+      "created_at": 1716931398.189397
     },
-    "source.london_bike_analysis.metaphor.cycle_stations": {
+    "source.london_bike_analysis.berlin_bicycles.cycle_stations": {
       "database": "DEMO_DB",
-      "schema": "metaphor",
+      "schema": "berlin_bicycles",
       "name": "cycle_stations",
       "resource_type": "source",
       "package_name": "london_bike_analysis",
       "path": "models/rides/schema.yml",
       "original_file_path": "models/rides/schema.yml",
-      "unique_id": "source.london_bike_analysis.metaphor.cycle_stations",
+      "unique_id": "source.london_bike_analysis.berlin_bicycles.cycle_stations",
       "fqn": [
         "london_bike_analysis",
         "rides",
-        "metaphor",
+        "berlin_bicycles",
         "cycle_stations"
       ],
-      "source_name": "metaphor",
+      "source_name": "berlin_bicycles",
       "source_description": "Number of hires of the Santander Cycle Hire Scheme",
       "loader": "",
       "identifier": "cycle_stations",
@@ -2155,8 +2210,8 @@
       },
       "patch_path": null,
       "unrendered_config": {},
-      "relation_name": "DEMO_DB.metaphor.cycle_stations",
-      "created_at": 1704787952.9184132
+      "relation_name": "DEMO_DB.berlin_bicycles.cycle_stations",
+      "created_at": 1716931398.190112
     }
   },
   "macros": {
@@ -2185,7 +2240,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.941015,
+      "created_at": 1716931397.195723,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_catalog_relations": {
@@ -2213,7 +2268,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.9414132,
+      "created_at": 1716931397.196104,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_catalog_tables_sql": {
@@ -2223,7 +2278,7 @@
       "path": "macros/catalog.sql",
       "original_file_path": "macros/catalog.sql",
       "unique_id": "macro.dbt_snowflake.snowflake__get_catalog_tables_sql",
-      "macro_sql": "{% macro snowflake__get_catalog_tables_sql(information_schema) -%}\n    select\n        table_catalog as \"table_database\",\n        table_schema as \"table_schema\",\n        table_name as \"table_name\",\n        coalesce(table_type, 'DYNAMIC TABLE') as \"table_type\",\n        comment as \"table_comment\",\n\n        -- note: this is the _role_ that owns the table\n        table_owner as \"table_owner\",\n\n        'Clustering Key' as \"stats:clustering_key:label\",\n        clustering_key as \"stats:clustering_key:value\",\n        'The key used to cluster this table' as \"stats:clustering_key:description\",\n        (clustering_key is not null) as \"stats:clustering_key:include\",\n\n        'Row Count' as \"stats:row_count:label\",\n        row_count as \"stats:row_count:value\",\n        'An approximate count of rows in this table' as \"stats:row_count:description\",\n        (row_count is not null) as \"stats:row_count:include\",\n\n        'Approximate Size' as \"stats:bytes:label\",\n        bytes as \"stats:bytes:value\",\n        'Approximate size of the table as reported by Snowflake' as \"stats:bytes:description\",\n        (bytes is not null) as \"stats:bytes:include\",\n\n        'Last Modified' as \"stats:last_modified:label\",\n        to_varchar(convert_timezone('UTC', last_altered), 'yyyy-mm-dd HH24:MI'||'UTC') as \"stats:last_modified:value\",\n        'The timestamp for last update/change' as \"stats:last_modified:description\",\n        (last_altered is not null and table_type='BASE TABLE') as \"stats:last_modified:include\"\n    from {{ information_schema }}.tables\n{%- endmacro %}",
+      "macro_sql": "{% macro snowflake__get_catalog_tables_sql(information_schema) -%}\n    select\n        table_catalog as \"table_database\",\n        table_schema as \"table_schema\",\n        table_name as \"table_name\",\n        case\n            when is_dynamic = 'YES' and table_type = 'BASE TABLE' THEN 'DYNAMIC TABLE'\n            else table_type\n        end as \"table_type\",\n        comment as \"table_comment\",\n\n        -- note: this is the _role_ that owns the table\n        table_owner as \"table_owner\",\n\n        'Clustering Key' as \"stats:clustering_key:label\",\n        clustering_key as \"stats:clustering_key:value\",\n        'The key used to cluster this table' as \"stats:clustering_key:description\",\n        (clustering_key is not null) as \"stats:clustering_key:include\",\n\n        'Row Count' as \"stats:row_count:label\",\n        row_count as \"stats:row_count:value\",\n        'An approximate count of rows in this table' as \"stats:row_count:description\",\n        (row_count is not null) as \"stats:row_count:include\",\n\n        'Approximate Size' as \"stats:bytes:label\",\n        bytes as \"stats:bytes:value\",\n        'Approximate size of the table as reported by Snowflake' as \"stats:bytes:description\",\n        (bytes is not null) as \"stats:bytes:include\",\n\n        'Last Modified' as \"stats:last_modified:label\",\n        to_varchar(convert_timezone('UTC', last_altered), 'yyyy-mm-dd HH24:MI'||'UTC') as \"stats:last_modified:value\",\n        'The timestamp for last update/change' as \"stats:last_modified:description\",\n        (last_altered is not null and table_type='BASE TABLE') as \"stats:last_modified:include\"\n    from {{ information_schema }}.tables\n{%- endmacro %}",
       "depends_on": {
         "macros": []
       },
@@ -2235,7 +2290,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.941608,
+      "created_at": 1716931397.196307,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_catalog_columns_sql": {
@@ -2257,7 +2312,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.94173,
+      "created_at": 1716931397.1964319,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_catalog_results_sql": {
@@ -2279,7 +2334,29 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.941813,
+      "created_at": 1716931397.196515,
+      "supported_languages": null
+    },
+    "macro.dbt_snowflake.snowflake__catalog_equals": {
+      "name": "snowflake__catalog_equals",
+      "resource_type": "macro",
+      "package_name": "dbt_snowflake",
+      "path": "macros/catalog.sql",
+      "original_file_path": "macros/catalog.sql",
+      "unique_id": "macro.dbt_snowflake.snowflake__catalog_equals",
+      "macro_sql": "{% macro snowflake__catalog_equals(field, value) %}\n    \"{{ field }}\" ilike '{{ value }}' and upper(\"{{ field }}\") = upper('{{ value }}')\n{% endmacro %}",
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1716931397.196678,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_catalog_schemas_where_clause_sql": {
@@ -2289,9 +2366,11 @@
       "path": "macros/catalog.sql",
       "original_file_path": "macros/catalog.sql",
       "unique_id": "macro.dbt_snowflake.snowflake__get_catalog_schemas_where_clause_sql",
-      "macro_sql": "{% macro snowflake__get_catalog_schemas_where_clause_sql(schemas) -%}\n    where ({%- for schema in schemas -%}\n        upper(\"table_schema\") = upper('{{ schema }}'){%- if not loop.last %} or {% endif -%}\n    {%- endfor -%})\n{%- endmacro %}",
+      "macro_sql": "{% macro snowflake__get_catalog_schemas_where_clause_sql(schemas) -%}\n    where ({%- for schema in schemas -%}\n        ({{ snowflake__catalog_equals('table_schema', schema) }}){%- if not loop.last %} or {% endif -%}\n    {%- endfor -%})\n{%- endmacro %}",
       "depends_on": {
-        "macros": []
+        "macros": [
+          "macro.dbt_snowflake.snowflake__catalog_equals"
+        ]
       },
       "description": "",
       "meta": {},
@@ -2301,7 +2380,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.942049,
+      "created_at": 1716931397.196959,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_catalog_relations_where_clause_sql": {
@@ -2311,9 +2390,11 @@
       "path": "macros/catalog.sql",
       "original_file_path": "macros/catalog.sql",
       "unique_id": "macro.dbt_snowflake.snowflake__get_catalog_relations_where_clause_sql",
-      "macro_sql": "{% macro snowflake__get_catalog_relations_where_clause_sql(relations) -%}\n    where (\n        {%- for relation in relations -%}\n            {% if relation.schema and relation.identifier %}\n                (\n                    upper(\"table_schema\") = upper('{{ relation.schema }}')\n                    and upper(\"table_name\") = upper('{{ relation.identifier }}')\n                )\n            {% elif relation.schema %}\n                (\n                    upper(\"table_schema\") = upper('{{ relation.schema }}')\n                )\n            {% else %}\n                {% do exceptions.raise_compiler_error(\n                    '`get_catalog_relations` requires a list of relations, each with a schema'\n                ) %}\n            {% endif %}\n\n            {%- if not loop.last %} or {% endif -%}\n        {%- endfor -%}\n    )\n{%- endmacro %}",
+      "macro_sql": "{% macro snowflake__get_catalog_relations_where_clause_sql(relations) -%}\n    where (\n        {%- for relation in relations -%}\n            {% if relation.schema and relation.identifier %}\n                (\n                    {{ snowflake__catalog_equals('table_schema', relation.schema) }}\n                    and {{ snowflake__catalog_equals('table_name', relation.identifier) }}\n                )\n            {% elif relation.schema %}\n                (\n                    {{ snowflake__catalog_equals('table_schema', relation.schema) }}\n                )\n            {% else %}\n                {% do exceptions.raise_compiler_error(\n                    '`get_catalog_relations` requires a list of relations, each with a schema'\n                ) %}\n            {% endif %}\n\n            {%- if not loop.last %} or {% endif -%}\n        {%- endfor -%}\n    )\n{%- endmacro %}",
       "depends_on": {
-        "macros": []
+        "macros": [
+          "macro.dbt_snowflake.snowflake__catalog_equals"
+        ]
       },
       "description": "",
       "meta": {},
@@ -2323,7 +2404,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.942901,
+      "created_at": 1716931397.1974862,
       "supported_languages": null
     },
     "macro.dbt_snowflake.get_column_comment_sql": {
@@ -2345,7 +2426,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.952659,
+      "created_at": 1716931397.2071838,
       "supported_languages": null
     },
     "macro.dbt_snowflake.get_persist_docs_column_list": {
@@ -2369,7 +2450,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.95295,
+      "created_at": 1716931397.207437,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_columns_in_relation": {
@@ -2393,7 +2474,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.953731,
+      "created_at": 1716931397.208171,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__list_schemas": {
@@ -2417,7 +2498,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.954392,
+      "created_at": 1716931397.208673,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_paginated_relations_array": {
@@ -2427,7 +2508,7 @@
       "path": "macros/adapters.sql",
       "original_file_path": "macros/adapters.sql",
       "unique_id": "macro.dbt_snowflake.snowflake__get_paginated_relations_array",
-      "macro_sql": "{% macro snowflake__get_paginated_relations_array(max_iter, max_results_per_iter, max_total_results, schema_relation, watermark) %}\n\n  {% set paginated_relations = [] %}\n\n  {% for _ in range(0, max_iter) %}\n\n      {%- set paginated_sql -%}\n         show terse objects in {{ schema_relation }} limit {{ max_results_per_iter }} from '{{ watermark.table_name }}'\n      {%- endset -%}\n\n      {%- set paginated_result = run_query(paginated_sql) %}\n      {%- set paginated_n = (paginated_result | length) -%}\n\n      {#\n        terminating condition: if there are 0 records in the result we reached\n        the end exactly on the previous iteration\n      #}\n      {%- if paginated_n == 0 -%}\n        {%- break -%}\n      {%- endif -%}\n\n      {#\n        terminating condition: At some point the user needs to be reasonable with how\n        many objects are contained in their schemas. Since there was already\n        one iteration before attempting pagination, loop.index == max_iter means\n        the limit has been surpassed.\n      #}\n\n      {%- if loop.index == max_iter -%}\n        {%- set msg -%}\n           dbt will list a maximum of {{ max_total_results }} objects in schema {{ schema_relation }}.\n           Your schema exceeds this limit. Please contact support@getdbt.com for troubleshooting tips,\n           or review and reduce the number of objects contained.\n        {%- endset -%}\n\n        {% do exceptions.raise_compiler_error(msg) %}\n      {%- endif -%}\n\n      {%- do paginated_relations.append(paginated_result) -%}\n      {% set watermark.table_name = paginated_result.columns[1].values()[-1] %}\n\n      {#\n        terminating condition: paginated_n < max_results_per_iter means we reached the end\n      #}\n      {%- if paginated_n < max_results_per_iter -%}\n         {%- break -%}\n      {%- endif -%}\n    {%- endfor -%}\n\n  {{ return(paginated_relations) }}\n\n{% endmacro %}",
+      "macro_sql": "{% macro snowflake__get_paginated_relations_array(max_iter, max_results_per_iter, max_total_results, schema_relation, watermark) %}\n\n  {% set paginated_relations = [] %}\n\n  {% for _ in range(0, max_iter) %}\n\n      {%- set paginated_sql -%}\n         show terse objects in {{ schema_relation.database }}.{{ schema_relation.schema }} limit {{ max_results_per_iter }} from '{{ watermark.table_name }}'\n      {%- endset -%}\n\n      {%- set paginated_result = run_query(paginated_sql) %}\n      {%- set paginated_n = (paginated_result | length) -%}\n\n      {#\n        terminating condition: if there are 0 records in the result we reached\n        the end exactly on the previous iteration\n      #}\n      {%- if paginated_n == 0 -%}\n        {%- break -%}\n      {%- endif -%}\n\n      {#\n        terminating condition: At some point the user needs to be reasonable with how\n        many objects are contained in their schemas. Since there was already\n        one iteration before attempting pagination, loop.index == max_iter means\n        the limit has been surpassed.\n      #}\n\n      {%- if loop.index == max_iter -%}\n        {%- set msg -%}\n           dbt will list a maximum of {{ max_total_results }} objects in schema {{ schema_relation.database }}.{{ schema_relation.schema }}.\n           Your schema exceeds this limit. Please contact support@getdbt.com for troubleshooting tips,\n           or review and reduce the number of objects contained.\n        {%- endset -%}\n\n        {% do exceptions.raise_compiler_error(msg) %}\n      {%- endif -%}\n\n      {%- do paginated_relations.append(paginated_result) -%}\n      {% set watermark.table_name = paginated_result.columns[1].values()[-1] %}\n\n      {#\n        terminating condition: paginated_n < max_results_per_iter means we reached the end\n      #}\n      {%- if paginated_n < max_results_per_iter -%}\n         {%- break -%}\n      {%- endif -%}\n    {%- endfor -%}\n\n  {{ return(paginated_relations) }}\n\n{% endmacro %}",
       "depends_on": {
         "macros": [
           "macro.dbt.run_query"
@@ -2441,7 +2522,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.9554272,
+      "created_at": 1716931397.2096891,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__list_relations_without_caching": {
@@ -2451,7 +2532,7 @@
       "path": "macros/adapters.sql",
       "original_file_path": "macros/adapters.sql",
       "unique_id": "macro.dbt_snowflake.snowflake__list_relations_without_caching",
-      "macro_sql": "{% macro snowflake__list_relations_without_caching(schema_relation, max_iter=10, max_results_per_iter=10000) %}\n\n  {%- set max_total_results = max_results_per_iter * max_iter -%}\n\n  {%- set sql -%}\n    show terse objects in {{ schema_relation }} limit {{ max_results_per_iter }}\n  {%- endset -%}\n\n  {%- set result = run_query(sql) -%}\n\n  {%- set n = (result | length) -%}\n  {%- set watermark = namespace(table_name=result.columns[1].values()[-1]) -%}\n  {%- set paginated = namespace(result=[]) -%}\n\n  {% if n >= max_results_per_iter %}\n\n    {% set paginated.result = snowflake__get_paginated_relations_array(\n         max_iter,\n         max_results_per_iter,\n         max_total_results,\n         schema_relation,\n         watermark\n       )\n    %}\n\n  {% endif %}\n\n  {%- set all_results_array = [result] + paginated.result -%}\n  {%- set result = result.merge(all_results_array) -%}\n  {%- do return(result) -%}\n\n{% endmacro %}",
+      "macro_sql": "{% macro snowflake__list_relations_without_caching(schema_relation, max_iter=10, max_results_per_iter=10000) %}\n\n  {%- set max_total_results = max_results_per_iter * max_iter -%}\n\n  {%- set sql -%}\n    show terse objects in {{ schema_relation.database }}.{{ schema_relation.schema }} limit {{ max_results_per_iter }}\n  {%- endset -%}\n\n  {%- set result = run_query(sql) -%}\n\n  {%- set n = (result | length) -%}\n  {%- set watermark = namespace(table_name=result.columns[1].values()[-1]) -%}\n  {%- set paginated = namespace(result=[]) -%}\n\n  {% if n >= max_results_per_iter %}\n\n    {% set paginated.result = snowflake__get_paginated_relations_array(\n         max_iter,\n         max_results_per_iter,\n         max_total_results,\n         schema_relation,\n         watermark\n       )\n    %}\n\n  {% endif %}\n\n  {%- set all_results_array = [result] + paginated.result -%}\n  {%- set result = result.merge(all_results_array) -%}\n  {%- do return(result) -%}\n\n{% endmacro %}",
       "depends_on": {
         "macros": [
           "macro.dbt.run_query",
@@ -2466,7 +2547,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.956339,
+      "created_at": 1716931397.2105322,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__check_schema_exists": {
@@ -2490,7 +2571,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.9566562,
+      "created_at": 1716931397.210824,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__alter_column_type": {
@@ -2514,7 +2595,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.956908,
+      "created_at": 1716931397.211047,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__alter_relation_comment": {
@@ -2536,7 +2617,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.957237,
+      "created_at": 1716931397.211336,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__alter_column_comment": {
@@ -2560,7 +2641,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.957881,
+      "created_at": 1716931397.211923,
       "supported_languages": null
     },
     "macro.dbt_snowflake.get_current_query_tag": {
@@ -2584,7 +2665,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.958059,
+      "created_at": 1716931397.2120929,
       "supported_languages": null
     },
     "macro.dbt_snowflake.set_query_tag": {
@@ -2608,7 +2689,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.95822,
+      "created_at": 1716931397.212241,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__set_query_tag": {
@@ -2633,7 +2714,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.958706,
+      "created_at": 1716931397.212668,
       "supported_languages": null
     },
     "macro.dbt_snowflake.unset_query_tag": {
@@ -2657,7 +2738,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.9588852,
+      "created_at": 1716931397.212842,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__unset_query_tag": {
@@ -2681,7 +2762,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.9593658,
+      "created_at": 1716931397.21329,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__alter_relation_add_remove_columns": {
@@ -2705,7 +2786,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.9602308,
+      "created_at": 1716931397.214106,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake_dml_explicit_transaction": {
@@ -2727,7 +2808,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.960445,
+      "created_at": 1716931397.214297,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__truncate_relation": {
@@ -2752,7 +2833,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.960681,
+      "created_at": 1716931397.214519,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__copy_grants": {
@@ -2774,7 +2855,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.9609542,
+      "created_at": 1716931397.214786,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__support_multiple_grantees_per_dcl_statement": {
@@ -2796,7 +2877,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.961061,
+      "created_at": 1716931397.214895,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_relation_last_modified": {
@@ -2821,7 +2902,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.9617448,
+      "created_at": 1716931397.215509,
       "supported_languages": null
     },
     "macro.dbt_snowflake.materialization_test_snowflake": {
@@ -2847,7 +2928,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.962083,
+      "created_at": 1716931397.215827,
       "supported_languages": [
         "sql"
       ]
@@ -2875,7 +2956,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.963427,
+      "created_at": 1716931397.2171159,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_delete_insert_merge_sql": {
@@ -2900,7 +2981,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.9637928,
+      "created_at": 1716931397.2174652,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__snapshot_merge_sql": {
@@ -2925,7 +3006,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.964045,
+      "created_at": 1716931397.217695,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_incremental_append_sql": {
@@ -2950,7 +3031,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.964247,
+      "created_at": 1716931397.217886,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__load_csv_rows": {
@@ -2975,7 +3056,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.966352,
+      "created_at": 1716931397.219871,
       "supported_languages": null
     },
     "macro.dbt_snowflake.materialization_seed_snowflake": {
@@ -3001,7 +3082,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.9666471,
+      "created_at": 1716931397.2201338,
       "supported_languages": [
         "sql"
       ]
@@ -3030,7 +3111,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.9671721,
+      "created_at": 1716931397.2206259,
       "supported_languages": [
         "sql"
       ]
@@ -3064,7 +3145,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.969356,
+      "created_at": 1716931397.2226639,
       "supported_languages": [
         "sql",
         "python"
@@ -3091,7 +3172,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.9698439,
+      "created_at": 1716931397.22312,
       "supported_languages": null
     },
     "macro.dbt_snowflake.py_script_comment": {
@@ -3113,7 +3194,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.9699452,
+      "created_at": 1716931397.223222,
       "supported_languages": null
     },
     "macro.dbt_snowflake.dbt_snowflake_get_tmp_relation_type": {
@@ -3135,7 +3216,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.9723809,
+      "created_at": 1716931397.225526,
       "supported_languages": null
     },
     "macro.dbt_snowflake.materialization_incremental_snowflake": {
@@ -3174,7 +3255,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.97566,
+      "created_at": 1716931397.228662,
       "supported_languages": [
         "sql",
         "python"
@@ -3201,7 +3282,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.9758248,
+      "created_at": 1716931397.22882,
       "supported_languages": null
     },
     "macro.dbt_snowflake.materialization_snapshot_snowflake": {
@@ -3227,7 +3308,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.976171,
+      "created_at": 1716931397.229145,
       "supported_languages": [
         "sql"
       ]
@@ -3259,7 +3340,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.979604,
+      "created_at": 1716931397.232511,
       "supported_languages": [
         "sql"
       ]
@@ -3289,7 +3370,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.980884,
+      "created_at": 1716931397.2336798,
       "supported_languages": null
     },
     "macro.dbt_snowflake.dynamic_table_execute_no_op": {
@@ -3311,7 +3392,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.98111,
+      "created_at": 1716931397.233889,
       "supported_languages": null
     },
     "macro.dbt_snowflake.dynamic_table_execute_build_sql": {
@@ -3338,7 +3419,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.981587,
+      "created_at": 1716931397.234323,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_dynamic_table_configuration_changes": {
@@ -3348,7 +3429,7 @@
       "path": "macros/materializations/dynamic_table.sql",
       "original_file_path": "macros/materializations/dynamic_table.sql",
       "unique_id": "macro.dbt_snowflake.snowflake__get_dynamic_table_configuration_changes",
-      "macro_sql": "{% macro snowflake__get_dynamic_table_configuration_changes(existing_relation, new_config) -%}\n    {% set _existing_dynamic_table = snowflake__describe_dynamic_table(existing_relation) %}\n    {% set _configuration_changes = existing_relation.dynamic_table_config_changeset(_existing_dynamic_table, new_config) %}\n    {% do return(_configuration_changes) %}\n{%- endmacro %}",
+      "macro_sql": "{% macro snowflake__get_dynamic_table_configuration_changes(existing_relation, new_config) -%}\n    {% set _existing_dynamic_table = snowflake__describe_dynamic_table(existing_relation) %}\n    {% set _configuration_changes = existing_relation.dynamic_table_config_changeset(_existing_dynamic_table, new_config.model) %}\n    {% do return(_configuration_changes) %}\n{%- endmacro %}",
       "depends_on": {
         "macros": [
           "macro.dbt_snowflake.snowflake__describe_dynamic_table"
@@ -3362,7 +3443,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.981858,
+      "created_at": 1716931397.234577,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__can_clone_table": {
@@ -3384,7 +3465,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.9820921,
+      "created_at": 1716931397.234803,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__create_or_replace_clone": {
@@ -3406,7 +3487,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.982371,
+      "created_at": 1716931397.23506,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_drop_sql": {
@@ -3431,7 +3512,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.9826822,
+      "created_at": 1716931397.235341,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_replace_sql": {
@@ -3456,7 +3537,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.9830668,
+      "created_at": 1716931397.235698,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__rename_relation": {
@@ -3480,7 +3561,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.983308,
+      "created_at": 1716931397.235926,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_create_sql": {
@@ -3505,7 +3586,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.983642,
+      "created_at": 1716931397.2362392,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_drop_table_sql": {
@@ -3527,7 +3608,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.983775,
+      "created_at": 1716931397.236365,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_replace_table_sql": {
@@ -3551,7 +3632,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.983959,
+      "created_at": 1716931397.236536,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_rename_table_sql": {
@@ -3573,7 +3654,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.984124,
+      "created_at": 1716931397.236691,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__create_table_as": {
@@ -3600,7 +3681,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.988029,
+      "created_at": 1716931397.261984,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_drop_view_sql": {
@@ -3622,7 +3703,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.9881768,
+      "created_at": 1716931397.26217,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_replace_view_sql": {
@@ -3646,7 +3727,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.9883468,
+      "created_at": 1716931397.262339,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_rename_view_sql": {
@@ -3668,7 +3749,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.988508,
+      "created_at": 1716931397.262497,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__create_view_as_with_temp_flag": {
@@ -3694,7 +3775,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.990182,
+      "created_at": 1716931397.264064,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__create_view_as": {
@@ -3718,7 +3799,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.990328,
+      "created_at": 1716931397.264205,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__create_or_replace_view": {
@@ -3748,7 +3829,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.991412,
+      "created_at": 1716931397.2651782,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_drop_dynamic_table_sql": {
@@ -3770,7 +3851,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.991551,
+      "created_at": 1716931397.265315,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_replace_dynamic_table_sql": {
@@ -3794,7 +3875,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.9919229,
+      "created_at": 1716931397.2656598,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__describe_dynamic_table": {
@@ -3818,7 +3899,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.9924579,
+      "created_at": 1716931397.266158,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__refresh_dynamic_table": {
@@ -3840,7 +3921,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.99266,
+      "created_at": 1716931397.266361,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_alter_dynamic_table_as_sql": {
@@ -3864,7 +3945,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.993686,
+      "created_at": 1716931397.267338,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__get_create_dynamic_table_as_sql": {
@@ -3874,7 +3955,7 @@
       "path": "macros/relations/dynamic_table/create.sql",
       "original_file_path": "macros/relations/dynamic_table/create.sql",
       "unique_id": "macro.dbt_snowflake.snowflake__get_create_dynamic_table_as_sql",
-      "macro_sql": "{% macro snowflake__get_create_dynamic_table_as_sql(relation, sql) -%}\n\n    create dynamic table {{ relation }}\n        target_lag = '{{ config.get(\"target_lag\") }}'\n        warehouse = {{ config.get(\"snowflake_warehouse\") }}\n        as (\n            {{ sql }}\n        )\n    ;\n\n{%- endmacro %}",
+      "macro_sql": "{% macro snowflake__get_create_dynamic_table_as_sql(relation, sql) -%}\n\n    create dynamic table {{ relation }}\n        target_lag = '{{ config.get(\"target_lag\") }}'\n        warehouse = {{ config.get(\"snowflake_warehouse\") }}\n        as (\n            {{ sql }}\n        )\n\n{%- endmacro %}",
       "depends_on": {
         "macros": []
       },
@@ -3886,7 +3967,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.994003,
+      "created_at": 1716931397.2676349,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__current_timestamp": {
@@ -3908,7 +3989,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.994278,
+      "created_at": 1716931397.2678971,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__snapshot_string_as_time": {
@@ -3930,7 +4011,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.994449,
+      "created_at": 1716931397.2680562,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__snapshot_get_time": {
@@ -3954,7 +4035,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.994555,
+      "created_at": 1716931397.268151,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__current_timestamp_backcompat": {
@@ -3978,7 +4059,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.994675,
+      "created_at": 1716931397.268245,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__current_timestamp_in_utc_backcompat": {
@@ -4003,7 +4084,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.9948092,
+      "created_at": 1716931397.268376,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__escape_single_quotes": {
@@ -4025,7 +4106,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.9949949,
+      "created_at": 1716931397.26855,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__right": {
@@ -4047,7 +4128,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.9952168,
+      "created_at": 1716931397.268826,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__safe_cast": {
@@ -4057,7 +4138,33 @@
       "path": "macros/utils/safe_cast.sql",
       "original_file_path": "macros/utils/safe_cast.sql",
       "unique_id": "macro.dbt_snowflake.snowflake__safe_cast",
-      "macro_sql": "{% macro snowflake__safe_cast(field, type) %}\n    try_cast({{field}} as {{type}})\n{% endmacro %}",
+      "macro_sql": "{% macro snowflake__safe_cast(field, type) %}\n    {% if type|upper == \"GEOMETRY\" -%}\n        try_to_geometry({{field}})\n    {% elif type|upper == \"GEOGRAPHY\" -%}\n        try_to_geography({{field}})\n    {% elif type|upper != \"VARIANT\" -%}\n        {#-- Snowflake try_cast does not support casting to variant, and expects the field as a string --#}\n        {% set field_as_string =  dbt.string_literal(field) if field is number else field %}\n        try_cast({{field_as_string}} as {{type}})\n    {% else -%}\n        {{ adapter.dispatch('cast', 'dbt')(field, type) }}\n    {% endif -%}\n{% endmacro %}",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.string_literal",
+          "macro.dbt.cast",
+          "macro.dbt_snowflake.snowflake__cast"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1716931397.269446,
+      "supported_languages": null
+    },
+    "macro.dbt_snowflake.snowflake__cast": {
+      "name": "snowflake__cast",
+      "resource_type": "macro",
+      "package_name": "dbt_snowflake",
+      "path": "macros/utils/cast.sql",
+      "original_file_path": "macros/utils/cast.sql",
+      "unique_id": "macro.dbt_snowflake.snowflake__cast",
+      "macro_sql": "{% macro snowflake__cast(field, type) %}\n    {% if (type|upper == \"GEOGRAPHY\") -%}\n        to_geography({{field}})\n    {% elif (type|upper == \"GEOMETRY\") -%}\n        to_geometry({{field}})\n    {% else -%}\n        cast({{field}} as {{type}})\n    {% endif -%}\n{% endmacro %}",
       "depends_on": {
         "macros": []
       },
@@ -4069,7 +4176,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.995372,
+      "created_at": 1716931397.269824,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__bool_or": {
@@ -4091,7 +4198,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.995553,
+      "created_at": 1716931397.2699468,
       "supported_languages": null
     },
     "macro.dbt_snowflake.snowflake__array_construct": {
@@ -4113,7 +4220,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.995723,
+      "created_at": 1716931397.270102,
       "supported_languages": null
     },
     "macro.dbt.run_hooks": {
@@ -4137,7 +4244,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.9967518,
+      "created_at": 1716931397.2710578,
       "supported_languages": null
     },
     "macro.dbt.make_hook_config": {
@@ -4159,7 +4266,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.996939,
+      "created_at": 1716931397.271232,
       "supported_languages": null
     },
     "macro.dbt.before_begin": {
@@ -4183,7 +4290,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.997082,
+      "created_at": 1716931397.271363,
       "supported_languages": null
     },
     "macro.dbt.in_transaction": {
@@ -4207,7 +4314,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.997222,
+      "created_at": 1716931397.271498,
       "supported_languages": null
     },
     "macro.dbt.after_commit": {
@@ -4231,7 +4338,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.997358,
+      "created_at": 1716931397.271627,
       "supported_languages": null
     },
     "macro.dbt.set_sql_header": {
@@ -4253,7 +4360,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.997708,
+      "created_at": 1716931397.271959,
       "supported_languages": null
     },
     "macro.dbt.should_full_refresh": {
@@ -4275,7 +4382,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.997998,
+      "created_at": 1716931397.2722208,
       "supported_languages": null
     },
     "macro.dbt.should_store_failures": {
@@ -4297,7 +4404,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.998297,
+      "created_at": 1716931397.272485,
       "supported_languages": null
     },
     "macro.dbt.snapshot_merge_sql": {
@@ -4321,7 +4428,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.998713,
+      "created_at": 1716931397.272877,
       "supported_languages": null
     },
     "macro.dbt.default__snapshot_merge_sql": {
@@ -4343,7 +4450,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787951.998975,
+      "created_at": 1716931397.2731168,
       "supported_languages": null
     },
     "macro.dbt.strategy_dispatch": {
@@ -4365,7 +4472,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.002356,
+      "created_at": 1716931397.2764428,
       "supported_languages": null
     },
     "macro.dbt.snapshot_hash_arguments": {
@@ -4389,7 +4496,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0025191,
+      "created_at": 1716931397.276601,
       "supported_languages": null
     },
     "macro.dbt.default__snapshot_hash_arguments": {
@@ -4411,7 +4518,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.002731,
+      "created_at": 1716931397.2768111,
       "supported_languages": null
     },
     "macro.dbt.snapshot_timestamp_strategy": {
@@ -4435,7 +4542,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.003478,
+      "created_at": 1716931397.2774558,
       "supported_languages": null
     },
     "macro.dbt.snapshot_string_as_time": {
@@ -4459,7 +4566,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0036402,
+      "created_at": 1716931397.277616,
       "supported_languages": null
     },
     "macro.dbt.default__snapshot_string_as_time": {
@@ -4481,7 +4588,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0038059,
+      "created_at": 1716931397.277772,
       "supported_languages": null
     },
     "macro.dbt.snapshot_check_all_get_existing_columns": {
@@ -4505,7 +4612,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.005159,
+      "created_at": 1716931397.279017,
       "supported_languages": null
     },
     "macro.dbt.snapshot_check_strategy": {
@@ -4532,7 +4639,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0064158,
+      "created_at": 1716931397.280234,
       "supported_languages": null
     },
     "macro.dbt.create_columns": {
@@ -4556,7 +4663,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0103848,
+      "created_at": 1716931397.284222,
       "supported_languages": null
     },
     "macro.dbt.default__create_columns": {
@@ -4580,7 +4687,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.010658,
+      "created_at": 1716931397.284477,
       "supported_languages": null
     },
     "macro.dbt.post_snapshot": {
@@ -4604,7 +4711,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0108202,
+      "created_at": 1716931397.284634,
       "supported_languages": null
     },
     "macro.dbt.default__post_snapshot": {
@@ -4626,7 +4733,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0109131,
+      "created_at": 1716931397.2847319,
       "supported_languages": null
     },
     "macro.dbt.get_true_sql": {
@@ -4650,7 +4757,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0110562,
+      "created_at": 1716931397.284877,
       "supported_languages": null
     },
     "macro.dbt.default__get_true_sql": {
@@ -4672,7 +4779,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.011168,
+      "created_at": 1716931397.284982,
       "supported_languages": null
     },
     "macro.dbt.snapshot_staging_table": {
@@ -4696,7 +4803,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0113878,
+      "created_at": 1716931397.285169,
       "supported_languages": null
     },
     "macro.dbt.default__snapshot_staging_table": {
@@ -4720,7 +4827,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.012244,
+      "created_at": 1716931397.2859678,
       "supported_languages": null
     },
     "macro.dbt.build_snapshot_table": {
@@ -4744,7 +4851,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0124311,
+      "created_at": 1716931397.286143,
       "supported_languages": null
     },
     "macro.dbt.default__build_snapshot_table": {
@@ -4766,7 +4873,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.012678,
+      "created_at": 1716931397.28637,
       "supported_languages": null
     },
     "macro.dbt.build_snapshot_staging_table": {
@@ -4793,7 +4900,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.013095,
+      "created_at": 1716931397.286756,
       "supported_languages": null
     },
     "macro.dbt.materialization_snapshot_default": {
@@ -4830,7 +4937,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.019259,
+      "created_at": 1716931397.29251,
       "supported_languages": [
         "sql"
       ]
@@ -4859,7 +4966,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.021877,
+      "created_at": 1716931397.2949948,
       "supported_languages": [
         "sql"
       ]
@@ -4885,7 +4992,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0223172,
+      "created_at": 1716931397.2960541,
       "supported_languages": null
     },
     "macro.dbt.default__get_test_sql": {
@@ -4907,7 +5014,55 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.022623,
+      "created_at": 1716931397.296329,
+      "supported_languages": null
+    },
+    "macro.dbt.get_unit_test_sql": {
+      "name": "get_unit_test_sql",
+      "resource_type": "macro",
+      "package_name": "dbt",
+      "path": "macros/materializations/tests/helpers.sql",
+      "original_file_path": "macros/materializations/tests/helpers.sql",
+      "unique_id": "macro.dbt.get_unit_test_sql",
+      "macro_sql": "{% macro get_unit_test_sql(main_sql, expected_fixture_sql, expected_column_names) -%}\n  {{ adapter.dispatch('get_unit_test_sql', 'dbt')(main_sql, expected_fixture_sql, expected_column_names) }}\n{%- endmacro %}",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__get_unit_test_sql"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1716931397.2965188,
+      "supported_languages": null
+    },
+    "macro.dbt.default__get_unit_test_sql": {
+      "name": "default__get_unit_test_sql",
+      "resource_type": "macro",
+      "package_name": "dbt",
+      "path": "macros/materializations/tests/helpers.sql",
+      "original_file_path": "macros/materializations/tests/helpers.sql",
+      "unique_id": "macro.dbt.default__get_unit_test_sql",
+      "macro_sql": "{% macro default__get_unit_test_sql(main_sql, expected_fixture_sql, expected_column_names) -%}\n-- Build actual result given inputs\nwith dbt_internal_unit_test_actual as (\n  select\n    {% for expected_column_name in expected_column_names %}{{expected_column_name}}{% if not loop.last -%},{% endif %}{%- endfor -%}, {{ dbt.string_literal(\"actual\") }} as {{ adapter.quote(\"actual_or_expected\") }}\n  from (\n    {{ main_sql }}\n  ) _dbt_internal_unit_test_actual\n),\n-- Build expected result\ndbt_internal_unit_test_expected as (\n  select\n    {% for expected_column_name in expected_column_names %}{{expected_column_name}}{% if not loop.last -%}, {% endif %}{%- endfor -%}, {{ dbt.string_literal(\"expected\") }} as {{ adapter.quote(\"actual_or_expected\") }}\n  from (\n    {{ expected_fixture_sql }}\n  ) _dbt_internal_unit_test_expected\n)\n-- Union actual and expected results\nselect * from dbt_internal_unit_test_actual\nunion all\nselect * from dbt_internal_unit_test_expected\n{%- endmacro %}",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.string_literal"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1716931397.297065,
       "supported_languages": null
     },
     "macro.dbt.get_where_subquery": {
@@ -4931,7 +5086,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0229828,
+      "created_at": 1716931397.2974179,
       "supported_languages": null
     },
     "macro.dbt.default__get_where_subquery": {
@@ -4953,8 +5108,41 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.023351,
+      "created_at": 1716931397.297764,
       "supported_languages": null
+    },
+    "macro.dbt.materialization_unit_default": {
+      "name": "materialization_unit_default",
+      "resource_type": "macro",
+      "package_name": "dbt",
+      "path": "macros/materializations/tests/unit.sql",
+      "original_file_path": "macros/materializations/tests/unit.sql",
+      "unique_id": "macro.dbt.materialization_unit_default",
+      "macro_sql": "{%- materialization unit, default -%}\n\n  {% set relations = [] %}\n\n  {% set expected_rows = config.get('expected_rows') %}\n  {% set expected_sql = config.get('expected_sql') %}\n  {% set tested_expected_column_names = expected_rows[0].keys() if (expected_rows | length ) > 0 else get_columns_in_query(sql) %} %}\n\n  {%- set target_relation = this.incorporate(type='table') -%}\n  {%- set temp_relation = make_temp_relation(target_relation)-%}\n  {% do run_query(get_create_table_as_sql(True, temp_relation, get_empty_subquery_sql(sql))) %}\n  {%- set columns_in_relation = adapter.get_columns_in_relation(temp_relation) -%}\n  {%- set column_name_to_data_types = {} -%}\n  {%- for column in columns_in_relation -%}\n  {%-   do column_name_to_data_types.update({column.name|lower: column.data_type}) -%}\n  {%- endfor -%}\n\n  {% if not expected_sql %}\n  {%   set expected_sql = get_expected_sql(expected_rows, column_name_to_data_types) %}\n  {% endif %}\n  {% set unit_test_sql = get_unit_test_sql(sql, expected_sql, tested_expected_column_names) %}\n\n  {% call statement('main', fetch_result=True) -%}\n\n    {{ unit_test_sql }}\n\n  {%- endcall %}\n\n  {% do adapter.drop_relation(temp_relation) %}\n\n  {{ return({'relations': relations}) }}\n\n{%- endmaterialization -%}",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.get_columns_in_query",
+          "macro.dbt.make_temp_relation",
+          "macro.dbt.run_query",
+          "macro.dbt.get_create_table_as_sql",
+          "macro.dbt.get_empty_subquery_sql",
+          "macro.dbt.get_expected_sql",
+          "macro.dbt.get_unit_test_sql",
+          "macro.dbt.statement"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1716931397.299365,
+      "supported_languages": [
+        "sql"
+      ]
     },
     "macro.dbt.materialization_materialized_view_default": {
       "name": "materialization_materialized_view_default",
@@ -4984,7 +5172,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.028123,
+      "created_at": 1716931397.3040252,
       "supported_languages": [
         "sql"
       ]
@@ -5012,7 +5200,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0285,
+      "created_at": 1716931397.304379,
       "supported_languages": null
     },
     "macro.dbt.materialized_view_teardown": {
@@ -5037,7 +5225,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.028744,
+      "created_at": 1716931397.304606,
       "supported_languages": null
     },
     "macro.dbt.materialized_view_get_build_sql": {
@@ -5066,7 +5254,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.029984,
+      "created_at": 1716931397.305797,
       "supported_languages": null
     },
     "macro.dbt.materialized_view_execute_no_op": {
@@ -5088,7 +5276,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.030207,
+      "created_at": 1716931397.306008,
       "supported_languages": null
     },
     "macro.dbt.materialized_view_execute_build_sql": {
@@ -5116,7 +5304,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.030842,
+      "created_at": 1716931397.306592,
       "supported_languages": null
     },
     "macro.dbt.materialization_view_default": {
@@ -5149,7 +5337,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.03364,
+      "created_at": 1716931397.309205,
       "supported_languages": [
         "sql"
       ]
@@ -5185,7 +5373,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.036426,
+      "created_at": 1716931397.3118021,
       "supported_languages": [
         "sql"
       ]
@@ -5209,7 +5397,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.03796,
+      "created_at": 1716931397.313302,
       "supported_languages": null
     },
     "macro.dbt.diff_columns": {
@@ -5231,7 +5419,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0384881,
+      "created_at": 1716931397.3137898,
       "supported_languages": null
     },
     "macro.dbt.diff_column_data_types": {
@@ -5253,7 +5441,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.039129,
+      "created_at": 1716931397.314378,
       "supported_languages": null
     },
     "macro.dbt.get_merge_update_columns": {
@@ -5277,7 +5465,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0393531,
+      "created_at": 1716931397.314595,
       "supported_languages": null
     },
     "macro.dbt.default__get_merge_update_columns": {
@@ -5299,7 +5487,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0400379,
+      "created_at": 1716931397.315237,
       "supported_languages": null
     },
     "macro.dbt.get_merge_sql": {
@@ -5323,7 +5511,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.046517,
+      "created_at": 1716931397.3215292,
       "supported_languages": null
     },
     "macro.dbt.default__get_merge_sql": {
@@ -5348,7 +5536,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.048157,
+      "created_at": 1716931397.32301,
       "supported_languages": null
     },
     "macro.dbt.get_delete_insert_merge_sql": {
@@ -5372,7 +5560,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.048425,
+      "created_at": 1716931397.323252,
       "supported_languages": null
     },
     "macro.dbt.default__get_delete_insert_merge_sql": {
@@ -5396,7 +5584,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.04944,
+      "created_at": 1716931397.324178,
       "supported_languages": null
     },
     "macro.dbt.get_insert_overwrite_merge_sql": {
@@ -5420,7 +5608,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.049703,
+      "created_at": 1716931397.3244228,
       "supported_languages": null
     },
     "macro.dbt.default__get_insert_overwrite_merge_sql": {
@@ -5444,7 +5632,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.050338,
+      "created_at": 1716931397.325011,
       "supported_languages": null
     },
     "macro.dbt.is_incremental": {
@@ -5468,7 +5656,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.050959,
+      "created_at": 1716931397.325578,
       "supported_languages": null
     },
     "macro.dbt.get_incremental_append_sql": {
@@ -5492,7 +5680,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0518,
+      "created_at": 1716931397.3263948,
       "supported_languages": null
     },
     "macro.dbt.default__get_incremental_append_sql": {
@@ -5516,7 +5704,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0520372,
+      "created_at": 1716931397.326606,
       "supported_languages": null
     },
     "macro.dbt.get_incremental_delete_insert_sql": {
@@ -5540,7 +5728,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0522199,
+      "created_at": 1716931397.326772,
       "supported_languages": null
     },
     "macro.dbt.default__get_incremental_delete_insert_sql": {
@@ -5564,7 +5752,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0525088,
+      "created_at": 1716931397.327044,
       "supported_languages": null
     },
     "macro.dbt.get_incremental_merge_sql": {
@@ -5588,7 +5776,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.052753,
+      "created_at": 1716931397.327212,
       "supported_languages": null
     },
     "macro.dbt.default__get_incremental_merge_sql": {
@@ -5612,7 +5800,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.053045,
+      "created_at": 1716931397.327483,
       "supported_languages": null
     },
     "macro.dbt.get_incremental_insert_overwrite_sql": {
@@ -5636,7 +5824,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.053225,
+      "created_at": 1716931397.327649,
       "supported_languages": null
     },
     "macro.dbt.default__get_incremental_insert_overwrite_sql": {
@@ -5660,7 +5848,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.053483,
+      "created_at": 1716931397.327889,
       "supported_languages": null
     },
     "macro.dbt.get_incremental_default_sql": {
@@ -5684,7 +5872,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.053663,
+      "created_at": 1716931397.3280609,
       "supported_languages": null
     },
     "macro.dbt.default__get_incremental_default_sql": {
@@ -5708,7 +5896,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0538108,
+      "created_at": 1716931397.328199,
       "supported_languages": null
     },
     "macro.dbt.get_insert_into_sql": {
@@ -5732,7 +5920,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.054076,
+      "created_at": 1716931397.3284569,
       "supported_languages": null
     },
     "macro.dbt.materialization_incremental_default": {
@@ -5771,7 +5959,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.058901,
+      "created_at": 1716931397.333002,
       "supported_languages": [
         "sql"
       ]
@@ -5795,7 +5983,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0643892,
+      "created_at": 1716931397.338381,
       "supported_languages": null
     },
     "macro.dbt.check_for_schema_changes": {
@@ -5820,7 +6008,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0655732,
+      "created_at": 1716931397.3394701,
       "supported_languages": null
     },
     "macro.dbt.sync_column_schemas": {
@@ -5845,7 +6033,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.06673,
+      "created_at": 1716931397.340569,
       "supported_languages": null
     },
     "macro.dbt.process_schema_changes": {
@@ -5870,7 +6058,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.067561,
+      "created_at": 1716931397.341334,
       "supported_languages": null
     },
     "macro.dbt.can_clone_table": {
@@ -5894,7 +6082,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.067791,
+      "created_at": 1716931397.341552,
       "supported_languages": null
     },
     "macro.dbt.default__can_clone_table": {
@@ -5916,7 +6104,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0679061,
+      "created_at": 1716931397.3416588,
       "supported_languages": null
     },
     "macro.dbt.create_or_replace_clone": {
@@ -5940,7 +6128,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.068188,
+      "created_at": 1716931397.3419268,
       "supported_languages": null
     },
     "macro.dbt.default__create_or_replace_clone": {
@@ -5962,7 +6150,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.068319,
+      "created_at": 1716931397.342054,
       "supported_languages": null
     },
     "macro.dbt.materialization_clone_default": {
@@ -5993,7 +6181,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0718532,
+      "created_at": 1716931397.34538,
       "supported_languages": [
         "sql"
       ]
@@ -6029,7 +6217,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.074928,
+      "created_at": 1716931397.348358,
       "supported_languages": [
         "sql"
       ]
@@ -6055,7 +6243,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.079802,
+      "created_at": 1716931397.353214,
       "supported_languages": null
     },
     "macro.dbt.default__create_csv_table": {
@@ -6079,7 +6267,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0806699,
+      "created_at": 1716931397.354007,
       "supported_languages": null
     },
     "macro.dbt.reset_csv_table": {
@@ -6103,7 +6291,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.080897,
+      "created_at": 1716931397.3542268,
       "supported_languages": null
     },
     "macro.dbt.default__reset_csv_table": {
@@ -6127,7 +6315,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.081354,
+      "created_at": 1716931397.354671,
       "supported_languages": null
     },
     "macro.dbt.get_csv_sql": {
@@ -6151,7 +6339,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.08154,
+      "created_at": 1716931397.354871,
       "supported_languages": null
     },
     "macro.dbt.default__get_csv_sql": {
@@ -6173,7 +6361,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0816681,
+      "created_at": 1716931397.35501,
       "supported_languages": null
     },
     "macro.dbt.get_binding_char": {
@@ -6197,7 +6385,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.081805,
+      "created_at": 1716931397.355138,
       "supported_languages": null
     },
     "macro.dbt.default__get_binding_char": {
@@ -6219,7 +6407,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.081915,
+      "created_at": 1716931397.355243,
       "supported_languages": null
     },
     "macro.dbt.get_batch_size": {
@@ -6243,7 +6431,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.082073,
+      "created_at": 1716931397.3553889,
       "supported_languages": null
     },
     "macro.dbt.default__get_batch_size": {
@@ -6265,7 +6453,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.082197,
+      "created_at": 1716931397.355499,
       "supported_languages": null
     },
     "macro.dbt.get_seed_column_quoted_csv": {
@@ -6287,7 +6475,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.082658,
+      "created_at": 1716931397.355922,
       "supported_languages": null
     },
     "macro.dbt.load_csv_rows": {
@@ -6311,7 +6499,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.082836,
+      "created_at": 1716931397.3560908,
       "supported_languages": null
     },
     "macro.dbt.default__load_csv_rows": {
@@ -6337,7 +6525,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.084071,
+      "created_at": 1716931397.357213,
       "supported_languages": null
     },
     "macro.dbt.generate_alias_name": {
@@ -6361,7 +6549,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0844858,
+      "created_at": 1716931397.3576021,
       "supported_languages": null
     },
     "macro.dbt.default__generate_alias_name": {
@@ -6383,7 +6571,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0848489,
+      "created_at": 1716931397.3579469,
       "supported_languages": null
     },
     "macro.dbt.generate_schema_name": {
@@ -6407,7 +6595,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.08536,
+      "created_at": 1716931397.3584268,
       "supported_languages": null
     },
     "macro.dbt.default__generate_schema_name": {
@@ -6429,7 +6617,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.085609,
+      "created_at": 1716931397.3586628,
       "supported_languages": null
     },
     "macro.dbt.generate_schema_name_for_env": {
@@ -6451,7 +6639,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.085883,
+      "created_at": 1716931397.3589199,
       "supported_languages": null
     },
     "macro.dbt.generate_database_name": {
@@ -6475,7 +6663,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.086258,
+      "created_at": 1716931397.3592918,
       "supported_languages": null
     },
     "macro.dbt.default__generate_database_name": {
@@ -6497,7 +6685,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.086498,
+      "created_at": 1716931397.359519,
       "supported_languages": null
     },
     "macro.dbt.get_drop_sql": {
@@ -6521,7 +6709,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0871732,
+      "created_at": 1716931397.36018,
       "supported_languages": null
     },
     "macro.dbt.default__get_drop_sql": {
@@ -6547,7 +6735,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0875351,
+      "created_at": 1716931397.360518,
       "supported_languages": null
     },
     "macro.dbt.drop_relation": {
@@ -6571,7 +6759,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.087716,
+      "created_at": 1716931397.360682,
       "supported_languages": null
     },
     "macro.dbt.default__drop_relation": {
@@ -6596,7 +6784,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0879219,
+      "created_at": 1716931397.3608608,
       "supported_languages": null
     },
     "macro.dbt.drop_relation_if_exists": {
@@ -6618,7 +6806,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.088106,
+      "created_at": 1716931397.361033,
       "supported_languages": null
     },
     "macro.dbt.get_replace_sql": {
@@ -6642,7 +6830,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0888472,
+      "created_at": 1716931397.361749,
       "supported_languages": null
     },
     "macro.dbt.default__get_replace_sql": {
@@ -6674,7 +6862,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.090237,
+      "created_at": 1716931397.362925,
       "supported_languages": null
     },
     "macro.dbt.get_create_intermediate_sql": {
@@ -6698,7 +6886,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.090613,
+      "created_at": 1716931397.363292,
       "supported_languages": null
     },
     "macro.dbt.default__get_create_intermediate_sql": {
@@ -6724,7 +6912,53 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0908532,
+      "created_at": 1716931397.3635159,
+      "supported_languages": null
+    },
+    "macro.dbt.drop_schema_named": {
+      "name": "drop_schema_named",
+      "resource_type": "macro",
+      "package_name": "dbt",
+      "path": "macros/relations/schema.sql",
+      "original_file_path": "macros/relations/schema.sql",
+      "unique_id": "macro.dbt.drop_schema_named",
+      "macro_sql": "{% macro drop_schema_named(schema_name) %}\n    {{ return(adapter.dispatch('drop_schema_named', 'dbt') (schema_name)) }}\n{% endmacro %}",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__drop_schema_named"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1716931397.3637602,
+      "supported_languages": null
+    },
+    "macro.dbt.default__drop_schema_named": {
+      "name": "default__drop_schema_named",
+      "resource_type": "macro",
+      "package_name": "dbt",
+      "path": "macros/relations/schema.sql",
+      "original_file_path": "macros/relations/schema.sql",
+      "unique_id": "macro.dbt.default__drop_schema_named",
+      "macro_sql": "{% macro default__drop_schema_named(schema_name) %}\n  {% set schema_relation = api.Relation.create(schema=schema_name) %}\n  {{ adapter.drop_schema(schema_relation) }}\n{% endmacro %}",
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1716931397.363955,
       "supported_languages": null
     },
     "macro.dbt.get_drop_backup_sql": {
@@ -6748,7 +6982,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.091159,
+      "created_at": 1716931397.3642461,
       "supported_languages": null
     },
     "macro.dbt.default__get_drop_backup_sql": {
@@ -6773,7 +7007,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.091373,
+      "created_at": 1716931397.364434,
       "supported_languages": null
     },
     "macro.dbt.get_rename_sql": {
@@ -6797,7 +7031,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0920398,
+      "created_at": 1716931397.365094,
       "supported_languages": null
     },
     "macro.dbt.default__get_rename_sql": {
@@ -6823,7 +7057,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.092469,
+      "created_at": 1716931397.3654778,
       "supported_languages": null
     },
     "macro.dbt.rename_relation": {
@@ -6847,7 +7081,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.092672,
+      "created_at": 1716931397.3656662,
       "supported_languages": null
     },
     "macro.dbt.default__rename_relation": {
@@ -6871,7 +7105,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0929458,
+      "created_at": 1716931397.365922,
       "supported_languages": null
     },
     "macro.dbt.get_create_backup_sql": {
@@ -6895,7 +7129,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.093292,
+      "created_at": 1716931397.366236,
       "supported_languages": null
     },
     "macro.dbt.default__get_create_backup_sql": {
@@ -6921,7 +7155,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0935512,
+      "created_at": 1716931397.366482,
       "supported_languages": null
     },
     "macro.dbt.get_create_sql": {
@@ -6945,7 +7179,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.094,
+      "created_at": 1716931397.366911,
       "supported_languages": null
     },
     "macro.dbt.default__get_create_sql": {
@@ -6971,7 +7205,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.094432,
+      "created_at": 1716931397.367309,
       "supported_languages": null
     },
     "macro.dbt.get_rename_intermediate_sql": {
@@ -6995,7 +7229,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.094763,
+      "created_at": 1716931397.367606,
       "supported_languages": null
     },
     "macro.dbt.default__get_rename_intermediate_sql": {
@@ -7020,7 +7254,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0949628,
+      "created_at": 1716931397.367796,
       "supported_languages": null
     },
     "macro.dbt.drop_materialized_view": {
@@ -7030,7 +7264,7 @@
       "path": "macros/relations/materialized_view/drop.sql",
       "original_file_path": "macros/relations/materialized_view/drop.sql",
       "unique_id": "macro.dbt.drop_materialized_view",
-      "macro_sql": "{% macro drop_materialized_view(relation) -%}\n    {{ return(adapter.dispatch('drop_materialized_view', 'dbt')(relation)) }}\n{%- endmacro %}",
+      "macro_sql": "{% macro drop_materialized_view(relation) -%}\n    {{- adapter.dispatch('drop_materialized_view', 'dbt')(relation) -}}\n{%- endmacro %}",
       "depends_on": {
         "macros": [
           "macro.dbt.default__drop_materialized_view"
@@ -7044,7 +7278,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0952199,
+      "created_at": 1716931397.368025,
       "supported_languages": null
     },
     "macro.dbt.default__drop_materialized_view": {
@@ -7066,7 +7300,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0953228,
+      "created_at": 1716931397.3681211,
       "supported_languages": null
     },
     "macro.dbt.get_replace_materialized_view_sql": {
@@ -7090,7 +7324,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.095584,
+      "created_at": 1716931397.368381,
       "supported_languages": null
     },
     "macro.dbt.default__get_replace_materialized_view_sql": {
@@ -7112,7 +7346,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.095724,
+      "created_at": 1716931397.368577,
       "supported_languages": null
     },
     "macro.dbt.refresh_materialized_view": {
@@ -7136,7 +7370,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.096019,
+      "created_at": 1716931397.368855,
       "supported_languages": null
     },
     "macro.dbt.default__refresh_materialized_view": {
@@ -7158,7 +7392,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.096205,
+      "created_at": 1716931397.368974,
       "supported_languages": null
     },
     "macro.dbt.get_rename_materialized_view_sql": {
@@ -7182,7 +7416,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.096467,
+      "created_at": 1716931397.369226,
       "supported_languages": null
     },
     "macro.dbt.default__get_rename_materialized_view_sql": {
@@ -7204,7 +7438,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.096608,
+      "created_at": 1716931397.369361,
       "supported_languages": null
     },
     "macro.dbt.get_alter_materialized_view_as_sql": {
@@ -7228,7 +7462,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.097193,
+      "created_at": 1716931397.369928,
       "supported_languages": null
     },
     "macro.dbt.default__get_alter_materialized_view_as_sql": {
@@ -7250,7 +7484,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.097377,
+      "created_at": 1716931397.370115,
       "supported_languages": null
     },
     "macro.dbt.get_materialized_view_configuration_changes": {
@@ -7274,7 +7508,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.097652,
+      "created_at": 1716931397.370384,
       "supported_languages": null
     },
     "macro.dbt.default__get_materialized_view_configuration_changes": {
@@ -7296,7 +7530,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.097793,
+      "created_at": 1716931397.370518,
       "supported_languages": null
     },
     "macro.dbt.get_create_materialized_view_as_sql": {
@@ -7320,7 +7554,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.098054,
+      "created_at": 1716931397.370771,
       "supported_languages": null
     },
     "macro.dbt.default__get_create_materialized_view_as_sql": {
@@ -7342,7 +7576,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.098189,
+      "created_at": 1716931397.370904,
       "supported_languages": null
     },
     "macro.dbt.get_table_columns_and_constraints": {
@@ -7366,7 +7600,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.099156,
+      "created_at": 1716931397.3718479,
       "supported_languages": null
     },
     "macro.dbt.default__get_table_columns_and_constraints": {
@@ -7390,7 +7624,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.099272,
+      "created_at": 1716931397.371962,
       "supported_languages": null
     },
     "macro.dbt.table_columns_and_constraints": {
@@ -7412,7 +7646,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.0998,
+      "created_at": 1716931397.372434,
       "supported_languages": null
     },
     "macro.dbt.get_assert_columns_equivalent": {
@@ -7436,7 +7670,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.09996,
+      "created_at": 1716931397.372583,
       "supported_languages": null
     },
     "macro.dbt.default__get_assert_columns_equivalent": {
@@ -7460,7 +7694,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.100089,
+      "created_at": 1716931397.372706,
       "supported_languages": null
     },
     "macro.dbt.assert_columns_equivalent": {
@@ -7486,7 +7720,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.101402,
+      "created_at": 1716931397.374033,
       "supported_languages": null
     },
     "macro.dbt.format_columns": {
@@ -7510,7 +7744,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.101772,
+      "created_at": 1716931397.3743749,
       "supported_languages": null
     },
     "macro.dbt.default__format_column": {
@@ -7532,7 +7766,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1021068,
+      "created_at": 1716931397.3746839,
       "supported_languages": null
     },
     "macro.dbt.drop_table": {
@@ -7542,7 +7776,7 @@
       "path": "macros/relations/table/drop.sql",
       "original_file_path": "macros/relations/table/drop.sql",
       "unique_id": "macro.dbt.drop_table",
-      "macro_sql": "{% macro drop_table(relation) -%}\n    {{ return(adapter.dispatch('drop_table', 'dbt')(relation)) }}\n{%- endmacro %}",
+      "macro_sql": "{% macro drop_table(relation) -%}\n    {{- adapter.dispatch('drop_table', 'dbt')(relation) -}}\n{%- endmacro %}",
       "depends_on": {
         "macros": [
           "macro.dbt.default__drop_table"
@@ -7556,7 +7790,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1023622,
+      "created_at": 1716931397.374912,
       "supported_languages": null
     },
     "macro.dbt.default__drop_table": {
@@ -7578,7 +7812,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.102464,
+      "created_at": 1716931397.375011,
       "supported_languages": null
     },
     "macro.dbt.get_replace_table_sql": {
@@ -7602,7 +7836,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.102724,
+      "created_at": 1716931397.3752599,
       "supported_languages": null
     },
     "macro.dbt.default__get_replace_table_sql": {
@@ -7624,7 +7858,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1028638,
+      "created_at": 1716931397.375392,
       "supported_languages": null
     },
     "macro.dbt.get_rename_table_sql": {
@@ -7648,7 +7882,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1031208,
+      "created_at": 1716931397.3756402,
       "supported_languages": null
     },
     "macro.dbt.default__get_rename_table_sql": {
@@ -7670,7 +7904,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.103263,
+      "created_at": 1716931397.375772,
       "supported_languages": null
     },
     "macro.dbt.get_create_table_as_sql": {
@@ -7694,7 +7928,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.104074,
+      "created_at": 1716931397.376561,
       "supported_languages": null
     },
     "macro.dbt.default__get_create_table_as_sql": {
@@ -7718,7 +7952,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.104251,
+      "created_at": 1716931397.376729,
       "supported_languages": null
     },
     "macro.dbt.create_table_as": {
@@ -7742,7 +7976,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.104673,
+      "created_at": 1716931397.3771589,
       "supported_languages": null
     },
     "macro.dbt.default__create_table_as": {
@@ -7768,7 +8002,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1053388,
+      "created_at": 1716931397.3777761,
       "supported_languages": null
     },
     "macro.dbt.default__get_column_names": {
@@ -7790,7 +8024,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1057868,
+      "created_at": 1716931397.378191,
       "supported_languages": null
     },
     "macro.dbt.get_select_subquery": {
@@ -7814,7 +8048,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1059682,
+      "created_at": 1716931397.378367,
       "supported_languages": null
     },
     "macro.dbt.default__get_select_subquery": {
@@ -7838,7 +8072,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1061382,
+      "created_at": 1716931397.378528,
       "supported_languages": null
     },
     "macro.dbt.drop_view": {
@@ -7848,7 +8082,7 @@
       "path": "macros/relations/view/drop.sql",
       "original_file_path": "macros/relations/view/drop.sql",
       "unique_id": "macro.dbt.drop_view",
-      "macro_sql": "{% macro drop_view(relation) -%}\n    {{ return(adapter.dispatch('drop_view', 'dbt')(relation)) }}\n{%- endmacro %}",
+      "macro_sql": "{% macro drop_view(relation) -%}\n    {{- adapter.dispatch('drop_view', 'dbt')(relation) -}}\n{%- endmacro %}",
       "depends_on": {
         "macros": [
           "macro.dbt.default__drop_view"
@@ -7862,7 +8096,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.106389,
+      "created_at": 1716931397.378753,
       "supported_languages": null
     },
     "macro.dbt.default__drop_view": {
@@ -7884,7 +8118,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1064918,
+      "created_at": 1716931397.378848,
       "supported_languages": null
     },
     "macro.dbt.get_replace_view_sql": {
@@ -7908,7 +8142,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1072981,
+      "created_at": 1716931397.3796558,
       "supported_languages": null
     },
     "macro.dbt.default__get_replace_view_sql": {
@@ -7930,7 +8164,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.107438,
+      "created_at": 1716931397.3798048,
       "supported_languages": null
     },
     "macro.dbt.create_or_replace_view": {
@@ -7960,7 +8194,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1085818,
+      "created_at": 1716931397.3808699,
       "supported_languages": null
     },
     "macro.dbt.handle_existing_table": {
@@ -7984,7 +8218,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.108771,
+      "created_at": 1716931397.38105,
       "supported_languages": null
     },
     "macro.dbt.default__handle_existing_table": {
@@ -8006,7 +8240,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1089852,
+      "created_at": 1716931397.381247,
       "supported_languages": null
     },
     "macro.dbt.get_rename_view_sql": {
@@ -8030,7 +8264,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1092439,
+      "created_at": 1716931397.381506,
       "supported_languages": null
     },
     "macro.dbt.default__get_rename_view_sql": {
@@ -8052,7 +8286,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1093829,
+      "created_at": 1716931397.3816378,
       "supported_languages": null
     },
     "macro.dbt.get_create_view_as_sql": {
@@ -8076,7 +8310,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1097758,
+      "created_at": 1716931397.382016,
       "supported_languages": null
     },
     "macro.dbt.default__get_create_view_as_sql": {
@@ -8100,7 +8334,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1099331,
+      "created_at": 1716931397.382164,
       "supported_languages": null
     },
     "macro.dbt.create_view_as": {
@@ -8124,7 +8358,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.110107,
+      "created_at": 1716931397.382327,
       "supported_languages": null
     },
     "macro.dbt.default__create_view_as": {
@@ -8148,7 +8382,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.110512,
+      "created_at": 1716931397.382708,
       "supported_languages": null
     },
     "macro.dbt.default__test_relationships": {
@@ -8170,7 +8404,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.110844,
+      "created_at": 1716931397.383028,
       "supported_languages": null
     },
     "macro.dbt.default__test_not_null": {
@@ -8194,7 +8428,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.11113,
+      "created_at": 1716931397.3832939,
       "supported_languages": null
     },
     "macro.dbt.default__test_unique": {
@@ -8216,7 +8450,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.111382,
+      "created_at": 1716931397.383519,
       "supported_languages": null
     },
     "macro.dbt.default__test_accepted_values": {
@@ -8238,7 +8472,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.111925,
+      "created_at": 1716931397.384031,
       "supported_languages": null
     },
     "macro.dbt.statement": {
@@ -8260,7 +8494,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.11333,
+      "created_at": 1716931397.3854,
       "supported_languages": null
     },
     "macro.dbt.noop_statement": {
@@ -8282,7 +8516,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.113888,
+      "created_at": 1716931397.38592,
       "supported_languages": null
     },
     "macro.dbt.run_query": {
@@ -8306,7 +8540,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.114172,
+      "created_at": 1716931397.386183,
       "supported_languages": null
     },
     "macro.dbt.convert_datetime": {
@@ -8328,7 +8562,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.115937,
+      "created_at": 1716931397.387913,
       "supported_languages": null
     },
     "macro.dbt.dates_in_range": {
@@ -8352,7 +8586,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1171541,
+      "created_at": 1716931397.389045,
       "supported_languages": null
     },
     "macro.dbt.partition_range": {
@@ -8376,7 +8610,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.117878,
+      "created_at": 1716931397.3897128,
       "supported_languages": null
     },
     "macro.dbt.py_current_timestring": {
@@ -8398,7 +8632,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1181061,
+      "created_at": 1716931397.389924,
       "supported_languages": null
     },
     "macro.dbt.except": {
@@ -8422,7 +8656,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.118325,
+      "created_at": 1716931397.390133,
       "supported_languages": null
     },
     "macro.dbt.default__except": {
@@ -8444,7 +8678,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.118399,
+      "created_at": 1716931397.3902059,
       "supported_languages": null
     },
     "macro.dbt.get_intervals_between": {
@@ -8468,7 +8702,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.119116,
+      "created_at": 1716931397.390903,
       "supported_languages": null
     },
     "macro.dbt.default__get_intervals_between": {
@@ -8493,7 +8727,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.11969,
+      "created_at": 1716931397.391437,
       "supported_languages": null
     },
     "macro.dbt.date_spine": {
@@ -8517,7 +8751,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.119915,
+      "created_at": 1716931397.391644,
       "supported_languages": null
     },
     "macro.dbt.default__date_spine": {
@@ -8543,7 +8777,53 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1202738,
+      "created_at": 1716931397.3919911,
+      "supported_languages": null
+    },
+    "macro.dbt.date": {
+      "name": "date",
+      "resource_type": "macro",
+      "package_name": "dbt",
+      "path": "macros/utils/date.sql",
+      "original_file_path": "macros/utils/date.sql",
+      "unique_id": "macro.dbt.date",
+      "macro_sql": "{% macro date(year, month, day) %}\n  {{ return(adapter.dispatch('date', 'dbt') (year, month, day)) }}\n{% endmacro %}",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.default__date"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1716931397.39232,
+      "supported_languages": null
+    },
+    "macro.dbt.default__date": {
+      "name": "default__date",
+      "resource_type": "macro",
+      "package_name": "dbt",
+      "path": "macros/utils/date.sql",
+      "original_file_path": "macros/utils/date.sql",
+      "unique_id": "macro.dbt.default__date",
+      "macro_sql": "{% macro default__date(year, month, day) -%}\n    {%- set dt = modules.datetime.date(year, month, day) -%}\n    {%- set iso_8601_formatted_date = dt.strftime('%Y-%m-%d') -%}\n    to_date('{{ iso_8601_formatted_date }}', 'YYYY-MM-DD')\n{%- endmacro %}",
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1716931397.3925738,
       "supported_languages": null
     },
     "macro.dbt.replace": {
@@ -8567,7 +8847,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1205912,
+      "created_at": 1716931397.392877,
       "supported_languages": null
     },
     "macro.dbt.default__replace": {
@@ -8589,7 +8869,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.120752,
+      "created_at": 1716931397.393026,
       "supported_languages": null
     },
     "macro.dbt.concat": {
@@ -8613,7 +8893,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.120987,
+      "created_at": 1716931397.393249,
       "supported_languages": null
     },
     "macro.dbt.default__concat": {
@@ -8635,7 +8915,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1211038,
+      "created_at": 1716931397.393363,
       "supported_languages": null
     },
     "macro.dbt.get_powers_of_two": {
@@ -8659,7 +8939,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1218922,
+      "created_at": 1716931397.3941371,
       "supported_languages": null
     },
     "macro.dbt.default__get_powers_of_two": {
@@ -8681,7 +8961,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1222951,
+      "created_at": 1716931397.394509,
       "supported_languages": null
     },
     "macro.dbt.generate_series": {
@@ -8705,7 +8985,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.122475,
+      "created_at": 1716931397.394681,
       "supported_languages": null
     },
     "macro.dbt.default__generate_series": {
@@ -8729,7 +9009,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.122977,
+      "created_at": 1716931397.395138,
       "supported_languages": null
     },
     "macro.dbt.length": {
@@ -8753,7 +9033,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.123221,
+      "created_at": 1716931397.395371,
       "supported_languages": null
     },
     "macro.dbt.default__length": {
@@ -8775,7 +9055,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.123323,
+      "created_at": 1716931397.395467,
       "supported_languages": null
     },
     "macro.dbt.dateadd": {
@@ -8799,7 +9079,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.123647,
+      "created_at": 1716931397.395774,
       "supported_languages": null
     },
     "macro.dbt.default__dateadd": {
@@ -8821,7 +9101,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.123808,
+      "created_at": 1716931397.395992,
       "supported_languages": null
     },
     "macro.dbt.intersect": {
@@ -8845,7 +9125,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.124022,
+      "created_at": 1716931397.396199,
       "supported_languages": null
     },
     "macro.dbt.default__intersect": {
@@ -8867,7 +9147,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1241589,
+      "created_at": 1716931397.39627,
       "supported_languages": null
     },
     "macro.dbt.escape_single_quotes": {
@@ -8891,7 +9171,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1244102,
+      "created_at": 1716931397.396523,
       "supported_languages": null
     },
     "macro.dbt.default__escape_single_quotes": {
@@ -8913,7 +9193,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.124545,
+      "created_at": 1716931397.396652,
       "supported_languages": null
     },
     "macro.dbt.right": {
@@ -8937,7 +9217,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.124824,
+      "created_at": 1716931397.396917,
       "supported_languages": null
     },
     "macro.dbt.default__right": {
@@ -8959,7 +9239,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.124956,
+      "created_at": 1716931397.3970401,
       "supported_languages": null
     },
     "macro.dbt.listagg": {
@@ -8983,7 +9263,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.125569,
+      "created_at": 1716931397.3976278,
       "supported_languages": null
     },
     "macro.dbt.default__listagg": {
@@ -9005,7 +9285,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.125962,
+      "created_at": 1716931397.397992,
       "supported_languages": null
     },
     "macro.dbt.datediff": {
@@ -9029,7 +9309,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1262841,
+      "created_at": 1716931397.398301,
       "supported_languages": null
     },
     "macro.dbt.default__datediff": {
@@ -9051,7 +9331,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.126441,
+      "created_at": 1716931397.398454,
       "supported_languages": null
     },
     "macro.dbt.safe_cast": {
@@ -9075,7 +9355,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.126716,
+      "created_at": 1716931397.39871,
       "supported_languages": null
     },
     "macro.dbt.default__safe_cast": {
@@ -9097,7 +9377,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.126852,
+      "created_at": 1716931397.398837,
       "supported_languages": null
     },
     "macro.dbt.hash": {
@@ -9121,7 +9401,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.127098,
+      "created_at": 1716931397.3990688,
       "supported_languages": null
     },
     "macro.dbt.default__hash": {
@@ -9143,7 +9423,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1272562,
+      "created_at": 1716931397.399222,
       "supported_languages": null
     },
     "macro.dbt.cast_bool_to_text": {
@@ -9167,7 +9447,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.127489,
+      "created_at": 1716931397.399442,
       "supported_languages": null
     },
     "macro.dbt.default__cast_bool_to_text": {
@@ -9189,7 +9469,53 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1276412,
+      "created_at": 1716931397.399584,
+      "supported_languages": null
+    },
+    "macro.dbt.cast": {
+      "name": "cast",
+      "resource_type": "macro",
+      "package_name": "dbt",
+      "path": "macros/utils/cast.sql",
+      "original_file_path": "macros/utils/cast.sql",
+      "unique_id": "macro.dbt.cast",
+      "macro_sql": "{% macro cast(field, type) %}\n  {{ return(adapter.dispatch('cast', 'dbt') (field, type)) }}\n{% endmacro %}",
+      "depends_on": {
+        "macros": [
+          "macro.dbt_snowflake.snowflake__cast"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1716931397.399837,
+      "supported_languages": null
+    },
+    "macro.dbt.default__cast": {
+      "name": "default__cast",
+      "resource_type": "macro",
+      "package_name": "dbt",
+      "path": "macros/utils/cast.sql",
+      "original_file_path": "macros/utils/cast.sql",
+      "unique_id": "macro.dbt.default__cast",
+      "macro_sql": "{% macro default__cast(field, type) %}\n    cast({{field}} as {{type}})\n{% endmacro %}",
+      "depends_on": {
+        "macros": []
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1716931397.3999648,
       "supported_languages": null
     },
     "macro.dbt.any_value": {
@@ -9213,7 +9539,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.127894,
+      "created_at": 1716931397.4002151,
       "supported_languages": null
     },
     "macro.dbt.default__any_value": {
@@ -9235,7 +9561,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.128266,
+      "created_at": 1716931397.400374,
       "supported_languages": null
     },
     "macro.dbt.position": {
@@ -9259,7 +9585,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.128623,
+      "created_at": 1716931397.400634,
       "supported_languages": null
     },
     "macro.dbt.default__position": {
@@ -9281,7 +9607,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.128775,
+      "created_at": 1716931397.4007602,
       "supported_languages": null
     },
     "macro.dbt.string_literal": {
@@ -9305,7 +9631,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.129044,
+      "created_at": 1716931397.40098,
       "supported_languages": null
     },
     "macro.dbt.default__string_literal": {
@@ -9327,7 +9653,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.129249,
+      "created_at": 1716931397.401074,
       "supported_languages": null
     },
     "macro.dbt.type_string": {
@@ -9351,7 +9677,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.130222,
+      "created_at": 1716931397.401932,
       "supported_languages": null
     },
     "macro.dbt.default__type_string": {
@@ -9373,7 +9699,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.130392,
+      "created_at": 1716931397.4020941,
       "supported_languages": null
     },
     "macro.dbt.type_timestamp": {
@@ -9397,7 +9723,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1305652,
+      "created_at": 1716931397.402242,
       "supported_languages": null
     },
     "macro.dbt.default__type_timestamp": {
@@ -9419,7 +9745,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.130729,
+      "created_at": 1716931397.402378,
       "supported_languages": null
     },
     "macro.dbt.type_float": {
@@ -9443,7 +9769,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.130904,
+      "created_at": 1716931397.402526,
       "supported_languages": null
     },
     "macro.dbt.default__type_float": {
@@ -9465,7 +9791,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1310651,
+      "created_at": 1716931397.4026618,
       "supported_languages": null
     },
     "macro.dbt.type_numeric": {
@@ -9489,7 +9815,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.131236,
+      "created_at": 1716931397.402806,
       "supported_languages": null
     },
     "macro.dbt.default__type_numeric": {
@@ -9511,7 +9837,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.131424,
+      "created_at": 1716931397.402967,
       "supported_languages": null
     },
     "macro.dbt.type_bigint": {
@@ -9535,7 +9861,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.131598,
+      "created_at": 1716931397.403112,
       "supported_languages": null
     },
     "macro.dbt.default__type_bigint": {
@@ -9557,7 +9883,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.131758,
+      "created_at": 1716931397.403251,
       "supported_languages": null
     },
     "macro.dbt.type_int": {
@@ -9581,7 +9907,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.131926,
+      "created_at": 1716931397.4034061,
       "supported_languages": null
     },
     "macro.dbt.default__type_int": {
@@ -9603,7 +9929,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.132083,
+      "created_at": 1716931397.4035368,
       "supported_languages": null
     },
     "macro.dbt.type_boolean": {
@@ -9627,7 +9953,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.132255,
+      "created_at": 1716931397.403682,
       "supported_languages": null
     },
     "macro.dbt.default__type_boolean": {
@@ -9649,7 +9975,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.132405,
+      "created_at": 1716931397.4038138,
       "supported_languages": null
     },
     "macro.dbt.array_concat": {
@@ -9673,7 +9999,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1327019,
+      "created_at": 1716931397.404072,
       "supported_languages": null
     },
     "macro.dbt.default__array_concat": {
@@ -9695,7 +10021,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.132842,
+      "created_at": 1716931397.404259,
       "supported_languages": null
     },
     "macro.dbt.bool_or": {
@@ -9719,7 +10045,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.133101,
+      "created_at": 1716931397.40448,
       "supported_languages": null
     },
     "macro.dbt.default__bool_or": {
@@ -9741,7 +10067,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.133211,
+      "created_at": 1716931397.404574,
       "supported_languages": null
     },
     "macro.dbt.last_day": {
@@ -9765,7 +10091,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.133572,
+      "created_at": 1716931397.404887,
       "supported_languages": null
     },
     "macro.dbt.default_last_day": {
@@ -9790,7 +10116,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.133926,
+      "created_at": 1716931397.4051259,
       "supported_languages": null
     },
     "macro.dbt.default__last_day": {
@@ -9814,7 +10140,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.134089,
+      "created_at": 1716931397.4052732,
       "supported_languages": null
     },
     "macro.dbt.split_part": {
@@ -9838,7 +10164,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.134659,
+      "created_at": 1716931397.405757,
       "supported_languages": null
     },
     "macro.dbt.default__split_part": {
@@ -9860,7 +10186,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1348422,
+      "created_at": 1716931397.405905,
       "supported_languages": null
     },
     "macro.dbt._split_part_negative": {
@@ -9882,7 +10208,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.135071,
+      "created_at": 1716931397.4061089,
       "supported_languages": null
     },
     "macro.dbt.date_trunc": {
@@ -9906,7 +10232,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.135354,
+      "created_at": 1716931397.406357,
       "supported_languages": null
     },
     "macro.dbt.default__date_trunc": {
@@ -9928,7 +10254,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.135487,
+      "created_at": 1716931397.4064782,
       "supported_languages": null
     },
     "macro.dbt.array_construct": {
@@ -9952,7 +10278,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.135874,
+      "created_at": 1716931397.406815,
       "supported_languages": null
     },
     "macro.dbt.default__array_construct": {
@@ -9974,7 +10300,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.13613,
+      "created_at": 1716931397.4070468,
       "supported_languages": null
     },
     "macro.dbt.array_append": {
@@ -9998,7 +10324,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.136419,
+      "created_at": 1716931397.4073331,
       "supported_languages": null
     },
     "macro.dbt.default__array_append": {
@@ -10020,7 +10346,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1365561,
+      "created_at": 1716931397.407454,
       "supported_languages": null
     },
     "macro.dbt.create_schema": {
@@ -10044,7 +10370,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.136936,
+      "created_at": 1716931397.407797,
       "supported_languages": null
     },
     "macro.dbt.default__create_schema": {
@@ -10068,7 +10394,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.137131,
+      "created_at": 1716931397.4079611,
       "supported_languages": null
     },
     "macro.dbt.drop_schema": {
@@ -10092,7 +10418,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.137297,
+      "created_at": 1716931397.408107,
       "supported_languages": null
     },
     "macro.dbt.default__drop_schema": {
@@ -10116,7 +10442,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1374872,
+      "created_at": 1716931397.4082701,
       "supported_languages": null
     },
     "macro.dbt.current_timestamp": {
@@ -10140,7 +10466,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.137982,
+      "created_at": 1716931397.408722,
       "supported_languages": null
     },
     "macro.dbt.default__current_timestamp": {
@@ -10162,7 +10488,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.138145,
+      "created_at": 1716931397.4089222,
       "supported_languages": null
     },
     "macro.dbt.snapshot_get_time": {
@@ -10186,7 +10512,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.138295,
+      "created_at": 1716931397.409054,
       "supported_languages": null
     },
     "macro.dbt.default__snapshot_get_time": {
@@ -10210,7 +10536,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1384032,
+      "created_at": 1716931397.409152,
       "supported_languages": null
     },
     "macro.dbt.current_timestamp_backcompat": {
@@ -10234,7 +10560,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.138579,
+      "created_at": 1716931397.409301,
       "supported_languages": null
     },
     "macro.dbt.default__current_timestamp_backcompat": {
@@ -10256,7 +10582,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.138659,
+      "created_at": 1716931397.409374,
       "supported_languages": null
     },
     "macro.dbt.current_timestamp_in_utc_backcompat": {
@@ -10280,7 +10606,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.138908,
+      "created_at": 1716931397.409525,
       "supported_languages": null
     },
     "macro.dbt.default__current_timestamp_in_utc_backcompat": {
@@ -10305,7 +10631,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1390789,
+      "created_at": 1716931397.409676,
       "supported_languages": null
     },
     "macro.dbt.get_create_index_sql": {
@@ -10329,7 +10655,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.139929,
+      "created_at": 1716931397.410458,
       "supported_languages": null
     },
     "macro.dbt.default__get_create_index_sql": {
@@ -10351,7 +10677,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.140073,
+      "created_at": 1716931397.410582,
       "supported_languages": null
     },
     "macro.dbt.create_indexes": {
@@ -10375,7 +10701,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1402361,
+      "created_at": 1716931397.4107242,
       "supported_languages": null
     },
     "macro.dbt.default__create_indexes": {
@@ -10400,7 +10726,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.140667,
+      "created_at": 1716931397.411081,
       "supported_languages": null
     },
     "macro.dbt.get_drop_index_sql": {
@@ -10424,7 +10750,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.140864,
+      "created_at": 1716931397.411247,
       "supported_languages": null
     },
     "macro.dbt.default__get_drop_index_sql": {
@@ -10446,7 +10772,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.141006,
+      "created_at": 1716931397.411372,
       "supported_languages": null
     },
     "macro.dbt.get_show_indexes_sql": {
@@ -10470,7 +10796,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.141174,
+      "created_at": 1716931397.411513,
       "supported_languages": null
     },
     "macro.dbt.default__get_show_indexes_sql": {
@@ -10492,7 +10818,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.141304,
+      "created_at": 1716931397.411626,
       "supported_languages": null
     },
     "macro.dbt.make_intermediate_relation": {
@@ -10516,7 +10842,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.143362,
+      "created_at": 1716931397.4135091,
       "supported_languages": null
     },
     "macro.dbt.default__make_intermediate_relation": {
@@ -10540,7 +10866,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1435351,
+      "created_at": 1716931397.413656,
       "supported_languages": null
     },
     "macro.dbt.make_temp_relation": {
@@ -10564,7 +10890,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1437619,
+      "created_at": 1716931397.41385,
       "supported_languages": null
     },
     "macro.dbt.default__make_temp_relation": {
@@ -10586,7 +10912,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.144066,
+      "created_at": 1716931397.414109,
       "supported_languages": null
     },
     "macro.dbt.make_backup_relation": {
@@ -10610,7 +10936,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.144316,
+      "created_at": 1716931397.414387,
       "supported_languages": null
     },
     "macro.dbt.default__make_backup_relation": {
@@ -10632,7 +10958,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.144644,
+      "created_at": 1716931397.4146729,
       "supported_languages": null
     },
     "macro.dbt.truncate_relation": {
@@ -10656,7 +10982,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1448379,
+      "created_at": 1716931397.41484,
       "supported_languages": null
     },
     "macro.dbt.default__truncate_relation": {
@@ -10680,7 +11006,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1450088,
+      "created_at": 1716931397.414995,
       "supported_languages": null
     },
     "macro.dbt.get_or_create_relation": {
@@ -10704,7 +11030,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1452658,
+      "created_at": 1716931397.415242,
       "supported_languages": null
     },
     "macro.dbt.default__get_or_create_relation": {
@@ -10726,7 +11052,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.145921,
+      "created_at": 1716931397.415756,
       "supported_languages": null
     },
     "macro.dbt.load_cached_relation": {
@@ -10748,7 +11074,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.146165,
+      "created_at": 1716931397.415967,
       "supported_languages": null
     },
     "macro.dbt.load_relation": {
@@ -10772,7 +11098,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1475651,
+      "created_at": 1716931397.4160929,
       "supported_languages": null
     },
     "macro.dbt.collect_freshness": {
@@ -10796,7 +11122,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.148119,
+      "created_at": 1716931397.416468,
       "supported_languages": null
     },
     "macro.dbt.default__collect_freshness": {
@@ -10821,7 +11147,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.148584,
+      "created_at": 1716931397.416834,
       "supported_languages": null
     },
     "macro.dbt.validate_sql": {
@@ -10845,7 +11171,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.14893,
+      "created_at": 1716931397.417089,
       "supported_languages": null
     },
     "macro.dbt.default__validate_sql": {
@@ -10869,7 +11195,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.149214,
+      "created_at": 1716931397.41729,
       "supported_languages": null
     },
     "macro.dbt.copy_grants": {
@@ -10893,7 +11219,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.151168,
+      "created_at": 1716931397.418891,
       "supported_languages": null
     },
     "macro.dbt.default__copy_grants": {
@@ -10915,7 +11241,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.151316,
+      "created_at": 1716931397.418997,
       "supported_languages": null
     },
     "macro.dbt.support_multiple_grantees_per_dcl_statement": {
@@ -10939,7 +11265,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.151503,
+      "created_at": 1716931397.419146,
       "supported_languages": null
     },
     "macro.dbt.default__support_multiple_grantees_per_dcl_statement": {
@@ -10961,7 +11287,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.151628,
+      "created_at": 1716931397.4192472,
       "supported_languages": null
     },
     "macro.dbt.should_revoke": {
@@ -10985,7 +11311,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.151992,
+      "created_at": 1716931397.4195719,
       "supported_languages": null
     },
     "macro.dbt.get_show_grant_sql": {
@@ -11009,7 +11335,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.15219,
+      "created_at": 1716931397.419738,
       "supported_languages": null
     },
     "macro.dbt.default__get_show_grant_sql": {
@@ -11031,7 +11357,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.15229,
+      "created_at": 1716931397.419837,
       "supported_languages": null
     },
     "macro.dbt.get_grant_sql": {
@@ -11055,7 +11381,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.152509,
+      "created_at": 1716931397.420042,
       "supported_languages": null
     },
     "macro.dbt.default__get_grant_sql": {
@@ -11077,7 +11403,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.15271,
+      "created_at": 1716931397.420275,
       "supported_languages": null
     },
     "macro.dbt.get_revoke_sql": {
@@ -11101,7 +11427,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.152946,
+      "created_at": 1716931397.420477,
       "supported_languages": null
     },
     "macro.dbt.default__get_revoke_sql": {
@@ -11123,7 +11449,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.153128,
+      "created_at": 1716931397.420646,
       "supported_languages": null
     },
     "macro.dbt.get_dcl_statement_list": {
@@ -11147,7 +11473,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.153343,
+      "created_at": 1716931397.420853,
       "supported_languages": null
     },
     "macro.dbt.default__get_dcl_statement_list": {
@@ -11171,7 +11497,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.154098,
+      "created_at": 1716931397.4214568,
       "supported_languages": null
     },
     "macro.dbt.call_dcl_statements": {
@@ -11195,7 +11521,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.154279,
+      "created_at": 1716931397.421628,
       "supported_languages": null
     },
     "macro.dbt.default__call_dcl_statements": {
@@ -11219,7 +11545,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.154512,
+      "created_at": 1716931397.421846,
       "supported_languages": null
     },
     "macro.dbt.apply_grants": {
@@ -11243,7 +11569,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.154758,
+      "created_at": 1716931397.422063,
       "supported_languages": null
     },
     "macro.dbt.default__apply_grants": {
@@ -11270,7 +11596,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1559281,
+      "created_at": 1716931397.423102,
       "supported_languages": null
     },
     "macro.dbt.get_show_sql": {
@@ -11294,7 +11620,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1564841,
+      "created_at": 1716931397.4235818,
       "supported_languages": null
     },
     "macro.dbt.get_limit_subquery_sql": {
@@ -11318,7 +11644,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.156683,
+      "created_at": 1716931397.423755,
       "supported_languages": null
     },
     "macro.dbt.default__get_limit_subquery_sql": {
@@ -11340,7 +11666,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1568232,
+      "created_at": 1716931397.423878,
       "supported_languages": null
     },
     "macro.dbt.alter_column_comment": {
@@ -11364,7 +11690,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1575098,
+      "created_at": 1716931397.4244952,
       "supported_languages": null
     },
     "macro.dbt.default__alter_column_comment": {
@@ -11386,7 +11712,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1576838,
+      "created_at": 1716931397.4246469,
       "supported_languages": null
     },
     "macro.dbt.alter_relation_comment": {
@@ -11410,7 +11736,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.157898,
+      "created_at": 1716931397.424829,
       "supported_languages": null
     },
     "macro.dbt.default__alter_relation_comment": {
@@ -11432,7 +11758,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.158068,
+      "created_at": 1716931397.42498,
       "supported_languages": null
     },
     "macro.dbt.persist_docs": {
@@ -11456,7 +11782,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.158331,
+      "created_at": 1716931397.425219,
       "supported_languages": null
     },
     "macro.dbt.default__persist_docs": {
@@ -11482,7 +11808,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.158824,
+      "created_at": 1716931397.4257002,
       "supported_languages": null
     },
     "macro.dbt.get_catalog_relations": {
@@ -11506,7 +11832,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.16176,
+      "created_at": 1716931397.4283872,
       "supported_languages": null
     },
     "macro.dbt.default__get_catalog_relations": {
@@ -11528,7 +11854,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.162035,
+      "created_at": 1716931397.428617,
       "supported_languages": null
     },
     "macro.dbt.get_catalog": {
@@ -11552,7 +11878,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.162237,
+      "created_at": 1716931397.428798,
       "supported_languages": null
     },
     "macro.dbt.default__get_catalog": {
@@ -11574,7 +11900,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.162484,
+      "created_at": 1716931397.4290318,
       "supported_languages": null
     },
     "macro.dbt.information_schema_name": {
@@ -11598,7 +11924,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.162681,
+      "created_at": 1716931397.4291961,
       "supported_languages": null
     },
     "macro.dbt.default__information_schema_name": {
@@ -11620,7 +11946,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.162842,
+      "created_at": 1716931397.42934,
       "supported_languages": null
     },
     "macro.dbt.list_schemas": {
@@ -11644,7 +11970,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.163028,
+      "created_at": 1716931397.429502,
       "supported_languages": null
     },
     "macro.dbt.default__list_schemas": {
@@ -11669,7 +11995,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.163337,
+      "created_at": 1716931397.4297202,
       "supported_languages": null
     },
     "macro.dbt.check_schema_exists": {
@@ -11693,7 +12019,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1635299,
+      "created_at": 1716931397.429922,
       "supported_languages": null
     },
     "macro.dbt.default__check_schema_exists": {
@@ -11718,7 +12044,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1638458,
+      "created_at": 1716931397.430212,
       "supported_languages": null
     },
     "macro.dbt.list_relations_without_caching": {
@@ -11742,7 +12068,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.164039,
+      "created_at": 1716931397.430378,
       "supported_languages": null
     },
     "macro.dbt.default__list_relations_without_caching": {
@@ -11764,7 +12090,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.16419,
+      "created_at": 1716931397.430518,
       "supported_languages": null
     },
     "macro.dbt.get_relations": {
@@ -11788,7 +12114,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.164347,
+      "created_at": 1716931397.430665,
       "supported_languages": null
     },
     "macro.dbt.default__get_relations": {
@@ -11810,7 +12136,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.164493,
+      "created_at": 1716931397.430805,
       "supported_languages": null
     },
     "macro.dbt.get_relation_last_modified": {
@@ -11834,7 +12160,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.164709,
+      "created_at": 1716931397.43099,
       "supported_languages": null
     },
     "macro.dbt.default__get_relation_last_modified": {
@@ -11856,7 +12182,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1648881,
+      "created_at": 1716931397.4311419,
       "supported_languages": null
     },
     "macro.dbt.get_columns_in_relation": {
@@ -11880,7 +12206,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.167129,
+      "created_at": 1716931397.433256,
       "supported_languages": null
     },
     "macro.dbt.default__get_columns_in_relation": {
@@ -11902,7 +12228,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.167286,
+      "created_at": 1716931397.433405,
       "supported_languages": null
     },
     "macro.dbt.sql_convert_columns_in_relation": {
@@ -11924,7 +12250,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.167618,
+      "created_at": 1716931397.4337401,
       "supported_languages": null
     },
     "macro.dbt.get_empty_subquery_sql": {
@@ -11948,7 +12274,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.167835,
+      "created_at": 1716931397.43394,
       "supported_languages": null
     },
     "macro.dbt.default__get_empty_subquery_sql": {
@@ -11970,7 +12296,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1680279,
+      "created_at": 1716931397.434125,
       "supported_languages": null
     },
     "macro.dbt.get_empty_schema_sql": {
@@ -11994,7 +12320,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.168201,
+      "created_at": 1716931397.434294,
       "supported_languages": null
     },
     "macro.dbt.default__get_empty_schema_sql": {
@@ -12004,9 +12330,11 @@
       "path": "macros/adapters/columns.sql",
       "original_file_path": "macros/adapters/columns.sql",
       "unique_id": "macro.dbt.default__get_empty_schema_sql",
-      "macro_sql": "{% macro default__get_empty_schema_sql(columns) %}\n    {%- set col_err = [] -%}\n    {%- set col_naked_numeric = [] -%}\n    select\n    {% for i in columns %}\n      {%- set col = columns[i] -%}\n      {%- if col['data_type'] is not defined -%}\n        {%- do col_err.append(col['name']) -%}\n      {#-- If this column's type is just 'numeric' then it is missing precision/scale, raise a warning --#}\n      {%- elif col['data_type'].strip().lower() in ('numeric', 'decimal', 'number') -%}\n        {%- do col_naked_numeric.append(col['name']) -%}\n      {%- endif -%}\n      {% set col_name = adapter.quote(col['name']) if col.get('quote') else col['name'] %}\n      cast(null as {{ col['data_type'] }}) as {{ col_name }}{{ \", \" if not loop.last }}\n    {%- endfor -%}\n    {%- if (col_err | length) > 0 -%}\n      {{ exceptions.column_type_missing(column_names=col_err) }}\n    {%- elif (col_naked_numeric | length) > 0 -%}\n      {{ exceptions.warn(\"Detected columns with numeric type and unspecified precision/scale, this can lead to unintended rounding: \" ~ col_naked_numeric ~ \"`\") }}\n    {%- endif -%}\n{% endmacro %}",
+      "macro_sql": "{% macro default__get_empty_schema_sql(columns) %}\n    {%- set col_err = [] -%}\n    {%- set col_naked_numeric = [] -%}\n    select\n    {% for i in columns %}\n      {%- set col = columns[i] -%}\n      {%- if col['data_type'] is not defined -%}\n        {%- do col_err.append(col['name']) -%}\n      {#-- If this column's type is just 'numeric' then it is missing precision/scale, raise a warning --#}\n      {%- elif col['data_type'].strip().lower() in ('numeric', 'decimal', 'number') -%}\n        {%- do col_naked_numeric.append(col['name']) -%}\n      {%- endif -%}\n      {% set col_name = adapter.quote(col['name']) if col.get('quote') else col['name'] %}\n      {{ cast('null', col['data_type']) }} as {{ col_name }}{{ \", \" if not loop.last }}\n    {%- endfor -%}\n    {%- if (col_err | length) > 0 -%}\n      {{ exceptions.column_type_missing(column_names=col_err) }}\n    {%- elif (col_naked_numeric | length) > 0 -%}\n      {{ exceptions.warn(\"Detected columns with numeric type and unspecified precision/scale, this can lead to unintended rounding: \" ~ col_naked_numeric ~ \"`\") }}\n    {%- endif -%}\n{% endmacro %}",
       "depends_on": {
-        "macros": []
+        "macros": [
+          "macro.dbt.cast"
+        ]
       },
       "description": "",
       "meta": {},
@@ -12016,7 +12344,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.169528,
+      "created_at": 1716931397.435334,
       "supported_languages": null
     },
     "macro.dbt.get_column_schema_from_query": {
@@ -12040,7 +12368,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.169871,
+      "created_at": 1716931397.435642,
       "supported_languages": null
     },
     "macro.dbt.get_columns_in_query": {
@@ -12064,7 +12392,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.170049,
+      "created_at": 1716931397.4358132,
       "supported_languages": null
     },
     "macro.dbt.default__get_columns_in_query": {
@@ -12089,7 +12417,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1703942,
+      "created_at": 1716931397.43612,
       "supported_languages": null
     },
     "macro.dbt.alter_column_type": {
@@ -12113,7 +12441,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.170627,
+      "created_at": 1716931397.436327,
       "supported_languages": null
     },
     "macro.dbt.default__alter_column_type": {
@@ -12137,7 +12465,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.171206,
+      "created_at": 1716931397.436859,
       "supported_languages": null
     },
     "macro.dbt.alter_relation_add_remove_columns": {
@@ -12161,7 +12489,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.171454,
+      "created_at": 1716931397.437088,
       "supported_languages": null
     },
     "macro.dbt.default__alter_relation_add_remove_columns": {
@@ -12185,7 +12513,83 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1722791,
+      "created_at": 1716931397.437801,
+      "supported_languages": null
+    },
+    "macro.dbt.get_fixture_sql": {
+      "name": "get_fixture_sql",
+      "resource_type": "macro",
+      "package_name": "dbt",
+      "path": "macros/unit_test_sql/get_fixture_sql.sql",
+      "original_file_path": "macros/unit_test_sql/get_fixture_sql.sql",
+      "unique_id": "macro.dbt.get_fixture_sql",
+      "macro_sql": "{% macro get_fixture_sql(rows, column_name_to_data_types) %}\n-- Fixture for {{ model.name }}\n{% set default_row = {} %}\n\n{%- if not column_name_to_data_types -%}\n{#-- Use defer_relation IFF it is available in the manifest and 'this' is missing from the database --#}\n{%-   set this_or_defer_relation = defer_relation if (defer_relation and not load_relation(this)) else this -%}\n{%-   set columns_in_relation = adapter.get_columns_in_relation(this_or_defer_relation) -%}\n\n{%-   set column_name_to_data_types = {} -%}\n{%-   for column in columns_in_relation -%}\n{#-- This needs to be a case-insensitive comparison --#}\n{%-     do column_name_to_data_types.update({column.name|lower: column.data_type}) -%}\n{%-   endfor -%}\n{%- endif -%}\n\n{%- if not column_name_to_data_types -%}\n    {{ exceptions.raise_compiler_error(\"Not able to get columns for unit test '\" ~ model.name ~ \"' from relation \" ~ this) }}\n{%- endif -%}\n\n{%- for column_name, column_type in column_name_to_data_types.items() -%}\n    {%- do default_row.update({column_name: (safe_cast(\"null\", column_type) | trim )}) -%}\n{%- endfor -%}\n\n\n{%- for row in rows -%}\n{%-   set formatted_row = format_row(row, column_name_to_data_types) -%}\n{%-   set default_row_copy = default_row.copy() -%}\n{%-   do default_row_copy.update(formatted_row) -%}\nselect\n{%-   for column_name, column_value in default_row_copy.items() %} {{ column_value }} as {{ column_name }}{% if not loop.last -%}, {%- endif %}\n{%-   endfor %}\n{%-   if not loop.last %}\nunion all\n{%    endif %}\n{%- endfor -%}\n\n{%- if (rows | length) == 0 -%}\n    select\n    {%- for column_name, column_value in default_row.items() %} {{ column_value }} as {{ column_name }}{% if not loop.last -%},{%- endif %}\n    {%- endfor %}\n    limit 0\n{%- endif -%}\n{% endmacro %}",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.load_relation",
+          "macro.dbt.safe_cast",
+          "macro.dbt.format_row"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1716931397.440774,
+      "supported_languages": null
+    },
+    "macro.dbt.get_expected_sql": {
+      "name": "get_expected_sql",
+      "resource_type": "macro",
+      "package_name": "dbt",
+      "path": "macros/unit_test_sql/get_fixture_sql.sql",
+      "original_file_path": "macros/unit_test_sql/get_fixture_sql.sql",
+      "unique_id": "macro.dbt.get_expected_sql",
+      "macro_sql": "{% macro get_expected_sql(rows, column_name_to_data_types) %}\n\n{%- if (rows | length) == 0 -%}\n    select * from dbt_internal_unit_test_actual\n    limit 0\n{%- else -%}\n{%- for row in rows -%}\n{%- set formatted_row = format_row(row, column_name_to_data_types) -%}\nselect\n{%- for column_name, column_value in formatted_row.items() %} {{ column_value }} as {{ column_name }}{% if not loop.last -%}, {%- endif %}\n{%- endfor %}\n{%- if not loop.last %}\nunion all\n{% endif %}\n{%- endfor -%}\n{%- endif -%}\n\n{% endmacro %}",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.format_row"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1716931397.441269,
+      "supported_languages": null
+    },
+    "macro.dbt.format_row": {
+      "name": "format_row",
+      "resource_type": "macro",
+      "package_name": "dbt",
+      "path": "macros/unit_test_sql/get_fixture_sql.sql",
+      "original_file_path": "macros/unit_test_sql/get_fixture_sql.sql",
+      "unique_id": "macro.dbt.format_row",
+      "macro_sql": "\n\n{%- macro format_row(row, column_name_to_data_types) -%}\n    {#-- generate case-insensitive formatted row --#}\n    {% set formatted_row = {} %}\n    {%- for column_name, column_value in row.items() -%}\n        {% set column_name = column_name|lower %}\n\n        {%- if column_name not in column_name_to_data_types %}\n            {#-- if user-provided row contains column name that relation does not contain, raise an error --#}\n            {% set fixture_name = \"expected output\" if model.resource_type == 'unit_test' else (\"'\" ~ model.name ~ \"'\") %}\n            {{ exceptions.raise_compiler_error(\n                \"Invalid column name: '\" ~ column_name ~ \"' in unit test fixture for \" ~ fixture_name ~ \".\"\n                \"\\nAccepted columns for \" ~ fixture_name ~ \" are: \" ~ (column_name_to_data_types.keys()|list)\n            ) }}\n        {%- endif -%}\n\n        {%- set column_type = column_name_to_data_types[column_name] %}\n\n        {#-- sanitize column_value: wrap yaml strings in quotes, apply cast --#}\n        {%- set column_value_clean = column_value -%}\n        {%- if column_value is string -%}\n            {%- set column_value_clean = dbt.string_literal(dbt.escape_single_quotes(column_value)) -%}\n        {%- elif column_value is none -%}\n            {%- set column_value_clean = 'null' -%}\n        {%- endif -%}\n\n        {%- set row_update = {column_name: safe_cast(column_value_clean, column_type) } -%}\n        {%- do formatted_row.update(row_update) -%}\n    {%- endfor -%}\n    {{ return(formatted_row) }}\n{%- endmacro -%}",
+      "depends_on": {
+        "macros": [
+          "macro.dbt.string_literal",
+          "macro.dbt.escape_single_quotes",
+          "macro.dbt.safe_cast"
+        ]
+      },
+      "description": "",
+      "meta": {},
+      "docs": {
+        "show": true,
+        "node_color": null
+      },
+      "patch_path": null,
+      "arguments": [],
+      "created_at": 1716931397.442261,
       "supported_languages": null
     },
     "macro.dbt.resolve_model_name": {
@@ -12209,7 +12613,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.173942,
+      "created_at": 1716931397.443818,
       "supported_languages": null
     },
     "macro.dbt.default__resolve_model_name": {
@@ -12231,7 +12635,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.174094,
+      "created_at": 1716931397.443957,
       "supported_languages": null
     },
     "macro.dbt.build_ref_function": {
@@ -12255,7 +12659,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1748931,
+      "created_at": 1716931397.4446871,
       "supported_languages": null
     },
     "macro.dbt.build_source_function": {
@@ -12279,7 +12683,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.175288,
+      "created_at": 1716931397.4450781,
       "supported_languages": null
     },
     "macro.dbt.build_config_dict": {
@@ -12301,7 +12705,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1758862,
+      "created_at": 1716931397.445605,
       "supported_languages": null
     },
     "macro.dbt.py_script_postfix": {
@@ -12330,7 +12734,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1763442,
+      "created_at": 1716931397.446027,
       "supported_languages": null
     },
     "macro.dbt.py_script_comment": {
@@ -12352,7 +12756,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.176414,
+      "created_at": 1716931397.446096,
       "supported_languages": null
     },
     "macro.dbt.test_unique": {
@@ -12376,7 +12780,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1769128,
+      "created_at": 1716931397.446591,
       "supported_languages": null
     },
     "macro.dbt.test_not_null": {
@@ -12400,7 +12804,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.177134,
+      "created_at": 1716931397.446816,
       "supported_languages": null
     },
     "macro.dbt.test_accepted_values": {
@@ -12424,7 +12828,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.17743,
+      "created_at": 1716931397.447089,
       "supported_languages": null
     },
     "macro.dbt.test_relationships": {
@@ -12448,7 +12852,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.1777122,
+      "created_at": 1716931397.447356,
       "supported_languages": null
     },
     "macro.dbt_utils.except": {
@@ -12472,7 +12876,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.177975,
+      "created_at": 1716931397.447587,
       "supported_languages": null
     },
     "macro.dbt_utils.default__except": {
@@ -12494,7 +12898,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.178049,
+      "created_at": 1716931397.447658,
       "supported_languages": null
     },
     "macro.dbt_utils.bigquery__except": {
@@ -12516,7 +12920,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.178118,
+      "created_at": 1716931397.447726,
       "supported_languages": null
     },
     "macro.dbt_utils.replace": {
@@ -12540,7 +12944,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.178431,
+      "created_at": 1716931397.448024,
       "supported_languages": null
     },
     "macro.dbt_utils.default__replace": {
@@ -12562,7 +12966,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.208568,
+      "created_at": 1716931397.448171,
       "supported_languages": null
     },
     "macro.dbt_utils.concat": {
@@ -12586,7 +12990,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.208873,
+      "created_at": 1716931397.448396,
       "supported_languages": null
     },
     "macro.dbt_utils.default__concat": {
@@ -12608,7 +13012,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2090082,
+      "created_at": 1716931397.44851,
       "supported_languages": null
     },
     "macro.dbt_utils.type_string": {
@@ -12632,7 +13036,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2096589,
+      "created_at": 1716931397.449332,
       "supported_languages": null
     },
     "macro.dbt_utils.default__type_string": {
@@ -12654,7 +13058,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.209733,
+      "created_at": 1716931397.449405,
       "supported_languages": null
     },
     "macro.dbt_utils.redshift__type_string": {
@@ -12676,7 +13080,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2098079,
+      "created_at": 1716931397.449476,
       "supported_languages": null
     },
     "macro.dbt_utils.postgres__type_string": {
@@ -12698,7 +13102,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.209879,
+      "created_at": 1716931397.4495418,
       "supported_languages": null
     },
     "macro.dbt_utils.snowflake__type_string": {
@@ -12720,7 +13124,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2099469,
+      "created_at": 1716931397.449606,
       "supported_languages": null
     },
     "macro.dbt_utils.type_timestamp": {
@@ -12744,7 +13148,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.210099,
+      "created_at": 1716931397.4497511,
       "supported_languages": null
     },
     "macro.dbt_utils.default__type_timestamp": {
@@ -12766,7 +13170,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.21017,
+      "created_at": 1716931397.449821,
       "supported_languages": null
     },
     "macro.dbt_utils.postgres__type_timestamp": {
@@ -12788,7 +13192,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.210238,
+      "created_at": 1716931397.449889,
       "supported_languages": null
     },
     "macro.dbt_utils.snowflake__type_timestamp": {
@@ -12810,7 +13214,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.210306,
+      "created_at": 1716931397.449954,
       "supported_languages": null
     },
     "macro.dbt_utils.type_float": {
@@ -12834,7 +13238,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.210457,
+      "created_at": 1716931397.450099,
       "supported_languages": null
     },
     "macro.dbt_utils.default__type_float": {
@@ -12856,7 +13260,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.210527,
+      "created_at": 1716931397.450166,
       "supported_languages": null
     },
     "macro.dbt_utils.bigquery__type_float": {
@@ -12878,7 +13282,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.210593,
+      "created_at": 1716931397.4502301,
       "supported_languages": null
     },
     "macro.dbt_utils.type_numeric": {
@@ -12902,7 +13306,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.210745,
+      "created_at": 1716931397.4503748,
       "supported_languages": null
     },
     "macro.dbt_utils.default__type_numeric": {
@@ -12924,7 +13328,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.210817,
+      "created_at": 1716931397.450443,
       "supported_languages": null
     },
     "macro.dbt_utils.bigquery__type_numeric": {
@@ -12946,7 +13350,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.210937,
+      "created_at": 1716931397.450508,
       "supported_languages": null
     },
     "macro.dbt_utils.type_bigint": {
@@ -12970,7 +13374,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.211091,
+      "created_at": 1716931397.450649,
       "supported_languages": null
     },
     "macro.dbt_utils.default__type_bigint": {
@@ -12992,7 +13396,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2111628,
+      "created_at": 1716931397.450716,
       "supported_languages": null
     },
     "macro.dbt_utils.bigquery__type_bigint": {
@@ -13014,7 +13418,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.211235,
+      "created_at": 1716931397.450782,
       "supported_languages": null
     },
     "macro.dbt_utils.type_int": {
@@ -13038,7 +13442,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.211411,
+      "created_at": 1716931397.450923,
       "supported_languages": null
     },
     "macro.dbt_utils.default__type_int": {
@@ -13060,7 +13464,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2114828,
+      "created_at": 1716931397.4509912,
       "supported_languages": null
     },
     "macro.dbt_utils.bigquery__type_int": {
@@ -13082,7 +13486,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.211549,
+      "created_at": 1716931397.451055,
       "supported_languages": null
     },
     "macro.dbt_utils._is_relation": {
@@ -13104,7 +13508,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.211982,
+      "created_at": 1716931397.451516,
       "supported_languages": null
     },
     "macro.dbt_utils.cast_array_to_string": {
@@ -13128,7 +13532,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.212362,
+      "created_at": 1716931397.4518778,
       "supported_languages": null
     },
     "macro.dbt_utils.default__cast_array_to_string": {
@@ -13152,7 +13556,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.212499,
+      "created_at": 1716931397.4520068,
       "supported_languages": null
     },
     "macro.dbt_utils.postgres__cast_array_to_string": {
@@ -13177,7 +13581,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.212796,
+      "created_at": 1716931397.452298,
       "supported_languages": null
     },
     "macro.dbt_utils.redshift__cast_array_to_string": {
@@ -13201,7 +13605,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2129338,
+      "created_at": 1716931397.452451,
       "supported_languages": null
     },
     "macro.dbt_utils.bigquery__cast_array_to_string": {
@@ -13223,7 +13627,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.213043,
+      "created_at": 1716931397.4525461,
       "supported_languages": null
     },
     "macro.dbt_utils.length": {
@@ -13247,7 +13651,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.213323,
+      "created_at": 1716931397.4528131,
       "supported_languages": null
     },
     "macro.dbt_utils.default__length": {
@@ -13269,7 +13673,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.213425,
+      "created_at": 1716931397.4529111,
       "supported_languages": null
     },
     "macro.dbt_utils.redshift__length": {
@@ -13291,7 +13695,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.213522,
+      "created_at": 1716931397.4530072,
       "supported_languages": null
     },
     "macro.dbt_utils.dateadd": {
@@ -13315,7 +13719,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.214047,
+      "created_at": 1716931397.453521,
       "supported_languages": null
     },
     "macro.dbt_utils.default__dateadd": {
@@ -13337,7 +13741,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.214207,
+      "created_at": 1716931397.4536698,
       "supported_languages": null
     },
     "macro.dbt_utils.bigquery__dateadd": {
@@ -13359,7 +13763,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.21436,
+      "created_at": 1716931397.4538162,
       "supported_languages": null
     },
     "macro.dbt_utils.postgres__dateadd": {
@@ -13381,7 +13785,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.214514,
+      "created_at": 1716931397.453961,
       "supported_languages": null
     },
     "macro.dbt_utils.redshift__dateadd": {
@@ -13405,7 +13809,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.214763,
+      "created_at": 1716931397.454133,
       "supported_languages": null
     },
     "macro.dbt_utils.intersect": {
@@ -13429,7 +13833,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2150002,
+      "created_at": 1716931397.454356,
       "supported_languages": null
     },
     "macro.dbt_utils.default__intersect": {
@@ -13451,7 +13855,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.215073,
+      "created_at": 1716931397.4544268,
       "supported_languages": null
     },
     "macro.dbt_utils.bigquery__intersect": {
@@ -13473,7 +13877,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2151418,
+      "created_at": 1716931397.454495,
       "supported_languages": null
     },
     "macro.dbt_utils.escape_single_quotes": {
@@ -13497,7 +13901,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.215449,
+      "created_at": 1716931397.454796,
       "supported_languages": null
     },
     "macro.dbt_utils.default__escape_single_quotes": {
@@ -13519,7 +13923,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.215584,
+      "created_at": 1716931397.4549298,
       "supported_languages": null
     },
     "macro.dbt_utils.snowflake__escape_single_quotes": {
@@ -13541,7 +13945,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2157178,
+      "created_at": 1716931397.45506,
       "supported_languages": null
     },
     "macro.dbt_utils.bigquery__escape_single_quotes": {
@@ -13563,7 +13967,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.215847,
+      "created_at": 1716931397.4552588,
       "supported_languages": null
     },
     "macro.dbt_utils.right": {
@@ -13587,7 +13991,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.216377,
+      "created_at": 1716931397.455774,
       "supported_languages": null
     },
     "macro.dbt_utils.default__right": {
@@ -13609,7 +14013,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.216506,
+      "created_at": 1716931397.4558988,
       "supported_languages": null
     },
     "macro.dbt_utils.bigquery__right": {
@@ -13631,7 +14035,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.216655,
+      "created_at": 1716931397.456043,
       "supported_languages": null
     },
     "macro.dbt_utils.snowflake__right": {
@@ -13653,7 +14057,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.216803,
+      "created_at": 1716931397.456185,
       "supported_languages": null
     },
     "macro.dbt_utils.listagg": {
@@ -13677,7 +14081,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2191832,
+      "created_at": 1716931397.4585059,
       "supported_languages": null
     },
     "macro.dbt_utils.default__listagg": {
@@ -13699,7 +14103,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.219581,
+      "created_at": 1716931397.458868,
       "supported_languages": null
     },
     "macro.dbt_utils.bigquery__listagg": {
@@ -13721,7 +14125,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.219857,
+      "created_at": 1716931397.459121,
       "supported_languages": null
     },
     "macro.dbt_utils.postgres__listagg": {
@@ -13743,7 +14147,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2202299,
+      "created_at": 1716931397.459473,
       "supported_languages": null
     },
     "macro.dbt_utils.redshift__listagg": {
@@ -13765,7 +14169,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.22121,
+      "created_at": 1716931397.460319,
       "supported_languages": null
     },
     "macro.dbt_utils.datediff": {
@@ -13789,7 +14193,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.223843,
+      "created_at": 1716931397.462958,
       "supported_languages": null
     },
     "macro.dbt_utils.default__datediff": {
@@ -13811,7 +14215,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2240078,
+      "created_at": 1716931397.4631228,
       "supported_languages": null
     },
     "macro.dbt_utils.bigquery__datediff": {
@@ -13833,7 +14237,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.224162,
+      "created_at": 1716931397.463268,
       "supported_languages": null
     },
     "macro.dbt_utils.postgres__datediff": {
@@ -13857,7 +14261,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2258172,
+      "created_at": 1716931397.4648252,
       "supported_languages": null
     },
     "macro.dbt_utils.redshift__datediff": {
@@ -13881,7 +14285,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.226016,
+      "created_at": 1716931397.465011,
       "supported_languages": null
     },
     "macro.dbt_utils.safe_cast": {
@@ -13905,7 +14309,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.226364,
+      "created_at": 1716931397.4653382,
       "supported_languages": null
     },
     "macro.dbt_utils.default__safe_cast": {
@@ -13927,7 +14331,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2264981,
+      "created_at": 1716931397.465462,
       "supported_languages": null
     },
     "macro.dbt_utils.snowflake__safe_cast": {
@@ -13949,7 +14353,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.226623,
+      "created_at": 1716931397.465576,
       "supported_languages": null
     },
     "macro.dbt_utils.bigquery__safe_cast": {
@@ -13971,7 +14375,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2267451,
+      "created_at": 1716931397.4656918,
       "supported_languages": null
     },
     "macro.dbt_utils.hash": {
@@ -13995,7 +14399,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.227021,
+      "created_at": 1716931397.465975,
       "supported_languages": null
     },
     "macro.dbt_utils.default__hash": {
@@ -14019,7 +14423,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.22716,
+      "created_at": 1716931397.466101,
       "supported_languages": null
     },
     "macro.dbt_utils.bigquery__hash": {
@@ -14043,7 +14447,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.227288,
+      "created_at": 1716931397.466219,
       "supported_languages": null
     },
     "macro.dbt_utils.cast_bool_to_text": {
@@ -14067,7 +14471,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.227585,
+      "created_at": 1716931397.466497,
       "supported_languages": null
     },
     "macro.dbt_utils.default__cast_bool_to_text": {
@@ -14091,7 +14495,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2277231,
+      "created_at": 1716931397.466632,
       "supported_languages": null
     },
     "macro.dbt_utils.redshift__cast_bool_to_text": {
@@ -14113,7 +14517,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.227843,
+      "created_at": 1716931397.466749,
       "supported_languages": null
     },
     "macro.dbt_utils.identifier": {
@@ -14137,7 +14541,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.228313,
+      "created_at": 1716931397.4671638,
       "supported_languages": null
     },
     "macro.dbt_utils.default__identifier": {
@@ -14159,7 +14563,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2284129,
+      "created_at": 1716931397.4672709,
       "supported_languages": null
     },
     "macro.dbt_utils.bigquery__identifier": {
@@ -14181,7 +14585,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.228509,
+      "created_at": 1716931397.46737,
       "supported_languages": null
     },
     "macro.dbt_utils.any_value": {
@@ -14205,7 +14609,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.228781,
+      "created_at": 1716931397.467653,
       "supported_languages": null
     },
     "macro.dbt_utils.default__any_value": {
@@ -14227,7 +14631,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.22895,
+      "created_at": 1716931397.467749,
       "supported_languages": null
     },
     "macro.dbt_utils.postgres__any_value": {
@@ -14249,7 +14653,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.229055,
+      "created_at": 1716931397.4678478,
       "supported_languages": null
     },
     "macro.dbt_utils.position": {
@@ -14273,7 +14677,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.229404,
+      "created_at": 1716931397.468183,
       "supported_languages": null
     },
     "macro.dbt_utils.default__position": {
@@ -14295,7 +14699,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2295392,
+      "created_at": 1716931397.468307,
       "supported_languages": null
     },
     "macro.dbt_utils.bigquery__position": {
@@ -14317,7 +14721,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.229669,
+      "created_at": 1716931397.4684422,
       "supported_languages": null
     },
     "macro.dbt_utils.string_literal": {
@@ -14341,7 +14745,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.229908,
+      "created_at": 1716931397.468728,
       "supported_languages": null
     },
     "macro.dbt_utils.default__string_literal": {
@@ -14363,7 +14767,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.230012,
+      "created_at": 1716931397.4688241,
       "supported_languages": null
     },
     "macro.dbt_utils.current_timestamp": {
@@ -14387,7 +14791,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.230547,
+      "created_at": 1716931397.469341,
       "supported_languages": null
     },
     "macro.dbt_utils.default__current_timestamp": {
@@ -14411,7 +14815,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.230658,
+      "created_at": 1716931397.469444,
       "supported_languages": null
     },
     "macro.dbt_utils.redshift__current_timestamp": {
@@ -14433,7 +14837,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.23073,
+      "created_at": 1716931397.469512,
       "supported_languages": null
     },
     "macro.dbt_utils.bigquery__current_timestamp": {
@@ -14455,7 +14859,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2308,
+      "created_at": 1716931397.469579,
       "supported_languages": null
     },
     "macro.dbt_utils.current_timestamp_in_utc": {
@@ -14479,7 +14883,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.230956,
+      "created_at": 1716931397.469725,
       "supported_languages": null
     },
     "macro.dbt_utils.default__current_timestamp_in_utc": {
@@ -14503,7 +14907,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.231064,
+      "created_at": 1716931397.469832,
       "supported_languages": null
     },
     "macro.dbt_utils.snowflake__current_timestamp_in_utc": {
@@ -14528,7 +14932,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.231207,
+      "created_at": 1716931397.46996,
       "supported_languages": null
     },
     "macro.dbt_utils.postgres__current_timestamp_in_utc": {
@@ -14552,7 +14956,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.231319,
+      "created_at": 1716931397.4700642,
       "supported_languages": null
     },
     "macro.dbt_utils.redshift__current_timestamp_in_utc": {
@@ -14576,7 +14980,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2314482,
+      "created_at": 1716931397.4701838,
       "supported_languages": null
     },
     "macro.dbt_utils.width_bucket": {
@@ -14600,7 +15004,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.232925,
+      "created_at": 1716931397.471612,
       "supported_languages": null
     },
     "macro.dbt_utils.default__width_bucket": {
@@ -14625,7 +15029,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.233376,
+      "created_at": 1716931397.4720352,
       "supported_languages": null
     },
     "macro.dbt_utils.redshift__width_bucket": {
@@ -14650,7 +15054,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.233886,
+      "created_at": 1716931397.4724412,
       "supported_languages": null
     },
     "macro.dbt_utils.snowflake__width_bucket": {
@@ -14672,7 +15076,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.234072,
+      "created_at": 1716931397.472608,
       "supported_languages": null
     },
     "macro.dbt_utils.array_concat": {
@@ -14696,7 +15100,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.234428,
+      "created_at": 1716931397.472944,
       "supported_languages": null
     },
     "macro.dbt_utils.default__array_concat": {
@@ -14718,7 +15122,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2345579,
+      "created_at": 1716931397.473066,
       "supported_languages": null
     },
     "macro.dbt_utils.bigquery__array_concat": {
@@ -14740,7 +15144,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.234684,
+      "created_at": 1716931397.473183,
       "supported_languages": null
     },
     "macro.dbt_utils.redshift__array_concat": {
@@ -14762,7 +15166,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.23481,
+      "created_at": 1716931397.4732978,
       "supported_languages": null
     },
     "macro.dbt_utils.bool_or": {
@@ -14786,7 +15190,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.235137,
+      "created_at": 1716931397.473595,
       "supported_languages": null
     },
     "macro.dbt_utils.default__bool_or": {
@@ -14808,7 +15212,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2352378,
+      "created_at": 1716931397.47375,
       "supported_languages": null
     },
     "macro.dbt_utils.snowflake__bool_or": {
@@ -14830,7 +15234,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2353358,
+      "created_at": 1716931397.473844,
       "supported_languages": null
     },
     "macro.dbt_utils.bigquery__bool_or": {
@@ -14852,7 +15256,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.235434,
+      "created_at": 1716931397.4739342,
       "supported_languages": null
     },
     "macro.dbt_utils.last_day": {
@@ -14876,7 +15280,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2359731,
+      "created_at": 1716931397.474453,
       "supported_languages": null
     },
     "macro.dbt_utils.default_last_day": {
@@ -14901,7 +15305,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.236235,
+      "created_at": 1716931397.474693,
       "supported_languages": null
     },
     "macro.dbt_utils.default__last_day": {
@@ -14925,7 +15329,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.236379,
+      "created_at": 1716931397.474827,
       "supported_languages": null
     },
     "macro.dbt_utils.postgres__last_day": {
@@ -14951,7 +15355,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.23679,
+      "created_at": 1716931397.475209,
       "supported_languages": null
     },
     "macro.dbt_utils.redshift__last_day": {
@@ -14975,7 +15379,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.236963,
+      "created_at": 1716931397.475383,
       "supported_languages": null
     },
     "macro.dbt_utils.split_part": {
@@ -14999,7 +15403,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.238445,
+      "created_at": 1716931397.4768362,
       "supported_languages": null
     },
     "macro.dbt_utils.default__split_part": {
@@ -15021,7 +15425,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2386072,
+      "created_at": 1716931397.476984,
       "supported_languages": null
     },
     "macro.dbt_utils._split_part_negative": {
@@ -15043,7 +15447,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.238822,
+      "created_at": 1716931397.477188,
       "supported_languages": null
     },
     "macro.dbt_utils.postgres__split_part": {
@@ -15068,7 +15472,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.239203,
+      "created_at": 1716931397.477477,
       "supported_languages": null
     },
     "macro.dbt_utils.redshift__split_part": {
@@ -15093,7 +15497,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2395258,
+      "created_at": 1716931397.477772,
       "supported_languages": null
     },
     "macro.dbt_utils.bigquery__split_part": {
@@ -15115,7 +15519,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2398741,
+      "created_at": 1716931397.478092,
       "supported_languages": null
     },
     "macro.dbt_utils.date_trunc": {
@@ -15139,7 +15543,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.240195,
+      "created_at": 1716931397.4784,
       "supported_languages": null
     },
     "macro.dbt_utils.default__date_trunc": {
@@ -15161,7 +15565,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.240321,
+      "created_at": 1716931397.478517,
       "supported_languages": null
     },
     "macro.dbt_utils.bigquery__date_trunc": {
@@ -15183,7 +15587,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.240449,
+      "created_at": 1716931397.4786339,
       "supported_languages": null
     },
     "macro.dbt_utils.array_construct": {
@@ -15207,7 +15611,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2409348,
+      "created_at": 1716931397.479091,
       "supported_languages": null
     },
     "macro.dbt_utils.default__array_construct": {
@@ -15229,7 +15633,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.241166,
+      "created_at": 1716931397.479307,
       "supported_languages": null
     },
     "macro.dbt_utils.snowflake__array_construct": {
@@ -15251,7 +15655,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.241301,
+      "created_at": 1716931397.479448,
       "supported_languages": null
     },
     "macro.dbt_utils.redshift__array_construct": {
@@ -15273,7 +15677,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.241437,
+      "created_at": 1716931397.479635,
       "supported_languages": null
     },
     "macro.dbt_utils.bigquery__array_construct": {
@@ -15295,7 +15699,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.241573,
+      "created_at": 1716931397.4797702,
       "supported_languages": null
     },
     "macro.dbt_utils._is_ephemeral": {
@@ -15317,7 +15721,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.242381,
+      "created_at": 1716931397.4805381,
       "supported_languages": null
     },
     "macro.dbt_utils.array_append": {
@@ -15341,7 +15745,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.242738,
+      "created_at": 1716931397.480871,
       "supported_languages": null
     },
     "macro.dbt_utils.default__array_append": {
@@ -15363,7 +15767,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2428658,
+      "created_at": 1716931397.480991,
       "supported_languages": null
     },
     "macro.dbt_utils.bigquery__array_append": {
@@ -15388,7 +15792,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.243048,
+      "created_at": 1716931397.481159,
       "supported_languages": null
     },
     "macro.dbt_utils.redshift__array_append": {
@@ -15413,7 +15817,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2432299,
+      "created_at": 1716931397.481328,
       "supported_languages": null
     },
     "macro.dbt_utils.get_period_boundaries": {
@@ -15437,7 +15841,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.249553,
+      "created_at": 1716931397.487535,
       "supported_languages": null
     },
     "macro.dbt_utils.default__get_period_boundaries": {
@@ -15464,7 +15868,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2500548,
+      "created_at": 1716931397.487991,
       "supported_languages": null
     },
     "macro.dbt_utils.get_period_sql": {
@@ -15488,7 +15892,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2503638,
+      "created_at": 1716931397.4882822,
       "supported_languages": null
     },
     "macro.dbt_utils.default__get_period_sql": {
@@ -15510,7 +15914,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.25091,
+      "created_at": 1716931397.4887328,
       "supported_languages": null
     },
     "macro.dbt_utils.materialization_insert_by_period_default": {
@@ -15540,7 +15944,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.255821,
+      "created_at": 1716931397.493252,
       "supported_languages": [
         "sql"
       ]
@@ -15566,7 +15970,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2562099,
+      "created_at": 1716931397.4936142,
       "supported_languages": null
     },
     "macro.dbt_utils.default__get_url_host": {
@@ -15593,7 +15997,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.25668,
+      "created_at": 1716931397.4940429,
       "supported_languages": null
     },
     "macro.dbt_utils.get_url_path": {
@@ -15617,7 +16021,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2571678,
+      "created_at": 1716931397.494507,
       "supported_languages": null
     },
     "macro.dbt_utils.default__get_url_path": {
@@ -15647,7 +16051,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.257804,
+      "created_at": 1716931397.495081,
       "supported_languages": null
     },
     "macro.dbt_utils.get_url_parameter": {
@@ -15671,7 +16075,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2581089,
+      "created_at": 1716931397.495369,
       "supported_languages": null
     },
     "macro.dbt_utils.default__get_url_parameter": {
@@ -15695,7 +16099,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.258424,
+      "created_at": 1716931397.4956548,
       "supported_languages": null
     },
     "macro.dbt_utils.test_fewer_rows_than": {
@@ -15719,7 +16123,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.258948,
+      "created_at": 1716931397.496162,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_fewer_rows_than": {
@@ -15741,7 +16145,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2591848,
+      "created_at": 1716931397.496384,
       "supported_languages": null
     },
     "macro.dbt_utils.test_equal_rowcount": {
@@ -15765,7 +16169,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.259565,
+      "created_at": 1716931397.496751,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_equal_rowcount": {
@@ -15787,7 +16191,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.259858,
+      "created_at": 1716931397.497046,
       "supported_languages": null
     },
     "macro.dbt_utils.test_relationships_where": {
@@ -15811,7 +16215,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.260478,
+      "created_at": 1716931397.497674,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_relationships_where": {
@@ -15833,7 +16237,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.260811,
+      "created_at": 1716931397.497977,
       "supported_languages": null
     },
     "macro.dbt_utils.test_recency": {
@@ -15857,7 +16261,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.261194,
+      "created_at": 1716931397.4983401,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_recency": {
@@ -15882,7 +16286,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2615309,
+      "created_at": 1716931397.4986298,
       "supported_languages": null
     },
     "macro.dbt_utils.test_not_constant": {
@@ -15906,7 +16310,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.261837,
+      "created_at": 1716931397.498917,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_not_constant": {
@@ -15928,7 +16332,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.262006,
+      "created_at": 1716931397.499073,
       "supported_languages": null
     },
     "macro.dbt_utils.test_accepted_range": {
@@ -15952,7 +16356,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.26258,
+      "created_at": 1716931397.499617,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_accepted_range": {
@@ -15974,7 +16378,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.263099,
+      "created_at": 1716931397.500094,
       "supported_languages": null
     },
     "macro.dbt_utils.test_not_accepted_values": {
@@ -15998,7 +16402,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2636359,
+      "created_at": 1716931397.5005949,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_not_accepted_values": {
@@ -16020,7 +16424,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.264012,
+      "created_at": 1716931397.50094,
       "supported_languages": null
     },
     "macro.dbt_utils.test_unique_where": {
@@ -16044,7 +16448,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.264401,
+      "created_at": 1716931397.501303,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_unique_where": {
@@ -16068,7 +16472,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.264565,
+      "created_at": 1716931397.5014532,
       "supported_languages": null
     },
     "macro.dbt_utils.test_at_least_one": {
@@ -16092,7 +16496,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.264875,
+      "created_at": 1716931397.501744,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_at_least_one": {
@@ -16114,7 +16518,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.265049,
+      "created_at": 1716931397.501908,
       "supported_languages": null
     },
     "macro.dbt_utils.test_unique_combination_of_columns": {
@@ -16138,7 +16542,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.265642,
+      "created_at": 1716931397.502475,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_unique_combination_of_columns": {
@@ -16160,7 +16564,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.266264,
+      "created_at": 1716931397.503066,
       "supported_languages": null
     },
     "macro.dbt_utils.test_cardinality_equality": {
@@ -16184,7 +16588,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2667918,
+      "created_at": 1716931397.503571,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_cardinality_equality": {
@@ -16208,7 +16612,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.267122,
+      "created_at": 1716931397.503875,
       "supported_languages": null
     },
     "macro.dbt_utils.test_expression_is_true": {
@@ -16232,7 +16636,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.267563,
+      "created_at": 1716931397.504291,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_expression_is_true": {
@@ -16254,7 +16658,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2678442,
+      "created_at": 1716931397.504549,
       "supported_languages": null
     },
     "macro.dbt_utils.test_not_null_proportion": {
@@ -16278,7 +16682,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.268249,
+      "created_at": 1716931397.5049431,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_not_null_proportion": {
@@ -16300,7 +16704,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.268746,
+      "created_at": 1716931397.5054138,
       "supported_languages": null
     },
     "macro.dbt_utils.test_sequential_values": {
@@ -16324,7 +16728,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.269374,
+      "created_at": 1716931397.506017,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_sequential_values": {
@@ -16350,7 +16754,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2700238,
+      "created_at": 1716931397.506612,
       "supported_languages": null
     },
     "macro.dbt_utils.test_not_null_where": {
@@ -16374,7 +16778,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.270417,
+      "created_at": 1716931397.506998,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_not_null_where": {
@@ -16398,7 +16802,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.27058,
+      "created_at": 1716931397.50717,
       "supported_languages": null
     },
     "macro.dbt_utils.test_equality": {
@@ -16422,7 +16826,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.271276,
+      "created_at": 1716931397.50783,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_equality": {
@@ -16448,7 +16852,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.272147,
+      "created_at": 1716931397.508628,
       "supported_languages": null
     },
     "macro.dbt_utils.test_mutually_exclusive_ranges": {
@@ -16472,7 +16876,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.275359,
+      "created_at": 1716931397.5117881,
       "supported_languages": null
     },
     "macro.dbt_utils.default__test_mutually_exclusive_ranges": {
@@ -16494,7 +16898,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.276832,
+      "created_at": 1716931397.513112,
       "supported_languages": null
     },
     "macro.dbt_utils.pretty_log_format": {
@@ -16518,7 +16922,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.27709,
+      "created_at": 1716931397.513363,
       "supported_languages": null
     },
     "macro.dbt_utils.default__pretty_log_format": {
@@ -16542,7 +16946,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2772532,
+      "created_at": 1716931397.513514,
       "supported_languages": null
     },
     "macro.dbt_utils.pretty_time": {
@@ -16566,7 +16970,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.277519,
+      "created_at": 1716931397.51376,
       "supported_languages": null
     },
     "macro.dbt_utils.default__pretty_time": {
@@ -16588,7 +16992,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2777169,
+      "created_at": 1716931397.513931,
       "supported_languages": null
     },
     "macro.dbt_utils.log_info": {
@@ -16612,7 +17016,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2779899,
+      "created_at": 1716931397.514164,
       "supported_languages": null
     },
     "macro.dbt_utils.default__log_info": {
@@ -16636,7 +17040,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2781599,
+      "created_at": 1716931397.514316,
       "supported_languages": null
     },
     "macro.dbt_utils.slugify": {
@@ -16658,7 +17062,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.278614,
+      "created_at": 1716931397.51473,
       "supported_languages": null
     },
     "macro.dbt_utils.get_intervals_between": {
@@ -16682,7 +17086,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.279295,
+      "created_at": 1716931397.515441,
       "supported_languages": null
     },
     "macro.dbt_utils.default__get_intervals_between": {
@@ -16707,7 +17111,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.279883,
+      "created_at": 1716931397.515977,
       "supported_languages": null
     },
     "macro.dbt_utils.date_spine": {
@@ -16731,7 +17135,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.280108,
+      "created_at": 1716931397.5162601,
       "supported_languages": null
     },
     "macro.dbt_utils.default__date_spine": {
@@ -16757,7 +17161,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.280464,
+      "created_at": 1716931397.5165892,
       "supported_languages": null
     },
     "macro.dbt_utils.nullcheck_table": {
@@ -16781,7 +17185,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.280763,
+      "created_at": 1716931397.516873,
       "supported_languages": null
     },
     "macro.dbt_utils.default__nullcheck_table": {
@@ -16807,7 +17211,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.281164,
+      "created_at": 1716931397.5171762,
       "supported_languages": null
     },
     "macro.dbt_utils.get_relations_by_pattern": {
@@ -16831,7 +17235,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.28186,
+      "created_at": 1716931397.517814,
       "supported_languages": null
     },
     "macro.dbt_utils.default__get_relations_by_pattern": {
@@ -16856,7 +17260,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.282691,
+      "created_at": 1716931397.518573,
       "supported_languages": null
     },
     "macro.dbt_utils.get_powers_of_two": {
@@ -16880,7 +17284,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.283495,
+      "created_at": 1716931397.519354,
       "supported_languages": null
     },
     "macro.dbt_utils.default__get_powers_of_two": {
@@ -16902,7 +17306,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.283905,
+      "created_at": 1716931397.519716,
       "supported_languages": null
     },
     "macro.dbt_utils.generate_series": {
@@ -16926,7 +17330,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.284087,
+      "created_at": 1716931397.519906,
       "supported_languages": null
     },
     "macro.dbt_utils.default__generate_series": {
@@ -16950,7 +17354,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2845929,
+      "created_at": 1716931397.520361,
       "supported_languages": null
     },
     "macro.dbt_utils.get_relations_by_prefix": {
@@ -16974,7 +17378,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.285262,
+      "created_at": 1716931397.521047,
       "supported_languages": null
     },
     "macro.dbt_utils.default__get_relations_by_prefix": {
@@ -16999,7 +17403,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.28609,
+      "created_at": 1716931397.521827,
       "supported_languages": null
     },
     "macro.dbt_utils.get_tables_by_prefix_sql": {
@@ -17023,7 +17427,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.286485,
+      "created_at": 1716931397.52219,
       "supported_languages": null
     },
     "macro.dbt_utils.default__get_tables_by_prefix_sql": {
@@ -17047,7 +17451,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2867599,
+      "created_at": 1716931397.52244,
       "supported_languages": null
     },
     "macro.dbt_utils.star": {
@@ -17071,7 +17475,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.287424,
+      "created_at": 1716931397.523068,
       "supported_languages": null
     },
     "macro.dbt_utils.default__star": {
@@ -17097,7 +17501,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.288385,
+      "created_at": 1716931397.524102,
       "supported_languages": null
     },
     "macro.dbt_utils.unpivot": {
@@ -17121,7 +17525,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.290139,
+      "created_at": 1716931397.52582,
       "supported_languages": null
     },
     "macro.dbt_utils.default__unpivot": {
@@ -17148,7 +17552,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.2922711,
+      "created_at": 1716931397.527581,
       "supported_languages": null
     },
     "macro.dbt_utils.union_relations": {
@@ -17172,7 +17576,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.295016,
+      "created_at": 1716931397.53024,
       "supported_languages": null
     },
     "macro.dbt_utils.default__union_relations": {
@@ -17199,7 +17603,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.297917,
+      "created_at": 1716931397.53289,
       "supported_languages": null
     },
     "macro.dbt_utils.group_by": {
@@ -17223,7 +17627,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.298204,
+      "created_at": 1716931397.5331619,
       "supported_languages": null
     },
     "macro.dbt_utils.default__group_by": {
@@ -17245,7 +17649,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.298443,
+      "created_at": 1716931397.533383,
       "supported_languages": null
     },
     "macro.dbt_utils.deduplicate": {
@@ -17269,7 +17673,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.300832,
+      "created_at": 1716931397.5356648,
       "supported_languages": null
     },
     "macro.dbt_utils.default__deduplicate": {
@@ -17291,7 +17695,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.301053,
+      "created_at": 1716931397.535869,
       "supported_languages": null
     },
     "macro.dbt_utils.redshift__deduplicate": {
@@ -17315,7 +17719,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.301248,
+      "created_at": 1716931397.5360472,
       "supported_languages": null
     },
     "macro.dbt_utils.postgres__deduplicate": {
@@ -17337,7 +17741,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.30143,
+      "created_at": 1716931397.5362198,
       "supported_languages": null
     },
     "macro.dbt_utils.snowflake__deduplicate": {
@@ -17359,7 +17763,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.3016078,
+      "created_at": 1716931397.536374,
       "supported_languages": null
     },
     "macro.dbt_utils.bigquery__deduplicate": {
@@ -17381,7 +17785,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.3017778,
+      "created_at": 1716931397.5365329,
       "supported_languages": null
     },
     "macro.dbt_utils.surrogate_key": {
@@ -17405,7 +17809,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.302334,
+      "created_at": 1716931397.537059,
       "supported_languages": null
     },
     "macro.dbt_utils.default__surrogate_key": {
@@ -17431,7 +17835,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.3032498,
+      "created_at": 1716931397.5378828,
       "supported_languages": null
     },
     "macro.dbt_utils.safe_add": {
@@ -17455,7 +17859,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.303616,
+      "created_at": 1716931397.538225,
       "supported_languages": null
     },
     "macro.dbt_utils.default__safe_add": {
@@ -17477,7 +17881,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.303893,
+      "created_at": 1716931397.538482,
       "supported_languages": null
     },
     "macro.dbt_utils.nullcheck": {
@@ -17501,7 +17905,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.3042219,
+      "created_at": 1716931397.538785,
       "supported_languages": null
     },
     "macro.dbt_utils.default__nullcheck": {
@@ -17523,7 +17927,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.304564,
+      "created_at": 1716931397.5390809,
       "supported_languages": null
     },
     "macro.dbt_utils.get_tables_by_pattern_sql": {
@@ -17547,7 +17951,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.306138,
+      "created_at": 1716931397.5406048,
       "supported_languages": null
     },
     "macro.dbt_utils.default__get_tables_by_pattern_sql": {
@@ -17571,7 +17975,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.3064058,
+      "created_at": 1716931397.540848,
       "supported_languages": null
     },
     "macro.dbt_utils.bigquery__get_tables_by_pattern_sql": {
@@ -17596,7 +18000,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.307165,
+      "created_at": 1716931397.541539,
       "supported_languages": null
     },
     "macro.dbt_utils._bigquery__get_matching_schemata": {
@@ -17620,7 +18024,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.30766,
+      "created_at": 1716931397.5419872,
       "supported_languages": null
     },
     "macro.dbt_utils.get_column_values": {
@@ -17644,7 +18048,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.3087769,
+      "created_at": 1716931397.543048,
       "supported_languages": null
     },
     "macro.dbt_utils.default__get_column_values": {
@@ -17670,7 +18074,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.310236,
+      "created_at": 1716931397.544379,
       "supported_languages": null
     },
     "macro.dbt_utils.pivot": {
@@ -17694,7 +18098,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.311285,
+      "created_at": 1716931397.5453591,
       "supported_languages": null
     },
     "macro.dbt_utils.default__pivot": {
@@ -17719,7 +18123,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.312112,
+      "created_at": 1716931397.546103,
       "supported_languages": null
     },
     "macro.dbt_utils.get_filtered_columns_in_relation": {
@@ -17743,7 +18147,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.312565,
+      "created_at": 1716931397.546533,
       "supported_languages": null
     },
     "macro.dbt_utils.default__get_filtered_columns_in_relation": {
@@ -17768,7 +18172,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.313261,
+      "created_at": 1716931397.547185,
       "supported_languages": null
     },
     "macro.dbt_utils.get_query_results_as_dict": {
@@ -17792,7 +18196,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.313637,
+      "created_at": 1716931397.5475452,
       "supported_languages": null
     },
     "macro.dbt_utils.default__get_query_results_as_dict": {
@@ -17816,7 +18220,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.314214,
+      "created_at": 1716931397.548067,
       "supported_languages": null
     },
     "macro.dbt_utils.get_table_types_sql": {
@@ -17840,7 +18244,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.314707,
+      "created_at": 1716931397.548529,
       "supported_languages": null
     },
     "macro.dbt_utils.default__get_table_types_sql": {
@@ -17862,7 +18266,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.314796,
+      "created_at": 1716931397.548618,
       "supported_languages": null
     },
     "macro.dbt_utils.postgres__get_table_types_sql": {
@@ -17884,7 +18288,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.314882,
+      "created_at": 1716931397.548699,
       "supported_languages": null
     },
     "macro.dbt_utils.bigquery__get_table_types_sql": {
@@ -17906,7 +18310,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.314968,
+      "created_at": 1716931397.548782,
       "supported_languages": null
     },
     "macro.dbt_utils.degrees_to_radians": {
@@ -17928,7 +18332,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.3159769,
+      "created_at": 1716931397.549783,
       "supported_languages": null
     },
     "macro.dbt_utils.haversine_distance": {
@@ -17952,7 +18356,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.316247,
+      "created_at": 1716931397.5500329,
       "supported_languages": null
     },
     "macro.dbt_utils.default__haversine_distance": {
@@ -17974,7 +18378,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.3168068,
+      "created_at": 1716931397.550522,
       "supported_languages": null
     },
     "macro.dbt_utils.bigquery__haversine_distance": {
@@ -17998,7 +18402,7 @@
       },
       "patch_path": null,
       "arguments": [],
-      "created_at": 1704787952.317661,
+      "created_at": 1716931397.551292,
       "supported_languages": null
     }
   },
@@ -18026,85 +18430,11 @@
   "metrics": {},
   "groups": {},
   "selectors": {},
-  "disabled": {
-    "test.london_bike_analysis.assert_stations_before_2017": [
-      {
-        "database": "DEMO_DB",
-        "schema": "METAPHOR_dbt_test__audit",
-        "name": "assert_stations_before_2017",
-        "resource_type": "test",
-        "package_name": "london_bike_analysis",
-        "path": "assert_stations_before_2017.sql",
-        "original_file_path": "tests/assert_stations_before_2017.sql",
-        "unique_id": "test.london_bike_analysis.assert_stations_before_2017",
-        "fqn": [
-          "london_bike_analysis",
-          "assert_stations_before_2017"
-        ],
-        "alias": "assert_stations_before_2017",
-        "checksum": {
-          "name": "sha256",
-          "checksum": "f6d5b26c17b46e0cdfff049c986df1572cf298527d00861a531dc0af6aca4be2"
-        },
-        "config": {
-          "enabled": false,
-          "alias": null,
-          "schema": "dbt_test__audit",
-          "database": null,
-          "tags": [],
-          "meta": {},
-          "group": null,
-          "materialized": "test",
-          "severity": "ERROR",
-          "store_failures": null,
-          "store_failures_as": null,
-          "where": null,
-          "limit": null,
-          "fail_calc": "count(*)",
-          "warn_if": "!= 0",
-          "error_if": "!= 0"
-        },
-        "tags": [],
-        "description": "",
-        "columns": {},
-        "meta": {},
-        "group": null,
-        "docs": {
-          "show": true,
-          "node_color": null
-        },
-        "patch_path": null,
-        "build_path": null,
-        "deferred": false,
-        "unrendered_config": {},
-        "created_at": 1704787952.74419,
-        "config_call_dict": {},
-        "relation_name": null,
-        "raw_code": "SELECT *\r\nFROM {{ ref('rides_by_month')}}\r\nWHERE end_station_install_date >= '2017-01-01'",
-        "language": "sql",
-        "refs": [
-          {
-            "name": "rides_by_month",
-            "package": null,
-            "version": null
-          }
-        ],
-        "sources": [],
-        "metrics": [],
-        "depends_on": {
-          "macros": [],
-          "nodes": []
-        },
-        "compiled_path": null,
-        "contract": {
-          "enforced": false,
-          "alias_types": true,
-          "checksum": null
-        }
-      }
-    ]
-  },
+  "disabled": {},
   "parent_map": {
+    "model.london_bike_analysis.cleaned_bike_rides_from_snapshot": [
+      "snapshot.london_bike_analysis.cycle_hire_snapshot"
+    ],
     "model.london_bike_analysis.rides_by_month_2017": [
       "model.london_bike_analysis.cleaned_bike_rides",
       "model.london_bike_analysis.raw_bike_stations"
@@ -18116,14 +18446,15 @@
       "model.london_bike_analysis.rides_by_month_2017"
     ],
     "model.london_bike_analysis.raw_bike_hires": [
-      "source.london_bike_analysis.metaphor.cycle_hire"
+      "source.london_bike_analysis.berlin_bicycles.cycle_hire"
     ],
     "model.london_bike_analysis.raw_bike_stations": [
-      "source.london_bike_analysis.metaphor.cycle_stations"
+      "source.london_bike_analysis.berlin_bicycles.cycle_stations"
     ],
     "snapshot.london_bike_analysis.cycle_hire_snapshot": [
-      "source.london_bike_analysis.metaphor.cycle_hire"
+      "source.london_bike_analysis.berlin_bicycles.cycle_hire"
     ],
+    "test.london_bike_analysis.assert_stations_before_2017": [],
     "test.london_bike_analysis.dbt_utils_fewer_rows_than_raw_bike_hires_ref_raw_bike_stations_.ffa7ccfb39": [
       "model.london_bike_analysis.raw_bike_hires",
       "model.london_bike_analysis.raw_bike_stations"
@@ -18155,13 +18486,11 @@
     "test.london_bike_analysis.not_null_cleaned_bike_rides_start_station_name.4eec63218d": [
       "model.london_bike_analysis.cleaned_bike_rides"
     ],
-    "model.london_bike_analysis.cleaned_bike_rides_from_snapshot": [
-      "snapshot.london_bike_analysis.cycle_hire_snapshot"
-    ],
-    "source.london_bike_analysis.metaphor.cycle_hire": [],
-    "source.london_bike_analysis.metaphor.cycle_stations": []
+    "source.london_bike_analysis.berlin_bicycles.cycle_hire": [],
+    "source.london_bike_analysis.berlin_bicycles.cycle_stations": []
   },
   "child_map": {
+    "model.london_bike_analysis.cleaned_bike_rides_from_snapshot": [],
     "model.london_bike_analysis.rides_by_month_2017": [
       "model.london_bike_analysis.rides_by_month_start_station_2017"
     ],
@@ -18189,6 +18518,7 @@
     "snapshot.london_bike_analysis.cycle_hire_snapshot": [
       "model.london_bike_analysis.cleaned_bike_rides_from_snapshot"
     ],
+    "test.london_bike_analysis.assert_stations_before_2017": [],
     "test.london_bike_analysis.dbt_utils_fewer_rows_than_raw_bike_hires_ref_raw_bike_stations_.ffa7ccfb39": [],
     "test.london_bike_analysis.not_null_cleaned_bike_rides_total_minutes.1c7c80a2d6": [],
     "test.london_bike_analysis.dbt_utils_at_least_one_cleaned_bike_rides_total_minutes.8432437e46": [],
@@ -18199,16 +18529,16 @@
     "test.london_bike_analysis.accepted_values_cleaned_bike_rides_start_peak_travel__Evening_Peak__Off_Peak__Morning_Peak.014130c1a3": [],
     "test.london_bike_analysis.not_null_cleaned_bike_rides_same_station_flag.6293c4e2a8": [],
     "test.london_bike_analysis.not_null_cleaned_bike_rides_start_station_name.4eec63218d": [],
-    "model.london_bike_analysis.cleaned_bike_rides_from_snapshot": [],
-    "source.london_bike_analysis.metaphor.cycle_hire": [
+    "source.london_bike_analysis.berlin_bicycles.cycle_hire": [
       "model.london_bike_analysis.raw_bike_hires",
       "snapshot.london_bike_analysis.cycle_hire_snapshot"
     ],
-    "source.london_bike_analysis.metaphor.cycle_stations": [
+    "source.london_bike_analysis.berlin_bicycles.cycle_stations": [
       "model.london_bike_analysis.raw_bike_stations"
     ]
   },
   "group_map": {},
   "saved_queries": {},
-  "semantic_models": {}
+  "semantic_models": {},
+  "unit_tests": {}
 }

--- a/tests/dbt/data/ride_share/run_results.json
+++ b/tests/dbt/data/ride_share/run_results.json
@@ -1,9 +1,9 @@
 {
   "metadata": {
-    "dbt_schema_version": "https://schemas.getdbt.com/dbt/run-results/v5.json",
-    "dbt_version": "1.7.3",
-    "generated_at": "2024-01-09T08:22:10.451896Z",
-    "invocation_id": "4c002312-d619-45e7-9208-49e8751dc20e",
+    "dbt_schema_version": "https://schemas.getdbt.com/dbt/run-results/v6.json",
+    "dbt_version": "1.8.0",
+    "generated_at": "2024-05-28T21:23:19.449154Z",
+    "invocation_id": "3a7cd1e1-3f19-4a52-b28b-bbc3645768de",
     "env": {}
   },
   "results": [
@@ -12,57 +12,23 @@
       "timing": [
         {
           "name": "compile",
-          "started_at": "2024-01-09T08:21:57.612116Z",
-          "completed_at": "2024-01-09T08:21:57.623945Z"
+          "started_at": "2024-05-28T21:23:19.333818Z",
+          "completed_at": "2024-05-28T21:23:19.345665Z"
         },
         {
           "name": "execute",
-          "started_at": "2024-01-09T08:21:57.624981Z",
-          "completed_at": "2024-01-09T08:21:59.220002Z"
+          "started_at": "2024-05-28T21:23:19.346055Z",
+          "completed_at": "2024-05-28T21:23:19.346069Z"
         }
       ],
       "thread_id": "Thread-1",
-      "execution_time": 2.0987839698791504,
-      "adapter_response": {
-        "_message": "SUCCESS 1",
-        "code": "SUCCESS",
-        "rows_affected": 1,
-        "query_id": "01b18cd5-0603-f4b9-0029-c003058c8d0e"
-      },
-      "message": "SUCCESS 1",
-      "failures": null,
-      "unique_id": "model.london_bike_analysis.cleaned_bike_rides_from_snapshot",
-      "compiled": true,
-      "compiled_code": "-- Adding extra fields including if the bike was rented during peak time \nSELECT\n    SUM(duration) as total_seconds\n    , COUNT(rental_id) as total_bike_hires\n    , ROUND(SUM(duration) / COUNT(rental_id), 2) AS average_duration\n    , EXTRACT(month from start_date) as month\n    , CASE\n        WHEN EXTRACT(HOUR from TO_TIMESTAMP(start_date)) >= 6 AND EXTRACT(HOUR from TO_TIMESTAMP(start_date)) <= 10 THEN 'Morning Peak'\n        WHEN EXTRACT(HOUR from TO_TIMESTAMP(start_date)) >= 16 AND EXTRACT(HOUR from TO_TIMESTAMP(start_date)) <= 19 THEN 'Evening Peak'\n        ELSE 'Off-Peak'\n      END AS start_peak_travel\n    , IFF(start_station_id = end_station_id, True, False) as same_station_flag\n    , start_station_id\n    , start_station_name\n    , end_station_id\n    , end_station_name\nFROM DEMO_DB.snapshots.cycle_hire_snapshot\nGROUP BY 4,5,6,7,8,9,10\nORDER BY total_seconds DESC",
-      "relation_name": "DEMO_DB.METAPHOR.cleaned_bike_rides_from_snapshot"
-    },
-    {
-      "status": "success",
-      "timing": [
-        {
-          "name": "compile",
-          "started_at": "2024-01-09T08:21:59.718150Z",
-          "completed_at": "2024-01-09T08:21:59.725778Z"
-        },
-        {
-          "name": "execute",
-          "started_at": "2024-01-09T08:21:59.727042Z",
-          "completed_at": "2024-01-09T08:22:01.375456Z"
-        }
-      ],
-      "thread_id": "Thread-1",
-      "execution_time": 2.021347999572754,
-      "adapter_response": {
-        "_message": "SUCCESS 1",
-        "code": "SUCCESS",
-        "rows_affected": 1,
-        "query_id": "01b18cd6-0603-f4b9-0029-c003058c8d12"
-      },
-      "message": "SUCCESS 1",
+      "execution_time": 0.013495922088623047,
+      "adapter_response": {},
+      "message": null,
       "failures": null,
       "unique_id": "model.london_bike_analysis.raw_bike_hires",
       "compiled": true,
-      "compiled_code": "SELECT \n    rental_id\n    , duration as duration_seconds\n    , duration / 60 as duration_minutes\n    , bike_id\n    , start_date\n    , start_station_id\n    , start_station_name\n    , end_date\n    , end_station_id\n    , end_station_name\nFROM  DEMO_DB.metaphor.cycle_hire\nWHERE EXTRACT(year from start_date) = 2017",
+      "compiled_code": "SELECT \n    rental_id\n    , duration as duration_seconds\n    , duration / 60 as duration_minutes\n    , bike_id\n    , start_date\n    , start_station_id\n    , start_station_name\n    , end_date\n    , end_station_id\n    , end_station_name\nFROM  DEMO_DB.berlin_bicycles.cycle_hire\nWHERE EXTRACT(year from start_date) = 2017",
       "relation_name": "DEMO_DB.METAPHOR.raw_bike_hires"
     },
     {
@@ -70,28 +36,23 @@
       "timing": [
         {
           "name": "compile",
-          "started_at": "2024-01-09T08:22:01.745774Z",
-          "completed_at": "2024-01-09T08:22:01.754245Z"
+          "started_at": "2024-05-28T21:23:19.347993Z",
+          "completed_at": "2024-05-28T21:23:19.352290Z"
         },
         {
           "name": "execute",
-          "started_at": "2024-01-09T08:22:01.755512Z",
-          "completed_at": "2024-01-09T08:22:03.770925Z"
+          "started_at": "2024-05-28T21:23:19.352605Z",
+          "completed_at": "2024-05-28T21:23:19.352611Z"
         }
       ],
       "thread_id": "Thread-1",
-      "execution_time": 2.4070920944213867,
-      "adapter_response": {
-        "_message": "SUCCESS 1",
-        "code": "SUCCESS",
-        "rows_affected": 1,
-        "query_id": "01b18cd6-0603-f4be-0029-c003058c94da"
-      },
-      "message": "SUCCESS 1",
+      "execution_time": 0.005464076995849609,
+      "adapter_response": {},
+      "message": null,
       "failures": null,
       "unique_id": "model.london_bike_analysis.raw_bike_stations",
       "compiled": true,
-      "compiled_code": "SELECT \n    id\n    , name as station_name\n    , bikes_count\n    , docks_count\n    , install_date\n    , removal_date\nFROM  DEMO_DB.metaphor.cycle_stations\nWHERE install_date < '2017-01-01' and (removal_date < '2018-01-01' or removal_date is null)",
+      "compiled_code": "SELECT \n    id\n    , name as station_name\n    , bikes_count\n    , docks_count\n    , install_date\n    , removal_date\nFROM  DEMO_DB.berlin_bicycles.cycle_stations\nWHERE install_date < '2017-01-01' and (removal_date < '2018-01-01' or removal_date is null)",
       "relation_name": "DEMO_DB.METAPHOR.raw_bike_stations"
     },
     {
@@ -99,24 +60,43 @@
       "timing": [
         {
           "name": "compile",
-          "started_at": "2024-01-09T08:22:04.160096Z",
-          "completed_at": "2024-01-09T08:22:04.166531Z"
+          "started_at": "2024-05-28T21:23:19.354313Z",
+          "completed_at": "2024-05-28T21:23:19.357397Z"
         },
         {
           "name": "execute",
-          "started_at": "2024-01-09T08:22:04.167785Z",
-          "completed_at": "2024-01-09T08:22:06.355011Z"
+          "started_at": "2024-05-28T21:23:19.357738Z",
+          "completed_at": "2024-05-28T21:23:19.357744Z"
         }
       ],
       "thread_id": "Thread-1",
-      "execution_time": 2.57037091255188,
-      "adapter_response": {
-        "_message": "SUCCESS 1",
-        "code": "SUCCESS",
-        "rows_affected": 1,
-        "query_id": "01b18cd6-0603-f4b9-0029-c003058c8d1e"
-      },
-      "message": "SUCCESS 1",
+      "execution_time": 0.004314899444580078,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
+      "unique_id": "snapshot.london_bike_analysis.cycle_hire_snapshot",
+      "compiled": true,
+      "compiled_code": "\n\n\nselect * from DEMO_DB.berlin_bicycles.cycle_hire",
+      "relation_name": "DEMO_DB.snapshots.cycle_hire_snapshot"
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-28T21:23:19.359239Z",
+          "completed_at": "2024-05-28T21:23:19.362120Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-28T21:23:19.362409Z",
+          "completed_at": "2024-05-28T21:23:19.362415Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.0038330554962158203,
+      "adapter_response": {},
+      "message": null,
       "failures": null,
       "unique_id": "model.london_bike_analysis.cleaned_bike_rides",
       "compiled": true,
@@ -128,24 +108,67 @@
       "timing": [
         {
           "name": "compile",
-          "started_at": "2024-01-09T08:22:06.737855Z",
-          "completed_at": "2024-01-09T08:22:06.744738Z"
+          "started_at": "2024-05-28T21:23:19.364153Z",
+          "completed_at": "2024-05-28T21:23:19.368713Z"
         },
         {
           "name": "execute",
-          "started_at": "2024-01-09T08:22:06.745922Z",
-          "completed_at": "2024-01-09T08:22:08.211585Z"
+          "started_at": "2024-05-28T21:23:19.369006Z",
+          "completed_at": "2024-05-28T21:23:19.369012Z"
         }
       ],
       "thread_id": "Thread-1",
-      "execution_time": 1.8485279083251953,
-      "adapter_response": {
-        "_message": "SUCCESS 1",
-        "code": "SUCCESS",
-        "rows_affected": 1,
-        "query_id": "01b18cd6-0603-f4b9-0029-c003058c8d2a"
-      },
-      "message": "SUCCESS 1",
+      "execution_time": 0.0057981014251708984,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
+      "unique_id": "test.london_bike_analysis.dbt_utils_fewer_rows_than_raw_bike_hires_ref_raw_bike_stations_.ffa7ccfb39",
+      "compiled": true,
+      "compiled_code": "\n\n\n\nwith a as (\n\n    select count(*) as count_our_model from DEMO_DB.METAPHOR.raw_bike_hires\n\n),\nb as (\n\n    select count(*) as count_comparison_model from DEMO_DB.METAPHOR.raw_bike_stations\n\n),\ncounts as (\n\n    select\n        count_our_model,\n        count_comparison_model\n    from a\n    cross join b\n\n),\nfinal as (\n\n    select *,\n        case\n            -- fail the test if we have more rows than the reference model and return the row count delta\n            when count_our_model > count_comparison_model then (count_our_model - count_comparison_model)\n            -- fail the test if they are the same number\n            when count_our_model = count_comparison_model then 1\n            -- pass the test if the delta is positive (i.e. return the number 0)\n            else 0\n    end as row_count_delta\n    from counts\n\n)\n\nselect * from final\n\n",
+      "relation_name": null
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-28T21:23:19.370300Z",
+          "completed_at": "2024-05-28T21:23:19.372867Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-28T21:23:19.373106Z",
+          "completed_at": "2024-05-28T21:23:19.373111Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.0034008026123046875,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
+      "unique_id": "model.london_bike_analysis.cleaned_bike_rides_from_snapshot",
+      "compiled": true,
+      "compiled_code": "-- Adding extra fields including if the bike was rented during peak time \nSELECT\n    SUM(duration) as total_seconds\n    , COUNT(rental_id) as total_bike_hires\n    , ROUND(SUM(duration) / COUNT(rental_id), 2) AS average_duration\n    , EXTRACT(month from start_date) as month\n    , CASE\n        WHEN EXTRACT(HOUR from TO_TIMESTAMP(start_date)) >= 6 AND EXTRACT(HOUR from TO_TIMESTAMP(start_date)) <= 10 THEN 'Morning Peak'\n        WHEN EXTRACT(HOUR from TO_TIMESTAMP(start_date)) >= 16 AND EXTRACT(HOUR from TO_TIMESTAMP(start_date)) <= 19 THEN 'Evening Peak'\n        ELSE 'Off-Peak'\n      END AS start_peak_travel\n    , IFF(start_station_id = end_station_id, True, False) as same_station_flag\n    , start_station_id\n    , start_station_name\n    , end_station_id\n    , end_station_name\nFROM DEMO_DB.snapshots.cycle_hire_snapshot\nGROUP BY 4,5,6,7,8,9,10\nORDER BY total_seconds DESC",
+      "relation_name": "DEMO_DB.METAPHOR.cleaned_bike_rides_from_snapshot"
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-28T21:23:19.374276Z",
+          "completed_at": "2024-05-28T21:23:19.377754Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-28T21:23:19.377978Z",
+          "completed_at": "2024-05-28T21:23:19.377983Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.004240274429321289,
+      "adapter_response": {},
+      "message": null,
       "failures": null,
       "unique_id": "model.london_bike_analysis.rides_by_month_2017",
       "compiled": true,
@@ -157,24 +180,235 @@
       "timing": [
         {
           "name": "compile",
-          "started_at": "2024-01-09T08:22:08.593947Z",
-          "completed_at": "2024-01-09T08:22:08.600985Z"
+          "started_at": "2024-05-28T21:23:19.379143Z",
+          "completed_at": "2024-05-28T21:23:19.413337Z"
         },
         {
           "name": "execute",
-          "started_at": "2024-01-09T08:22:08.602320Z",
-          "completed_at": "2024-01-09T08:22:10.047149Z"
+          "started_at": "2024-05-28T21:23:19.413567Z",
+          "completed_at": "2024-05-28T21:23:19.413573Z"
         }
       ],
       "thread_id": "Thread-1",
-      "execution_time": 1.8513391017913818,
-      "adapter_response": {
-        "_message": "SUCCESS 1",
-        "code": "SUCCESS",
-        "rows_affected": 1,
-        "query_id": "01b18cd6-0603-f4be-0029-c003058c94ea"
-      },
-      "message": "SUCCESS 1",
+      "execution_time": 0.03499293327331543,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
+      "unique_id": "test.london_bike_analysis.accepted_values_cleaned_bike_rides_start_peak_travel__Evening_Peak__Off_Peak__Morning_Peak.014130c1a3",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\nwith all_values as (\n\n    select\n        start_peak_travel as value_field,\n        count(*) as n_records\n\n    from DEMO_DB.METAPHOR.cleaned_bike_rides\n    group by start_peak_travel\n\n)\n\nselect *\nfrom all_values\nwhere value_field not in (\n    'Evening Peak','Off-Peak','Morning Peak'\n)\n\n\n",
+      "relation_name": null
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-28T21:23:19.414582Z",
+          "completed_at": "2024-05-28T21:23:19.417238Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-28T21:23:19.417433Z",
+          "completed_at": "2024-05-28T21:23:19.417437Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.003306150436401367,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
+      "unique_id": "test.london_bike_analysis.dbt_utils_at_least_one_cleaned_bike_rides_month.909766ad33",
+      "compiled": true,
+      "compiled_code": "\n\nselect *\nfrom (\n    select\n        \n        \n      count(month) as filler_column\n\n    from DEMO_DB.METAPHOR.cleaned_bike_rides\n\n    having count(month) = 0\n\n) validation_errors\n\n",
+      "relation_name": null
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-28T21:23:19.418418Z",
+          "completed_at": "2024-05-28T21:23:19.420879Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-28T21:23:19.421076Z",
+          "completed_at": "2024-05-28T21:23:19.421080Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.003122091293334961,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
+      "unique_id": "test.london_bike_analysis.dbt_utils_at_least_one_cleaned_bike_rides_total_bike_hires.db70dcef4a",
+      "compiled": true,
+      "compiled_code": "\n\nselect *\nfrom (\n    select\n        \n        \n      count(total_bike_hires) as filler_column\n\n    from DEMO_DB.METAPHOR.cleaned_bike_rides\n\n    having count(total_bike_hires) = 0\n\n) validation_errors\n\n",
+      "relation_name": null
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-28T21:23:19.421994Z",
+          "completed_at": "2024-05-28T21:23:19.424420Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-28T21:23:19.424620Z",
+          "completed_at": "2024-05-28T21:23:19.424623Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.0030591487884521484,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
+      "unique_id": "test.london_bike_analysis.dbt_utils_at_least_one_cleaned_bike_rides_total_minutes.8432437e46",
+      "compiled": true,
+      "compiled_code": "\n\nselect *\nfrom (\n    select\n        \n        \n      count(total_minutes) as filler_column\n\n    from DEMO_DB.METAPHOR.cleaned_bike_rides\n\n    having count(total_minutes) = 0\n\n) validation_errors\n\n",
+      "relation_name": null
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-28T21:23:19.425607Z",
+          "completed_at": "2024-05-28T21:23:19.430280Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-28T21:23:19.430474Z",
+          "completed_at": "2024-05-28T21:23:19.430478Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.00537419319152832,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
+      "unique_id": "test.london_bike_analysis.not_null_cleaned_bike_rides_month.e937c898a1",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\n\n\nselect month\nfrom DEMO_DB.METAPHOR.cleaned_bike_rides\nwhere month is null\n\n\n",
+      "relation_name": null
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-28T21:23:19.431387Z",
+          "completed_at": "2024-05-28T21:23:19.434500Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-28T21:23:19.434694Z",
+          "completed_at": "2024-05-28T21:23:19.434697Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.0037338733673095703,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
+      "unique_id": "test.london_bike_analysis.not_null_cleaned_bike_rides_same_station_flag.6293c4e2a8",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\n\n\nselect same_station_flag\nfrom DEMO_DB.METAPHOR.cleaned_bike_rides\nwhere same_station_flag is null\n\n\n",
+      "relation_name": null
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-28T21:23:19.435609Z",
+          "completed_at": "2024-05-28T21:23:19.438024Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-28T21:23:19.438212Z",
+          "completed_at": "2024-05-28T21:23:19.438215Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.003031015396118164,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
+      "unique_id": "test.london_bike_analysis.not_null_cleaned_bike_rides_start_station_name.4eec63218d",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\n\n\nselect start_station_name\nfrom DEMO_DB.METAPHOR.cleaned_bike_rides\nwhere start_station_name is null\n\n\n",
+      "relation_name": null
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-28T21:23:19.439125Z",
+          "completed_at": "2024-05-28T21:23:19.441661Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-28T21:23:19.441853Z",
+          "completed_at": "2024-05-28T21:23:19.441856Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.003158092498779297,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
+      "unique_id": "test.london_bike_analysis.not_null_cleaned_bike_rides_total_bike_hires.848927fb8f",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\n\n\nselect total_bike_hires\nfrom DEMO_DB.METAPHOR.cleaned_bike_rides\nwhere total_bike_hires is null\n\n\n",
+      "relation_name": null
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-28T21:23:19.442767Z",
+          "completed_at": "2024-05-28T21:23:19.445151Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-28T21:23:19.445335Z",
+          "completed_at": "2024-05-28T21:23:19.445339Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.003000020980834961,
+      "adapter_response": {},
+      "message": null,
+      "failures": null,
+      "unique_id": "test.london_bike_analysis.not_null_cleaned_bike_rides_total_minutes.1c7c80a2d6",
+      "compiled": true,
+      "compiled_code": "\n    \n    \n\n\n\nselect total_minutes\nfrom DEMO_DB.METAPHOR.cleaned_bike_rides\nwhere total_minutes is null\n\n\n",
+      "relation_name": null
+    },
+    {
+      "status": "success",
+      "timing": [
+        {
+          "name": "compile",
+          "started_at": "2024-05-28T21:23:19.446239Z",
+          "completed_at": "2024-05-28T21:23:19.448006Z"
+        },
+        {
+          "name": "execute",
+          "started_at": "2024-05-28T21:23:19.448208Z",
+          "completed_at": "2024-05-28T21:23:19.448211Z"
+        }
+      ],
+      "thread_id": "Thread-1",
+      "execution_time": 0.002393960952758789,
+      "adapter_response": {},
+      "message": null,
       "failures": null,
       "unique_id": "model.london_bike_analysis.rides_by_month_start_station_2017",
       "compiled": true,
@@ -182,45 +416,51 @@
       "relation_name": "DEMO_DB.METAPHOR.rides_by_month_start_station_2017"
     }
   ],
-  "elapsed_time": 17.67696475982666,
+  "elapsed_time": 1.1765928268432617,
   "args": {
-    "quiet": false,
-    "printer_width": 80,
-    "partial_parse": true,
-    "use_colors_file": true,
-    "enable_legacy_logger": false,
-    "log_path": "/Users/andy/work/dbt/ride_share/logs",
-    "log_format": "default",
-    "print": true,
+    "use_colors": true,
+    "macro_debugging": false,
+    "send_anonymous_usage_stats": true,
     "log_format_file": "debug",
+    "select": [],
+    "print": true,
+    "source_freshness_run_project_hooks": false,
+    "enable_legacy_logger": false,
+    "which": "generate",
+    "write_json": true,
+    "compile": true,
+    "vars": {},
+    "profiles_dir": "/Users/marslan/.dbt",
+    "defer": false,
+    "empty_catalog": false,
+    "log_level": "info",
+    "version_check": true,
+    "strict_mode": false,
+    "introspect": true,
+    "project_dir": "/Users/marslan/Metaphor/dbt/ride_share",
+    "use_colors_file": true,
+    "favor_state": false,
+    "log_format": "default",
+    "partial_parse_file_diff": true,
+    "log_file_max_bytes": 10485760,
     "warn_error_options": {
       "include": [],
       "exclude": []
     },
-    "profiles_dir": "/Users/andy/.dbt",
-    "exclude": [],
-    "log_level": "info",
-    "cache_selected_only": false,
-    "version_check": true,
-    "strict_mode": false,
-    "log_level_file": "debug",
-    "partial_parse_file_diff": true,
-    "select": [],
-    "macro_debugging": false,
-    "vars": {},
-    "which": "run",
-    "log_file_max_bytes": 10485760,
-    "project_dir": "/Users/andy/work/dbt/ride_share",
-    "show_resource_report": false,
-    "static_parser": true,
-    "introspect": true,
-    "defer": false,
-    "write_json": true,
-    "populate_cache": true,
-    "use_colors": true,
-    "favor_state": false,
-    "invocation_command": "dbt run",
     "indirect_selection": "eager",
-    "send_anonymous_usage_stats": true
+    "log_level_file": "debug",
+    "cache_selected_only": false,
+    "require_resource_names_without_spaces": false,
+    "static_parser": true,
+    "require_explicit_package_overrides_for_builtin_materializations": true,
+    "invocation_command": "dbt docs generate",
+    "static": false,
+    "show_resource_report": false,
+    "exclude": [],
+    "partial_parse": true,
+    "printer_width": 80,
+    "log_path": "/Users/marslan/Metaphor/dbt/ride_share/logs",
+    "populate_cache": true,
+    "quiet": false
   }
 }

--- a/tests/dbt/test_extractor.py
+++ b/tests/dbt/test_extractor.py
@@ -114,6 +114,7 @@ async def _test_project(
         project_source_url=project_source_url,
         meta_ownerships=[MetaOwnership(meta_key="owner", ownership_type="Maintainer")],
         meta_tags=[MetaTag(meta_key="pii", tag_type="PII")],
+        meta_key_tags="dbt_tags",
     )
     extractor = DbtExtractor(config)
     events = [EventUtil.trim_event(e) for e in await extractor.extract()]

--- a/tests/dbt/test_util.py
+++ b/tests/dbt/test_util.py
@@ -1,6 +1,10 @@
 from metaphor.common.entity_id import to_person_entity_id
 from metaphor.dbt.config import MetaOwnership, MetaTag
-from metaphor.dbt.util import get_ownerships_from_meta, get_tags_from_meta
+from metaphor.dbt.util import (
+    get_dbt_tags_from_meta,
+    get_metaphor_tags_from_meta,
+    get_ownerships_from_meta,
+)
 from metaphor.models.metadata_change_event import Ownership
 
 
@@ -114,7 +118,7 @@ def test_get_ownerships_with_assignment_targets(test_root_dir):
     assert ownerships.materialized_table == expected_materialized_table_ownerships
 
 
-def test_get_tags_from_meta(test_root_dir):
+def test_get_metaphor_tags_from_meta(test_root_dir):
     meta = {
         "pii": True,
         "prod": False,
@@ -144,4 +148,18 @@ def test_get_tags_from_meta(test_root_dir):
 
     expected_tags = ["pii", "sales"]
 
-    assert get_tags_from_meta(meta, meta_tags) == expected_tags
+    assert get_metaphor_tags_from_meta(meta, meta_tags) == expected_tags
+
+
+def test_get_dbt_tags_from_meta(test_root_dir):
+
+    assert get_dbt_tags_from_meta(None, None) == []
+
+    assert get_dbt_tags_from_meta({"other_key": "val"}, "dbt_tag") == []
+
+    assert get_dbt_tags_from_meta({"dbt_tag": "foo"}, "dbt_tag") == ["foo"]
+
+    assert get_dbt_tags_from_meta({"dbt_tags": ["foo", "bar"]}, "dbt_tags") == [
+        "foo",
+        "bar",
+    ]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

We're moving away from treating tags declared in dbt's [meta](https://docs.getdbt.com/reference/resource-configs/meta) field as Metaphor's governance tag. Instead, they should be treated just as additional "dbt tags".

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Add `meta_key_tags` to dbt connector config to point to the key name in `meta` field where the additional dbt tags are defined.
- Combining and deduping additional dbt tags defined in `meta` with the [tags](https://docs.getdbt.com/reference/resource-configs/tags) defined at the model level into `SystemTags` in MCE.
- Rename `get_tags_from_meta` to `get_metaphor_tags_from_meta` to disambiguate.

TODOs in follow-up PRs:
- Migrate Metaphor ownerships declared in `meta` into `SystemContacts`.
- Update models to support column-level tags.

> Note: `tests/dbt/data/ride_share/manifest.json` & `tests/dbt/data/ride_share/run_results.json` are regenerated based on the latest code in https://github.com/MetaphorData/dbt, which led to a substantial diff.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified end to end against a production instance.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
