### PR TITLE
[sc-26791][sc-26630] Parse test run results via discovery api, and fill in `DataMonitor.last_run` for dbt data monitors

### DIFF
--- a/metaphor/dbt/artifact_parser.py
+++ b/metaphor/dbt/artifact_parser.py
@@ -1,5 +1,6 @@
 import json
 from copy import deepcopy
+from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type, Union
 
 from metaphor.common.entity_id import EntityId
@@ -632,9 +633,16 @@ class ArtifactParser:
         )
 
         status = dbt_run_result_output_data_monitor_status_map[run_result.status]
-        add_data_quality_monitor(
-            dataset, test.name, test.column_name, status, last_run=None
+        last_run = None
+        completed_times = sorted(
+            timing.completed_at
+            for timing in run_result.timing
+            if isinstance(timing.completed_at, datetime)
         )
+        if completed_times:
+            last_run = completed_times[-1]
+
+        add_data_quality_monitor(dataset, test.name, test.column_name, status, last_run)
 
     def _parse_virtual_view_node(
         self,

--- a/metaphor/dbt/artifact_parser.py
+++ b/metaphor/dbt/artifact_parser.py
@@ -632,7 +632,9 @@ class ArtifactParser:
         )
 
         status = dbt_run_result_output_data_monitor_status_map[run_result.status]
-        add_data_quality_monitor(dataset, test.name, test.column_name, status)
+        add_data_quality_monitor(
+            dataset, test.name, test.column_name, status, last_run=None
+        )
 
     def _parse_virtual_view_node(
         self,

--- a/metaphor/dbt/cloud/README.md
+++ b/metaphor/dbt/cloud/README.md
@@ -41,6 +41,14 @@ If you're using dbt [Single Tenancy](https://docs.getdbt.com/docs/cloud/about-cl
 base_url: https://cloud.<tenant>.getdbt.com
 ```
 
+#### Discovery API URL
+
+Specify this if your dbt instance isn't a North America multi-tenant deployment. See [Discovery API endpoints](https://docs.getdbt.com/docs/dbt-cloud-apis/discovery-querying#discovery-api-endpoints) for reference.
+
+```yaml
+discovery_api_url: https://metadata.cloud.getdbt.com/graphql
+```
+
 #### Environment IDs
 
 ```yaml

--- a/metaphor/dbt/cloud/config.py
+++ b/metaphor/dbt/cloud/config.py
@@ -33,3 +33,6 @@ class DbtCloudConfig(BaseConfig):
 
     # Base URL for dbt instance
     base_url: str = "https://cloud.getdbt.com"
+
+    # Discovery API endpoint
+    discovery_api_url: str = "https://metadata.cloud.getdbt.com/graphql"

--- a/metaphor/dbt/cloud/discovery_api.py
+++ b/metaphor/dbt/cloud/discovery_api.py
@@ -1,0 +1,69 @@
+from typing import Any, Dict
+
+from requests import post
+
+from metaphor.common.entity_id import dataset_normalized_name
+
+
+class DiscoveryAPI:
+    def __init__(self, url: str, token: str) -> None:
+        self.url = url
+        self.token = token
+
+    def _send(self, query: str, variables: Dict[str, Any]):
+        resp = post(
+            url=self.url,
+            headers={
+                "authorization": f"Bearer {self.token}",
+                "content-type": "application/json",
+            },
+            json={"query": query, "variables": variables},
+            timeout=15,
+        )
+        return resp.json()["data"]
+
+    def get_model_dataset_name(self, job_id: int, model_unique_id: str):
+        query = """
+query Model($uniqueId: String!, $jobId: BigInt!) {
+    job(id: $jobId) {
+        model(uniqueId: $uniqueId) {
+            alias
+            database
+            name
+            schema
+        }
+    }
+}
+        """
+        variables = {
+            "uniqueId": model_unique_id,
+            "jobId": job_id,
+        }
+
+        model = self._send(query, variables)["job"]["model"]
+        database, schema, name = (
+            model.get("database"),
+            model.get("schema"),
+            model.get("alias") or model.get("name"),
+        )
+        return dataset_normalized_name(database, schema, name)
+
+    def get_test_status(self, job_id: int, test_unique_id: str):
+        query = """
+query Test($uniqueId: String!, $jobId: BigInt!) {
+  job(id: $jobId) {
+    test(uniqueId: $uniqueId) {
+      status
+    }
+  }
+}
+        """
+        variables = {
+            "jobId": job_id,
+            "uniqueId": test_unique_id,
+        }
+
+        res = self._send(query, variables)["job"]["test"]
+        if res is None:
+            return "skipped"
+        return res["status"]

--- a/metaphor/dbt/cloud/discovery_api.py
+++ b/metaphor/dbt/cloud/discovery_api.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 import requests
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from metaphor.common.entity_id import dataset_normalized_name
 
@@ -25,11 +25,11 @@ class DiscoveryModelNode(BaseModel):
     name: Optional[str]
     alias: Optional[str]
     database: Optional[str]
-    schema: Optional[str]
+    schema_: Optional[str] = Field(alias="schema")
 
     @property
     def normalized_name(self) -> str:
-        return dataset_normalized_name(self.database, self.schema, self.name)
+        return dataset_normalized_name(self.database, self.schema_, self.name)
 
 
 class DiscoveryAPI:

--- a/metaphor/dbt/cloud/discovery_api.py
+++ b/metaphor/dbt/cloud/discovery_api.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Any, Dict, Optional
 
 import requests
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel
 
 from metaphor.common.entity_id import dataset_normalized_name
 

--- a/metaphor/dbt/cloud/discovery_api.py
+++ b/metaphor/dbt/cloud/discovery_api.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict
 
-from requests import post
+import requests
 
 from metaphor.common.entity_id import dataset_normalized_name
 
@@ -11,7 +11,7 @@ class DiscoveryAPI:
         self.token = token
 
     def _send(self, query: str, variables: Dict[str, Any]):
-        resp = post(
+        resp = requests.post(
             url=self.url,
             headers={
                 "authorization": f"Bearer {self.token}",

--- a/metaphor/dbt/cloud/discovery_api.py
+++ b/metaphor/dbt/cloud/discovery_api.py
@@ -1,7 +1,8 @@
+from datetime import datetime
 from typing import Any, Dict, Optional
 
 import requests
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 from metaphor.common.entity_id import dataset_normalized_name
 
@@ -11,6 +12,7 @@ class DiscoveryTestNode(BaseModel):
     name: Optional[str]
     status: Optional[str]
     columnName: Optional[str]
+    executeCompletedAt: Optional[datetime]
 
 
 class DiscoveryAPI:
@@ -60,7 +62,7 @@ query Model($uniqueId: String!, $jobId: BigInt!) {
         )
         return dataset_normalized_name(database, schema, name)
 
-    def get_all_test_status(self, job_id: int):
+    def get_all_job_tests(self, job_id: int):
         query = """
 query Tests($jobId: BigInt!) {
   job(id: $jobId) {
@@ -69,6 +71,7 @@ query Tests($jobId: BigInt!) {
         name
         status
         columnName
+        executeCompletedAt
     }
   }
 }

--- a/metaphor/dbt/cloud/discovery_api.py
+++ b/metaphor/dbt/cloud/discovery_api.py
@@ -6,6 +6,10 @@ from metaphor.common.entity_id import dataset_normalized_name
 
 
 class DiscoveryAPI:
+    """
+    A wrapper around dbt cloud's discovery API.
+    """
+
     def __init__(self, url: str, token: str) -> None:
         self.url = url
         self.token = token
@@ -49,6 +53,9 @@ query Model($uniqueId: String!, $jobId: BigInt!) {
         return dataset_normalized_name(database, schema, name)
 
     def get_test_status(self, job_id: int, test_unique_id: str):
+        """
+        If the test cannot be found, we consider it as `skipped`.
+        """
         query = """
 query Test($uniqueId: String!, $jobId: BigInt!) {
   job(id: $jobId) {

--- a/metaphor/dbt/cloud/extractor.py
+++ b/metaphor/dbt/cloud/extractor.py
@@ -161,7 +161,6 @@ class DbtCloudExtractor(BaseExtractor):
                     test.columnName,
                     status,
                     test.executeCompletedAt,
-                    check_monitor_exists=True,  # If this monitor is already collected, we don't want to duplicate or overwrite it
                 )
 
         return list(entities) + new_monitor_datasets

--- a/metaphor/dbt/cloud/extractor.py
+++ b/metaphor/dbt/cloud/extractor.py
@@ -1,7 +1,6 @@
 from typing import Collection, Dict, List, Optional
 
 from metaphor.common.base_extractor import BaseExtractor
-from metaphor.common.entity_id import EntityId, to_dataset_entity_id_from_logical_id
 from metaphor.common.event_util import ENTITY_TYPES
 from metaphor.common.logger import get_logger
 from metaphor.dbt.artifact_parser import dbt_run_result_output_data_monitor_status_map

--- a/metaphor/dbt/cloud/extractor.py
+++ b/metaphor/dbt/cloud/extractor.py
@@ -140,10 +140,12 @@ class DbtCloudExtractor(BaseExtractor):
         for entity in entities:
             if not isinstance(entity, VirtualView):
                 continue
-            if not entity.dbt_model or not entity.dbt_model.tests:
-                continue
-
-            if not entity.logical_id or not entity.logical_id.name:
+            if (
+                not entity.dbt_model
+                or not entity.dbt_model.tests
+                or not entity.logical_id
+                or not entity.logical_id.name
+            ):
                 continue
 
             model_unique_id = f"model.{entity.logical_id.name}"

--- a/metaphor/dbt/cloud/extractor.py
+++ b/metaphor/dbt/cloud/extractor.py
@@ -145,7 +145,6 @@ class DbtCloudExtractor(BaseExtractor):
             dataset = Dataset(
                 logical_id=dataset_logical_id,
             )
-            new_monitor_datasets.append(dataset)
 
             for test in discovery_api.get_all_job_tests(job_id):
                 if not test.name:
@@ -162,5 +161,8 @@ class DbtCloudExtractor(BaseExtractor):
                     status,
                     test.executeCompletedAt,
                 )
+
+            if dataset.data_quality and dataset.data_quality.monitors:
+                new_monitor_datasets.append(dataset)
 
         return list(entities) + new_monitor_datasets

--- a/metaphor/dbt/extractor.py
+++ b/metaphor/dbt/extractor.py
@@ -6,6 +6,7 @@ from metaphor.common.event_util import ENTITY_TYPES
 from metaphor.common.logger import add_debug_file, get_logger
 from metaphor.dbt.artifact_parser import ArtifactParser
 from metaphor.dbt.config import DbtRunConfig
+from metaphor.dbt.util import get_data_platform_from_manifest
 from metaphor.models.crawler_run_metadata import Platform
 from metaphor.models.metadata_change_event import (
     DataPlatform,
@@ -49,13 +50,10 @@ class DbtExtractor(BaseExtractor):
     async def extract(self) -> Collection[ENTITY_TYPES]:
         logger.info("Fetching metadata from DBT repo")
 
-        with open(self._manifest) as file:
-            manifest_json = json.load(file)
+        self._data_platform = get_data_platform_from_manifest(self._manifest)
 
-        manifest_metadata = manifest_json.get("metadata", {})
-        platform = manifest_metadata.get("adapter_type", "").upper()
-        assert platform in DataPlatform.__members__, f"Invalid data platform {platform}"
-        self._data_platform = DataPlatform[platform]
+        with open(self._manifest) as f:
+            manifest_json = json.load(f)
 
         run_results_json = None
         if self._run_results is not None:

--- a/metaphor/dbt/util.py
+++ b/metaphor/dbt/util.py
@@ -290,7 +290,6 @@ def add_data_quality_monitor(
     column_name: Optional[str],
     status: DataMonitorStatus,
     last_run: Optional[datetime],
-    check_monitor_exists: bool = False,
 ) -> None:
     if dataset.data_quality is None:
         dataset.data_quality = DatasetDataQuality(
@@ -300,27 +299,24 @@ def add_data_quality_monitor(
     assert dataset.data_quality.monitors is not None
     assert dataset.logical_id
 
-    if not check_monitor_exists or not any(
-        monitor.title == name for monitor in dataset.data_quality.monitors
-    ):
-        dataset.data_quality.monitors.append(
-            # For `DataMonitorTarget`:
-            # column: Name of the target column. Not set if the monitor performs dataset-level tests, e.g. row count.
-            # dataset: Entity ID of the target dataset. Set only if the monitor uses a different dataset from the one the data quality metadata is attached to.
-            DataMonitor(
-                last_run=last_run,
-                title=name,
-                targets=[
-                    DataMonitorTarget(
-                        dataset=str(
-                            to_dataset_entity_id_from_logical_id(dataset.logical_id)
-                        ),
-                        column=column_name,
-                    )
-                ],
-                status=status,
-            )
+    dataset.data_quality.monitors.append(
+        # For `DataMonitorTarget`:
+        # column: Name of the target column. Not set if the monitor performs dataset-level tests, e.g. row count.
+        # dataset: Entity ID of the target dataset. Set only if the monitor uses a different dataset from the one the data quality metadata is attached to.
+        DataMonitor(
+            last_run=last_run,
+            title=name,
+            targets=[
+                DataMonitorTarget(
+                    dataset=str(
+                        to_dataset_entity_id_from_logical_id(dataset.logical_id)
+                    ),
+                    column=column_name,
+                )
+            ],
+            status=status,
         )
+    )
 
 
 def get_data_platform_from_manifest(

--- a/metaphor/dbt/util.py
+++ b/metaphor/dbt/util.py
@@ -1,3 +1,4 @@
+import json
 import re
 from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Optional
@@ -308,3 +309,14 @@ def add_data_quality_monitor(
             status=status,
         )
     )
+
+
+def get_data_platform_from_manifest(
+    manifest_file: str,
+):
+    with open(manifest_file) as f:
+        manifest_json = json.load(f)
+    manifest_metadata = manifest_json.get("metadata", {})
+    platform = manifest_metadata.get("adapter_type", "").upper()
+    assert platform in DataPlatform.__members__, f"Invalid data platform {platform}"
+    return DataPlatform[platform]

--- a/metaphor/dbt/util.py
+++ b/metaphor/dbt/util.py
@@ -287,28 +287,36 @@ def add_data_quality_monitor(
     name: str,
     column_name: Optional[str],
     status: DataMonitorStatus,
+    check_monitor_exists: bool = False,
 ) -> None:
     if dataset.data_quality is None:
         dataset.data_quality = DatasetDataQuality(
             monitors=[], provider=DataQualityProvider.DBT
         )
-    dataset.data_quality.monitors.append(
-        # For `DataMonitorTarget`:
-        # column: Name of the target column. Not set if the monitor performs dataset-level tests, e.g. row count.
-        # dataset: Entity ID of the target dataset. Set only if the monitor uses a different dataset from the one the data quality metadata is attached to.
-        DataMonitor(
-            title=name,
-            targets=[
-                DataMonitorTarget(
-                    dataset=str(
-                        to_dataset_entity_id_from_logical_id(dataset.logical_id)
-                    ),
-                    column=column_name,
-                )
-            ],
-            status=status,
+
+    assert dataset.data_quality.monitors is not None
+    assert dataset.logical_id
+
+    if not check_monitor_exists or not any(
+        monitor.title == name for monitor in dataset.data_quality.monitors
+    ):
+        dataset.data_quality.monitors.append(
+            # For `DataMonitorTarget`:
+            # column: Name of the target column. Not set if the monitor performs dataset-level tests, e.g. row count.
+            # dataset: Entity ID of the target dataset. Set only if the monitor uses a different dataset from the one the data quality metadata is attached to.
+            DataMonitor(
+                title=name,
+                targets=[
+                    DataMonitorTarget(
+                        dataset=str(
+                            to_dataset_entity_id_from_logical_id(dataset.logical_id)
+                        ),
+                        column=column_name,
+                    )
+                ],
+                status=status,
+            )
         )
-    )
 
 
 def get_data_platform_from_manifest(

--- a/metaphor/dbt/util.py
+++ b/metaphor/dbt/util.py
@@ -1,6 +1,7 @@
 import json
 import re
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Callable, Dict, List, Optional
 
 from metaphor.common.entity_id import (
@@ -51,6 +52,7 @@ def get_dataset_entity_id(self, db: str, schema: str, table: str) -> EntityId:
 
 
 def get_virtual_view_id(logical_id: VirtualViewLogicalID) -> str:
+    assert logical_id.name and logical_id.type
     return str(to_virtual_view_entity_id(logical_id.name, logical_id.type))
 
 
@@ -287,6 +289,7 @@ def add_data_quality_monitor(
     name: str,
     column_name: Optional[str],
     status: DataMonitorStatus,
+    last_run: Optional[datetime],
     check_monitor_exists: bool = False,
 ) -> None:
     if dataset.data_quality is None:
@@ -305,6 +308,7 @@ def add_data_quality_monitor(
             # column: Name of the target column. Not set if the monitor performs dataset-level tests, e.g. row count.
             # dataset: Entity ID of the target dataset. Set only if the monitor uses a different dataset from the one the data quality metadata is attached to.
             DataMonitor(
+                last_run=last_run,
                 title=name,
                 targets=[
                     DataMonitorTarget(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.15"
+version = "0.14.16"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/dbt/cloud/test_discovery_api.py
+++ b/tests/dbt/cloud/test_discovery_api.py
@@ -32,22 +32,40 @@ def test(mock_requests_post: MagicMock):
                     }
                 }
             )
-        elif json["query"].strip().startswith("query Test"):
-            if json["variables"].get("uniqueId", "") == "bad test":
-                return Response(response={"job": {"test": None}})
-            return Response(
-                response={
-                    "job": {
-                        "test": {
-                            "status": "pass",
+        elif json["query"].strip().startswith("query Tests"):
+            job_id = json["variables"].get("jobId", 0)
+            if job_id == 0:
+                return Response(response={"job": {"tests": []}})
+            elif job_id == 1:
+                return Response(
+                    response={
+                        "job": {
+                            "tests": [
+                                {
+                                    "uniqueId": "1",
+                                    "name": None,
+                                    "columnName": "col",
+                                    "status": "pass",
+                                },
+                                {
+                                    "uniqueId": "2",
+                                    "name": "not pass",
+                                    "columnName": "col2",
+                                    "status": "error",
+                                },
+                            ]
                         }
                     }
-                }
-            )
+                )
         assert False
 
     mock_requests_post.side_effect = fake_post
     discovery_api = DiscoveryAPI("url", "token")
     assert discovery_api.get_model_dataset_name(123, "foo") == "db.sch.tab"
-    assert discovery_api.get_test_status(123, "foo") == "pass"
-    assert discovery_api.get_test_status(123, "bad test") == "skipped"
+    assert not discovery_api.get_all_test_status(0)
+    test_statuses = discovery_api.get_all_test_status(1)
+    assert len(test_statuses) == 2
+    assert test_statuses[0].name is None
+    assert test_statuses[0].status == "pass"
+    assert test_statuses[1].columnName == "col2"
+    assert test_statuses[1].status == "error"

--- a/tests/dbt/cloud/test_discovery_api.py
+++ b/tests/dbt/cloud/test_discovery_api.py
@@ -1,0 +1,53 @@
+from dataclasses import dataclass
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+from metaphor.dbt.cloud.discovery_api import DiscoveryAPI
+
+
+@patch("requests.post")
+def test(mock_requests_post: MagicMock):
+    def fake_post(
+        url: str, headers: Dict[str, Any], json: Dict[str, Any], timeout: int
+    ):
+        @dataclass
+        class Response:
+            response: Dict[str, Any]
+
+            def json(self):
+                return {
+                    "data": self.response,
+                }
+
+        if json["query"].strip().startswith("query Model"):
+            return Response(
+                response={
+                    "job": {
+                        "model": {
+                            "alias": None,
+                            "database": "db",
+                            "schema": "sch",
+                            "name": "tab",
+                        }
+                    }
+                }
+            )
+        elif json["query"].strip().startswith("query Test"):
+            if json["variables"].get("uniqueId", "") == "bad test":
+                return Response(response={"job": {"test": None}})
+            return Response(
+                response={
+                    "job": {
+                        "test": {
+                            "status": "pass",
+                        }
+                    }
+                }
+            )
+        assert False
+
+    mock_requests_post.side_effect = fake_post
+    discovery_api = DiscoveryAPI("url", "token")
+    assert discovery_api.get_model_dataset_name(123, "foo") == "db.sch.tab"
+    assert discovery_api.get_test_status(123, "foo") == "pass"
+    assert discovery_api.get_test_status(123, "bad test") == "skipped"

--- a/tests/dbt/cloud/test_discovery_api.py
+++ b/tests/dbt/cloud/test_discovery_api.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, Dict
 from unittest.mock import MagicMock, patch
 
@@ -46,12 +47,14 @@ def test(mock_requests_post: MagicMock):
                                     "name": None,
                                     "columnName": "col",
                                     "status": "pass",
+                                    "executeCompletedAt": datetime.now(),
                                 },
                                 {
                                     "uniqueId": "2",
                                     "name": "not pass",
                                     "columnName": "col2",
                                     "status": "error",
+                                    "executeCompletedAt": datetime.now(),
                                 },
                             ]
                         }
@@ -62,8 +65,8 @@ def test(mock_requests_post: MagicMock):
     mock_requests_post.side_effect = fake_post
     discovery_api = DiscoveryAPI("url", "token")
     assert discovery_api.get_model_dataset_name(123, "foo") == "db.sch.tab"
-    assert not discovery_api.get_all_test_status(0)
-    test_statuses = discovery_api.get_all_test_status(1)
+    assert not discovery_api.get_all_job_tests(0)
+    test_statuses = discovery_api.get_all_job_tests(1)
     assert len(test_statuses) == 2
     assert test_statuses[0].name is None
     assert test_statuses[0].status == "pass"

--- a/tests/dbt/cloud/test_discovery_api.py
+++ b/tests/dbt/cloud/test_discovery_api.py
@@ -20,16 +20,19 @@ def test(mock_requests_post: MagicMock):
                     "data": self.response,
                 }
 
-        if json["query"].strip().startswith("query Model"):
+        if json["query"].strip().startswith("query Models"):
             return Response(
                 response={
                     "job": {
-                        "model": {
-                            "alias": None,
-                            "database": "db",
-                            "schema": "sch",
-                            "name": "tab",
-                        }
+                        "models": [
+                            {
+                                "alias": None,
+                                "database": "db",
+                                "schema": "sch",
+                                "name": "tab",
+                                "uniqueId": "foo",
+                            },
+                        ]
                     }
                 }
             )
@@ -48,6 +51,9 @@ def test(mock_requests_post: MagicMock):
                                     "columnName": "col",
                                     "status": "pass",
                                     "executeCompletedAt": datetime.now(),
+                                    "dependsOn": [
+                                        "model.foo.bar",
+                                    ],
                                 },
                                 {
                                     "uniqueId": "2",
@@ -55,6 +61,9 @@ def test(mock_requests_post: MagicMock):
                                     "columnName": "col2",
                                     "status": "error",
                                     "executeCompletedAt": datetime.now(),
+                                    "dependsOn": [
+                                        "model.foo.bar",
+                                    ],
                                 },
                             ]
                         }
@@ -64,7 +73,7 @@ def test(mock_requests_post: MagicMock):
 
     mock_requests_post.side_effect = fake_post
     discovery_api = DiscoveryAPI("url", "token")
-    assert discovery_api.get_model_dataset_name(123, "foo") == "db.sch.tab"
+    assert discovery_api.get_all_job_model_names(123)["foo"] == "db.sch.tab"
     assert not discovery_api.get_all_job_tests(0)
     test_statuses = discovery_api.get_all_job_tests(1)
     assert len(test_statuses) == 2

--- a/tests/dbt/cloud/test_extractor.py
+++ b/tests/dbt/cloud/test_extractor.py
@@ -158,14 +158,18 @@ def test_extend_test_run_results_entities(mock_discovery_api_class: MagicMock):
                     ),
                 ]
             ),
-        )
+        ),
+        Dataset(),
+        VirtualView(),
     ]
 
     res = extractor._extend_test_run_results_entities(
         DataPlatform.UNKNOWN, None, 2222, entities
     )
-    assert len(res) == 2
-    dataset = next(x for x in res if isinstance(x, Dataset))
+    assert len(res) == 4
+    dataset = next(
+        x for x in res if isinstance(x, Dataset) and x.data_quality is not None
+    )
     assert dataset.data_quality and dataset.data_quality.monitors
     assert dataset.data_quality.monitors[0].status == DataMonitorStatus.PASSED
     assert dataset.data_quality.monitors[0].targets == [

--- a/tests/dbt/cloud/test_extractor.py
+++ b/tests/dbt/cloud/test_extractor.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -132,23 +133,25 @@ def test_extend_test_run_results_entities(mock_discovery_api_class: MagicMock):
     mock_discovery_api = MagicMock()
     mock_discovery_api.get_model_dataset_name.return_value = "db.sch.tab"
 
-    def fake_get_all_test_status(job_id: int):
+    def fake_get_all_job_tests(job_id: int):
         return [
             DiscoveryTestNode(
                 uniqueId="1",
                 name="test1",
                 columnName="col1",
                 status="pass",
+                executeCompletedAt=datetime.now(),
             ),
             DiscoveryTestNode(
                 uniqueId="2",
                 name="test2",
                 columnName="col2",
                 status="error",
+                executeCompletedAt=datetime.now(),
             ),
         ]
 
-    mock_discovery_api.get_all_test_status.side_effect = fake_get_all_test_status
+    mock_discovery_api.get_all_job_tests.side_effect = fake_get_all_job_tests
     mock_discovery_api_class.return_value = mock_discovery_api
     entities = [
         VirtualView(

--- a/tests/dbt/cloud/test_extractor.py
+++ b/tests/dbt/cloud/test_extractor.py
@@ -11,6 +11,7 @@ from metaphor.models.metadata_change_event import (
     DataMonitorTarget,
     DataPlatform,
     Dataset,
+    DatasetLogicalID,
     DbtModel,
     DbtTest,
     VirtualView,
@@ -159,7 +160,12 @@ def test_extend_test_run_results_entities(mock_discovery_api_class: MagicMock):
                 ]
             ),
         ),
-        Dataset(),
+        Dataset(
+            logical_id=DatasetLogicalID(
+                name="a.b.c",
+                platform=DataPlatform.UNKNOWN,
+            )
+        ),
         VirtualView(),
     ]
 


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

It is possible for `run_results.json` to not have the results of previously run tests. Since dbt cloud provides the discovery API for metadata discovery, we should use that instead of only relying on `run_results.json`. We should not overwrite the data monitors collected by DbtCoreExtractor though; the monitors we collected via discovery API are only added to the collected entities if it does not exist before. 

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Added logic in `dbt.cloud.DbtCloudExtractor` to extend core's parsed entities with test results parsed from discovery api.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

- Crawler run locally, seems normal
- Successfully ingested data monitors into andy.dev.metaphor.io.
- Added unit test.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
