### PR TITLE
Snowflake last update time is not correct

### DIFF
--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -392,7 +392,7 @@ class SnowflakeExtractor(BaseExtractor):
             timestamp = results[f"UPDATED_{normalized_name}"]
             if timestamp > 0:
                 dataset.source_info.last_updated = to_utc_datetime_from_timestamp(
-                    timestamp / 1_000_000_1000
+                    timestamp / 1_000_000_000
                 )
 
     def _fetch_unique_keys(self, cursor: SnowflakeCursor) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.19"
+version = "0.14.20"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/snowflake/test_extractor.py
+++ b/tests/snowflake/test_extractor.py
@@ -205,7 +205,7 @@ def test_fetch_table_info(mock_connect: MagicMock):
 
     mock_cursor.fetchone.return_value = {
         f"DDL_{normalized_name}": "ddl",
-        f"UPDATED_{normalized_name}": 1,
+        f"UPDATED_{normalized_name}": 1719327434000000000,
     }
 
     extractor = SnowflakeExtractor(make_snowflake_config())
@@ -220,8 +220,8 @@ def test_fetch_table_info(mock_connect: MagicMock):
     extractor._fetch_table_info({normalized_name: table_info}, False, set())
 
     assert dataset.schema.sql_schema.table_schema == "ddl"
-    assert dataset.source_info.last_updated == datetime.fromtimestamp(
-        0, tz=timezone.utc
+    assert dataset.source_info.last_updated == datetime(
+        2024, 6, 25, 14, 57, 14, tzinfo=timezone.utc
     )
 
 


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

There is a typo when converting nanosecond to second timestamp...

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

- Fix the typo
- Update test cases, we are not using meaningful timestamp here.

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

- Check unit tests
- Check output MCEs

<img width="753" alt="image" src="https://github.com/MetaphorData/connectors/assets/4019086/12309419-5857-4479-b513-15a20af1f249">

<!--
  Describe how the change was tested end-to-end.
-->

### ☑️ Checks




<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
