### PR TITLE
Support Looker folder structure

### DIFF
--- a/metaphor/looker/config.py
+++ b/metaphor/looker/config.py
@@ -45,7 +45,10 @@ class LookerRunConfig(BaseConfig):
     project_source_url: Optional[str] = None
 
     verify_ssl: bool = True
-    timeout: int = 120
+    timeout: int = 300
+
+    # Whether to include dashboards in personal folders
+    include_personal_folders: bool = False
 
     @model_validator(mode="after")
     def have_local_or_git_dir_for_lookml(self):

--- a/metaphor/looker/extractor.py
+++ b/metaphor/looker/extractor.py
@@ -120,6 +120,8 @@ class LookerExtractor(BaseExtractor):
         json_dump_to_debug_file(folders, "all_folders.json")
 
         for folder in folders:
+            if folder.id is None:
+                continue
             folder_map[folder.id] = FolderMetadata(
                 id=folder.id, name=folder.name, parent_id=folder.parent_id
             )
@@ -144,8 +146,13 @@ class LookerExtractor(BaseExtractor):
                 continue
 
             # Skip personal folders
-            if not self._include_personal_folders and (
-                dashboard.folder.is_personal or dashboard.folder.is_personal_descendant
+            if (
+                not self._include_personal_folders
+                and dashboard.folder
+                and (
+                    dashboard.folder.is_personal
+                    or dashboard.folder.is_personal_descendant
+                )
             ):
                 logger.info(f"Skipping personal dashboard {dashboard.id}")
                 continue
@@ -182,9 +189,15 @@ class LookerExtractor(BaseExtractor):
                     dashboard_info=dashboard_info,
                     source_info=source_info,
                     entity_upstream=entity_upstream,
-                    structure=AssetStructure(
-                        directories=build_directories(dashboard.folder.id, folder_map),
-                        name=dashboard.title,
+                    structure=(
+                        AssetStructure(
+                            directories=build_directories(
+                                dashboard.folder.id, folder_map
+                            ),
+                            name=dashboard.title,
+                        )
+                        if dashboard.folder and dashboard.folder.id
+                        else None
                     ),
                 )
             )

--- a/metaphor/looker/folder.py
+++ b/metaphor/looker/folder.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from metaphor.common.logger import get_logger
+
+
+@dataclass
+class FolderMetadata:
+    id: str
+    name: str
+    parent_id: Optional[str] = None
+
+
+FolderMap = Dict[str, FolderMetadata]
+
+logger = get_logger()
+
+
+def build_directories(folder_id: str, folder_map: FolderMap) -> List[str]:
+    directories: List[str] = []
+
+    while True:
+        folder = folder_map.get(folder_id)
+        if folder is None:
+            logger.error(f"Invalid folder ID: {folder_id}")
+            return []
+
+        directories.insert(0, folder.name)
+
+        if folder.parent_id is None:
+            return directories
+
+        folder_id = folder.parent_id

--- a/metaphor/looker/folder.py
+++ b/metaphor/looker/folder.py
@@ -25,7 +25,7 @@ def build_directories(folder_id: str, folder_map: FolderMap) -> List[str]:
             logger.error(f"Invalid folder ID: {folder_id}")
             return []
 
-        directories.insert(0, folder.name)
+        directories.insert(0, folder.id)
 
         if folder.parent_id is None:
             return directories

--- a/metaphor/looker/lookml_parser.py
+++ b/metaphor/looker/lookml_parser.py
@@ -82,6 +82,9 @@ class Model:
         return Model(explores=dict((e.name, e) for e in explores))
 
 
+ModelMap = Dict[str, Model]
+
+
 _parsed_files: Dict[str, Dict] = {}
 
 
@@ -602,7 +605,7 @@ def parse_project(
     base_dir: str,
     connections: Dict[str, LookerConnectionConfig],
     projectSourceUrl: Optional[str] = None,
-) -> Tuple[Dict[str, Model], List[VirtualView]]:
+) -> Tuple[ModelMap, List[VirtualView]]:
     """
     parse the project under base_dir, returning a Model map and a list of virtual views including
     Looker Explores and Views

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.23"
+version = "0.14.24"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/looker/config2.yml
+++ b/tests/looker/config2.yml
@@ -12,4 +12,5 @@ connections:
     default_schema: schema1
     platform: SNOWFLAKE
     account: account1
+include_personal_folders: true
 output: {}

--- a/tests/looker/expected.json
+++ b/tests/looker/expected.json
@@ -16,17 +16,18 @@
       ]
     },
     "logicalId": {
-      "dashboardId": "model1::1",
+      "dashboardId": "1",
       "platform": "LOOKER"
     },
     "sourceInfo": {
-      "mainUrl": "http://test/me/model1::1"
+      "mainUrl": "http://test/me/1"
     },
     "structure": {
       "directories": [
-        "model1"
+        "shared",
+        "folder1"
       ],
-      "name": "1"
+      "name": "first"
     }
   }
 ]

--- a/tests/looker/expected.json
+++ b/tests/looker/expected.json
@@ -24,8 +24,8 @@
     },
     "structure": {
       "directories": [
-        "shared",
-        "folder1"
+        "1",
+        "2"
       ],
       "name": "first"
     }

--- a/tests/looker/test_config.py
+++ b/tests/looker/test_config.py
@@ -31,6 +31,7 @@ def test_yaml_config(test_root_dir):
         project_source_url="http://foo.bar",
         verify_ssl=True,
         timeout=1,
+        include_personal_folders=False,
         output=OutputConfig(),
     )
 
@@ -55,6 +56,7 @@ def test_yaml_config_with_git(test_root_dir):
             username="foo",
             access_token="bar",
         ),
+        include_personal_folders=True,
         output=OutputConfig(),
     )
 

--- a/tests/looker/test_extractor.py
+++ b/tests/looker/test_extractor.py
@@ -1,9 +1,10 @@
-from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from looker_sdk.sdk.api40.models import (
     Dashboard,
+    DashboardBase,
     DashboardElement,
+    FolderBase,
     ResultMakerFilterables,
     ResultMakerWithIdVisConfigAndDynamicFields,
 )
@@ -12,6 +13,7 @@ from metaphor.common.base_config import OutputConfig
 from metaphor.common.event_util import EventUtil
 from metaphor.looker.config import LookerConnectionConfig, LookerRunConfig
 from metaphor.looker.extractor import LookerExtractor
+from metaphor.looker.folder import FolderMetadata
 from metaphor.looker.lookml_parser import Explore, Model
 from tests.test_utils import load_json
 
@@ -23,6 +25,7 @@ def test_fetch_dashboards(test_root_dir) -> None:
         client_id="id",
         client_secret="secret",
         lookml_dir=".",
+        include_personal_folders=False,
         connections={
             "conn": LookerConnectionConfig(
                 "database",
@@ -34,16 +37,20 @@ def test_fetch_dashboards(test_root_dir) -> None:
     extractor._sdk = MagicMock()
     extractor._sdk.all_dashboards = MagicMock()
     extractor._sdk.all_dashboards.return_value = [
-        SimpleNamespace(id="1"),
+        DashboardBase(id="1"),
+        DashboardBase(id="2"),
+        DashboardBase(id="3"),
     ]
 
-    def mock_dashboard(dashboard_id: str):
-        return Dashboard(
-            id="model1::1",
+    mock_dashboards = [
+        # In shared folder
+        Dashboard(
+            id="1",
             title="first",
             description="first dashboard",
             preferred_viewer="me",
             view_count=123,
+            folder=FolderBase(id="2", name="folder1"),
             dashboard_elements=[
                 DashboardElement(
                     type="vis",
@@ -60,7 +67,29 @@ def test_fetch_dashboards(test_root_dir) -> None:
                     ),
                 )
             ],
-        )
+        ),
+        # In personal folder
+        Dashboard(
+            id="2",
+            title="second",
+            folder=FolderBase(
+                id="3",
+                name="personal",
+                is_personal=True,
+            ),
+        ),
+        # In personal descendant folder
+        Dashboard(
+            id="3",
+            title="third",
+            folder=FolderBase(
+                id="4",
+                name="personal descendant",
+                is_personal=False,
+                is_personal_descendant=True,
+            ),
+        ),
+    ]
 
     models = {
         "model1": Model(
@@ -72,8 +101,15 @@ def test_fetch_dashboards(test_root_dir) -> None:
         )
     }
 
-    extractor._sdk.dashboard = mock_dashboard
-    dashboards = extractor._fetch_dashboards(models)
-    assert len(dashboards) == 1
+    folders = {
+        "1": FolderMetadata(id="1", name="shared"),
+        "2": FolderMetadata(id="2", name="folder1", parent_id="1"),
+        "3": FolderMetadata(id="3", name="personal"),
+        "4": FolderMetadata(id="4", name="personal descendant", parent_id="3"),
+    }
+
+    extractor._sdk.dashboard.side_effect = mock_dashboards
+
+    dashboards = extractor._fetch_dashboards(models, folders)
     events = [EventUtil.trim_event(e) for e in dashboards]
     assert events == load_json(f"{test_root_dir}/looker/expected.json")

--- a/tests/looker/test_folder.py
+++ b/tests/looker/test_folder.py
@@ -9,6 +9,6 @@ def test_build_directories(test_root_dir) -> None:
         "3": FolderMetadata(id="3", name="folder3", parent_id="2"),
     }
 
-    assert build_directories("1", folder_map) == ["folder1"]
-    assert build_directories("2", folder_map) == ["folder1", "folder2"]
-    assert build_directories("3", folder_map) == ["folder1", "folder2", "folder3"]
+    assert build_directories("1", folder_map) == ["1"]
+    assert build_directories("2", folder_map) == ["1", "2"]
+    assert build_directories("3", folder_map) == ["1", "2", "3"]

--- a/tests/looker/test_folder.py
+++ b/tests/looker/test_folder.py
@@ -1,0 +1,14 @@
+from metaphor.looker.folder import FolderMetadata, build_directories
+
+
+def test_build_directories(test_root_dir) -> None:
+
+    folder_map = {
+        "1": FolderMetadata(id="1", name="folder1", parent_id=None),
+        "2": FolderMetadata(id="2", name="folder2", parent_id="1"),
+        "3": FolderMetadata(id="3", name="folder3", parent_id="2"),
+    }
+
+    assert build_directories("1", folder_map) == ["folder1"]
+    assert build_directories("2", folder_map) == ["folder1", "folder2"]
+    assert build_directories("3", folder_map) == ["folder1", "folder2", "folder3"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Looker dashboards are [organized using folders](https://cloud.google.com/looker/docs/organizing-spaces), and they expect the asset hierarchy to match the folder structure.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Set `AssetStructure` for dashboards based on their Looker folder path.
- Add `include_personal_folders` config to allow explicit inclusion of dashboards in personal folders. 
- Extend the default Looker API timeout to 5 mins as [all_dashboards](https://developers.looker.com/api/explorer/4.0/methods/Dashboard/all_dashboards) can take that long to return if there were thousands of dashboards.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified against a production instance.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
