### PR TITLE
[sc-26934] Expose `query_log_batch_size_count` as a config value

### DIFF
--- a/metaphor/common/docs/output.md
+++ b/metaphor/common/docs/output.md
@@ -22,6 +22,9 @@ output:
 
     # (Optional) IAM role to assume. Default using the current AWS credential.
     assume_role_arn: <iam_role_arn>
+
+    # (Optional) Maximum number of query logs to store in one batch file. Default to 100.
+    query_log_batch_size_count: <query_logs_per_file>
 ```
 
 ## Output to S3

--- a/metaphor/common/query_history.py
+++ b/metaphor/common/query_history.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 from metaphor.common.utils import is_email
 
 # max number of query logs to output in one MCE
-DEFAULT_QUERY_LOG_OUTPUT_SIZE = 100
+DEFAULT_QUERY_LOG_BATCH_SIZE_COUNT = 100
 
 
 def user_id_or_email(maybe_email: str) -> Tuple[Optional[str], Optional[str]]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.16"
+version = "0.14.17"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/common/test_file_sink.py
+++ b/tests/common/test_file_sink.py
@@ -153,7 +153,11 @@ def test_sink_file(test_root_dir):
 def test_query_log_sink_chunk_by_count():
     directory = tempfile.mkdtemp()
 
-    sink = FileSink(FileSinkConfig(directory=directory, batch_size_count=3))
+    sink = FileSink(
+        FileSinkConfig(
+            directory=directory, batch_size_count=3, query_log_batch_size_count=2
+        )
+    )
     query_logs = [
         QueryLog(
             id=f"{DataPlatform.SNOWFLAKE.name}:{query_id}",
@@ -167,7 +171,7 @@ def test_query_log_sink_chunk_by_count():
             f"this is query no. {x}" for x in range(17)
         )
     ]
-    with sink.get_query_log_sink(2) as query_log_sink:
+    with sink.get_query_log_sink() as query_log_sink:
         for query_log in query_logs:
             query_log_sink.write_query_log(query_log)
 


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Ovative's lineage parser is timing out. Currently the lineage parser is able to handle individual queries, but the lineage lambda actually writes all parsed lineage into MongoDB one *all* queries have been parsed, which causes a single batch that contains multiple very long queries not being written to MongoDB at all.

One way to solve this is to reduce the number of query logs in a single batch file. Before it's hard-coded to 100,  but we probably want to expose this config value and try out different possible values to see if that'll fix the issue.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Exposed `query_log_batch_size_count` in `FileSinkConfig`. Set it like
```yaml
output:
    file:
        directory: ...
        query_log_batch_size_count: ... /// Default is 100
```

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Tested locally, verified that with different `query_log_batch_size_count` the number of queries in a single batch file does change.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
