### PR TITLE
Move text_from_HTML out of metaphor.common

### DIFF
--- a/metaphor/common/utils.py
+++ b/metaphor/common/utils.py
@@ -3,8 +3,6 @@ from datetime import datetime, time, timedelta, timezone
 from hashlib import md5
 from typing import Any, Callable, Dict, Iterable, List, Optional, Union
 
-from bs4 import BeautifulSoup
-from bs4.element import Comment
 from dateutil.parser import isoparse
 from pydantic import validate_email
 
@@ -174,29 +172,3 @@ def is_email(email: str) -> bool:
     except (ValueError, AssertionError):
         return False
     return True
-
-
-def text_from_HTML(html_content: str) -> str:
-    """
-    Extracts and returns visible text from given HTML content as a single string.
-    """
-
-    def filter_visible(el):
-        if el.parent.name in [
-            "style",
-            "script",
-            "head",
-            "title",
-            "meta",
-            "[document]",
-        ]:
-            return False
-        elif isinstance(el, Comment):
-            return False
-        else:
-            return True
-
-    # Use bs4 to find visible text elements
-    soup = BeautifulSoup(html_content, "lxml")
-    visible_text = filter(filter_visible, soup.findAll(string=True))
-    return "\n".join(t.strip() for t in visible_text)

--- a/metaphor/sharepoint/extractor.py
+++ b/metaphor/sharepoint/extractor.py
@@ -10,9 +10,9 @@ from metaphor.common.base_extractor import BaseExtractor
 from metaphor.common.embeddings import embed_documents, map_metadata, sanitize_text
 from metaphor.common.event_util import ENTITY_TYPES
 from metaphor.common.logger import get_logger
-from metaphor.common.utils import text_from_HTML
 from metaphor.models.crawler_run_metadata import Platform
 from metaphor.sharepoint.config import SharepointRunConfig
+from metaphor.static_web.utils import text_from_HTML
 
 logger = get_logger()
 

--- a/metaphor/static_web/utils.py
+++ b/metaphor/static_web/utils.py
@@ -1,0 +1,44 @@
+from bs4 import BeautifulSoup
+from bs4.element import Comment
+
+
+def text_from_HTML(html_content: str) -> str:
+    """
+    Extracts and returns visible text from given HTML content as a single string.
+    """
+
+    def filter_visible(el):
+        if el.parent.name in [
+            "style",
+            "script",
+            "head",
+            "title",
+            "meta",
+            "[document]",
+        ]:
+            return False
+        elif isinstance(el, Comment):
+            return False
+        else:
+            return True
+
+    # Use bs4 to find visible text elements
+    soup = BeautifulSoup(html_content, "lxml")
+    visible_text = filter(filter_visible, soup.findAll(string=True))
+    return "\n".join(t.strip() for t in visible_text)
+
+
+def title_from_HTML(html_content: str) -> str:
+    """
+    Extracts the title of a webpage given HTML content as a single string.
+    Designed to handle output from get_page_HTML.
+    """
+
+    soup = BeautifulSoup(html_content, "lxml")
+    title_tag = soup.find("title")
+
+    if title_tag:
+        return title_tag.text
+
+    else:
+        return ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.14"
+version = "0.14.15"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -17,10 +17,8 @@ from metaphor.common.utils import (
     safe_parse_ISO8601,
     safe_str,
     start_of_day,
-    text_from_HTML,
     unique_list,
 )
-from tests.test_utils import load_text
 
 
 @freeze_time("2020-01-10")
@@ -175,18 +173,3 @@ def test_is_email():
     assert is_email("a+c@b.c")
     assert not is_email("foo")
     assert not is_email("foo@127.0.0.1")
-
-
-# Test for extracting visible text from HTML, with filtering
-def test_text_from_HTML(test_root_dir: str):
-    html_content = load_text(f"{test_root_dir}/common/samples/titles_text.html")
-    text = text_from_HTML(html_content)
-    assert "Visible paragraph 1." in text
-    assert "Visible paragraph 2." in text
-    assert "Test Title" not in text
-    assert "Some style" not in text
-    assert "Some script" not in text
-    assert "Some meta" not in text
-    assert "Commented text" not in text
-    assert "Script text" not in text
-    assert "Style text" not in text

--- a/tests/static_web/test_extractor.py
+++ b/tests/static_web/test_extractor.py
@@ -59,37 +59,6 @@ def test_get_subpages_from_HTML(static_web_extractor):
     assert "https://example.com/test" in result
 
 
-# Test for extracting visible text from HTML, with filtering
-def test_get_text_from_HTML_with_filtering(static_web_extractor, test_root_dir: str):
-    html_content = load_text(
-        f"{test_root_dir}/static_web/sample_pages/titles_text.html"
-    )
-    text = static_web_extractor._get_text_from_HTML(html_content)
-    assert "Visible paragraph 1." in text
-    assert "Visible paragraph 2." in text
-    assert "Test Title" not in text
-    assert "Some style" not in text
-    assert "Some script" not in text
-    assert "Some meta" not in text
-    assert "Commented text" not in text
-    assert "Script text" not in text
-    assert "Style text" not in text
-
-
-# Test for extracting title from HTML
-def test_get_title_from_HTML_success(static_web_extractor):
-    html_content = "<html><head><title>Test Title</title></head></html>"
-    title = static_web_extractor._get_title_from_HTML(html_content)
-    assert title == "Test Title"
-
-
-# Test for extracting empty title
-def test_get_title_from_HTML_failure(static_web_extractor):
-    html_content = "<html><head></head><body><h1>Hello World!</h1></body></html>"
-    title = static_web_extractor._get_title_from_HTML(html_content)
-    assert title == ""
-
-
 # Test for making a document
 def test_make_document(static_web_extractor):
     doc = static_web_extractor._make_document(

--- a/tests/static_web/test_utils.py
+++ b/tests/static_web/test_utils.py
@@ -1,0 +1,48 @@
+from metaphor.static_web.utils import text_from_HTML, title_from_HTML
+from tests.test_utils import load_text
+
+
+# Test for extracting visible text from HTML, with filtering
+def test_text_from_HTML(test_root_dir: str):
+    html_content = load_text(f"{test_root_dir}/common/samples/titles_text.html")
+    text = text_from_HTML(html_content)
+    assert "Visible paragraph 1." in text
+    assert "Visible paragraph 2." in text
+    assert "Test Title" not in text
+    assert "Some style" not in text
+    assert "Some script" not in text
+    assert "Some meta" not in text
+    assert "Commented text" not in text
+    assert "Script text" not in text
+    assert "Style text" not in text
+
+
+# Test for extracting visible text from HTML, with filtering
+def test_get_text_from_HTML_with_filtering(test_root_dir: str):
+    html_content = load_text(
+        f"{test_root_dir}/static_web/sample_pages/titles_text.html"
+    )
+    text = text_from_HTML(html_content)
+    assert "Visible paragraph 1." in text
+    assert "Visible paragraph 2." in text
+    assert "Test Title" not in text
+    assert "Some style" not in text
+    assert "Some script" not in text
+    assert "Some meta" not in text
+    assert "Commented text" not in text
+    assert "Script text" not in text
+    assert "Style text" not in text
+
+
+# Test for extracting title from HTML
+def test_get_title_from_HTML_success(test_root_dir: str):
+    html_content = "<html><head><title>Test Title</title></head></html>"
+    title = title_from_HTML(html_content)
+    assert title == "Test Title"
+
+
+# Test for extracting empty title
+def test_get_title_from_HTML_failure(test_root_dir: str):
+    html_content = "<html><head></head><body><h1>Hello World!</h1></body></html>"
+    title = title_from_HTML(html_content)
+    assert title == ""


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

The `text_from_HTML` util function depends on the rather heavy `beautifulsoup` library. Since we don't expect it to be used by connectors other than `static_web` & `sharepoint`, it makes sense to move it out of `metaphor.common.utils`. 

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Move `text_from_HTML` to from `metaphor.common.utils` to`metaphor.static_web.util`, along with `title_from_HTML`.
- Refactor `static_web` & `sharepoint` connectors to make use of these util functions.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Unit tests.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
