### PR TITLE
Make the Tableau GraphQL pagination size configurable

### DIFF
--- a/metaphor/tableau/config.py
+++ b/metaphor/tableau/config.py
@@ -66,6 +66,9 @@ class TableauRunConfig(BaseConfig):
     # whether to disable Chart preview image
     disable_preview_image: bool = False
 
+    # max number of nodes to request when pagination over GraphQL connections
+    graphql_pagination_size: int = 20
+
     @model_validator(mode="after")
     def have_access_token_or_user_password(self):
         must_set_exactly_one(self.__dict__, ["access_token", "user_password"])

--- a/metaphor/tableau/extractor.py
+++ b/metaphor/tableau/extractor.py
@@ -95,6 +95,7 @@ class TableauExtractor(BaseExtractor):
         self._disable_preview_image = config.disable_preview_image
         self._include_personal_space = config.include_personal_space
         self._projects_filter = config.projects_filter
+        self._graphql_pagination_size = config.graphql_pagination_size
 
         self._views: Dict[str, tableau.ViewItem] = {}
         self._projects: Dict[str, List[str]] = {}  # project id -> project hierarchy
@@ -136,7 +137,7 @@ class TableauExtractor(BaseExtractor):
 
         server = tableau.Server(self._server_url, use_server_version=True)
         with server.auth.sign_in(tableau_auth):
-            workbooks = get_all_workbooks(server)
+            workbooks = get_all_workbooks(server, self._graphql_pagination_size)
             self._extract_dashboards(server, workbooks)
             self._extract_datasources(server, workbooks)
 
@@ -188,7 +189,9 @@ class TableauExtractor(BaseExtractor):
     def _extract_datasources(
         self, server: tableau.Server, workbooks: List[Workbook]
     ) -> None:
-        custom_sql_tables = fetch_custom_sql_tables(server)
+        custom_sql_tables = fetch_custom_sql_tables(
+            server, self._graphql_pagination_size
+        )
 
         # mapping of datasource to (query, list of upstream dataset IDs)
         datasource_upstream_datasets = {

--- a/metaphor/tableau/graphql_utils.py
+++ b/metaphor/tableau/graphql_utils.py
@@ -14,7 +14,7 @@ logger = get_logger()
 
 
 def _paginate_connection(
-    server: tableau.Server, query: str, connection_name: str, batch_size=50
+    server: tableau.Server, query: str, connection_name: str, batch_size
 ) -> List[Dict]:
     """Return all the nodes from GraphQL connection through pagination"""
 
@@ -36,7 +36,7 @@ def _paginate_connection(
         offset += batch_size
 
 
-def fetch_workbooks(server: tableau.Server, batch_size: int = 50):
+def fetch_workbooks(server: tableau.Server, batch_size):
     # fetch workbook related info from Metadata GraphQL API
     workbooks = _paginate_connection(
         server, workbooks_graphql_query, "workbooksConnection", batch_size
@@ -46,7 +46,7 @@ def fetch_workbooks(server: tableau.Server, batch_size: int = 50):
     return [WorkbookQueryResponse.model_validate(workbook) for workbook in workbooks]
 
 
-def fetch_custom_sql_tables(server: tableau.Server, batch_size: int = 50):
+def fetch_custom_sql_tables(server: tableau.Server, batch_size):
     # fetch custom SQL tables from Metadata GraphQL API
     custom_sql_tables = _paginate_connection(
         server, custom_sql_graphql_query, "customSQLTablesConnection", batch_size

--- a/metaphor/tableau/workbook.py
+++ b/metaphor/tableau/workbook.py
@@ -28,8 +28,8 @@ class Workbook:
         return self.graphql_item.projectName
 
 
-def get_all_workbooks(server: tableau.Server):
-    graphql_items = fetch_workbooks(server)
+def get_all_workbooks(server: tableau.Server, batch_size: int):
+    graphql_items = fetch_workbooks(server, batch_size)
     rest_items: List[tableau.WorkbookItem] = list(tableau.Pager(server.workbooks))
     workbooks: List[Workbook] = list()
     for rest_item in rest_items:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.13"
+version = "0.14.14"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/tableau/config.yml
+++ b/tests/tableau/config.yml
@@ -9,4 +9,5 @@ snowflake_account: snow
 bigquery_project_name_to_id_map:
   bq_name: bq_id
 disable_preview_image: true
+graphql_pagination_size: 30
 output: {}

--- a/tests/tableau/test_config.py
+++ b/tests/tableau/test_config.py
@@ -17,6 +17,7 @@ def test_yaml_config(test_root_dir):
         snowflake_account="snow",
         bigquery_project_name_to_id_map={"bq_name": "bq_id"},
         disable_preview_image=True,
+        graphql_pagination_size=30,
         output=OutputConfig(),
     )
 
@@ -37,6 +38,7 @@ def test_yaml_config_no_optional(test_root_dir):
         snowflake_account=None,
         bigquery_project_name_to_id_map=dict(),
         disable_preview_image=False,
+        graphql_pagination_size=20,
         output=OutputConfig(),
     )
 

--- a/tests/tableau/test_workbook.py
+++ b/tests/tableau/test_workbook.py
@@ -111,7 +111,7 @@ def test_workbook(
         graphql_workbooks_response,
     ]
 
-    workbooks = get_all_workbooks(mock_server)
+    workbooks = get_all_workbooks(mock_server, 20)
     assert len(workbooks) == 1
     with open(f"{test_root_dir}/tableau/workbook/expected_graphql_item.json") as f:
         assert workbooks[0].graphql_item.model_dump(exclude_none=True) == json.loads(


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Currently we fetch up to 50 nodes when paginating through GraphQL connections in [Tableau Metadata API](https://help.tableau.com/current/api/metadata_api/en-us/index.html). However, the API can return partial/invalid data with a [NODE_LIMIT_EXCEEDED](https://help.tableau.com/current/api/metadata_api/en-us/docs/meta_api_errors.html#:~:text=may%20be%20returned.-,NODE_LIMIT_EXCEEDED,-Warning) error when the number of total nodes exceeds server's [configuration](https://help.tableau.com/current/server/en-us/dm_catalog_enable.htm#:~:text=the%20following%20message%3A-,NODE_LIMIT_EXCEEDED,-To%20resolve%20this).

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Make the hard-coded batch size configurable and lower the default to 20.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified against a production instance.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
