### PR TITLE
[sc-27082] Split up `stl_querytext` table with OVER before aggregating query text rows

### DIFF
--- a/metaphor/redshift/access_event.py
+++ b/metaphor/redshift/access_event.py
@@ -12,7 +12,23 @@ SELECT DISTINCT
     ss.rows,
     ss.bytes,
     ss.tbl,
-    LISTAGG(CASE WHEN LEN(RTRIM(sqt.text)) = 0 THEN sqt.text ELSE RTRIM(sqt.text) END, '') within group (order by sqt.sequence) AS querytxt,
+    REPLACE(
+        REPLACE(
+            LISTAGG(
+                CASE
+                    WHEN LEN(RTRIM(sqt.text)) = 0 THEN sqt.text
+                    ELSE RTRIM(sqt.text)
+                END,
+                ''
+            )
+            WITHIN GROUP (ORDER BY sqt.sequence)
+            OVER (
+                PARTITION BY sqt.userid, sqt.xid, sqt.pid, sqt.query
+            ),
+            '\r', ''
+        ),
+        '\\n', ''
+    ) AS querytxt,
     sti.database,
     sti.schema,
     sti.table,
@@ -40,7 +56,13 @@ GROUP BY
     sq.starttime,
     sq.endtime,
     sq.aborted,
-    ss.endtime
+    ss.endtime,
+    sqt.text,
+    sqt.userid,
+    sqt.xid,
+    sqt.pid,
+    sqt.query,
+    sqt.sequence
 ORDER BY ss.endtime DESC;
 """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.20"
+version = "0.14.21"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.21"
+version = "0.14.22"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->


The Redshift crawler could fail while collecting query logs if there are a lot of queries in the cluster:
```
Invalid operation: Result size exceeds LISTAGG limit
```
To avoid that, we split `stl_querytext` with `OVER` clause before doing `LISTAGG`, so that we're doing `LISTAGG` on single queries instead of the whole column.

Reference: https://thedataguy.in/redshift-reconstructing-sql-from-sql-querytext/

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Split up `stl_querytext` table with OVER before aggregating query text rows

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Run the updated query against our own Redshift cluster. Our cluster does not have much going on though, so it's hard to say how this change will impact the performance in production.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
