### PR TITLE
add exclude options to Metabase crawler [sc-27133]

### DIFF
--- a/metaphor/metabase/README.md
+++ b/metaphor/metabase/README.md
@@ -39,6 +39,27 @@ database_defaults:
 
 See [Output Config](../common/docs/output.md) for more information.
 
+#### Excluding Directories
+
+You can specify the directories (collection paths) to be included / excluded by the connector. By default all assets are included.
+
+To specify the directories to include / exclude, use the following field:
+
+```yaml
+directories_filter:
+  includes:
+    - directory/path/1
+    - directory/path/2
+    ...
+  excludes:
+    - directory/path/3
+    - directory/path/4
+    ...
+```
+
+To only include specific paths, use `includes` field. To only exclude certain paths, use `excludes` field.
+
+
 ## Testing
 
 Follow the [Installation](../../README.md) instructions to install `metaphor-connectors` in your environment (or virtualenv). Make sure to include either `all` or `metabase` extra.

--- a/metaphor/metabase/config.py
+++ b/metaphor/metabase/config.py
@@ -14,9 +14,25 @@ class MetabaseDatabaseDefaults:
 
 
 @dataclass(config=ConnectorConfig)
+class MetabaseAssetFilter:
+    includes: List[str] = field(default_factory=list)
+    excludes: List[str] = field(default_factory=list)
+
+    def include_path(self, collection_path: List[str]):
+        path = "/".join(collection_path)
+        if self.includes and not any(path.startswith(item) for item in self.includes):
+            return False
+        if self.excludes and any(path.startswith(item) for item in self.excludes):
+            return False
+        return True
+
+
+@dataclass(config=ConnectorConfig)
 class MetabaseRunConfig(BaseConfig):
     server_url: str
     username: str
     password: str
 
     database_defaults: List[MetabaseDatabaseDefaults] = field(default_factory=list)
+
+    asset_filter: MetabaseAssetFilter = field(default_factory=MetabaseAssetFilter)

--- a/metaphor/metabase/config.py
+++ b/metaphor/metabase/config.py
@@ -35,4 +35,4 @@ class MetabaseRunConfig(BaseConfig):
 
     database_defaults: List[MetabaseDatabaseDefaults] = field(default_factory=list)
 
-    asset_filter: MetabaseAssetFilter = field(default_factory=MetabaseAssetFilter)
+    filter: MetabaseAssetFilter = field(default_factory=MetabaseAssetFilter)

--- a/metaphor/metabase/extractor.py
+++ b/metaphor/metabase/extractor.py
@@ -90,7 +90,7 @@ class MetabaseExtractor(BaseExtractor):
         self._password = config.password
         self._session = requests.session()
         self._database_defaults = config.database_defaults
-        self._asset_filter = config.asset_filter
+        self._filter = config.filter
 
         self._databases: Dict[int, DatabaseInfo] = {}
         self._dashboards: Dict[int, Dashboard] = {}
@@ -183,13 +183,13 @@ class MetabaseExtractor(BaseExtractor):
             return
 
         parent_path = location.split("/")[1:-1]
-        logger.info(
+        logger.debug(
             f"location {location}, parent_path {parent_path}, collection {collection_id}"
         )
 
         path = parent_path + [str(collection_id)]
-        if not self._asset_filter.include_path(path):
-            logger.info(f"skipping hierachy path {path}")
+        if not self._filter.include_path(path):
+            logger.info(f"skipping hierarchy path {path}")
             return
 
         hierarchy = Hierarchy(
@@ -261,7 +261,7 @@ class MetabaseExtractor(BaseExtractor):
         )
 
         path = collection.logical_id.path[1:] if collection else []
-        if not self._asset_filter.include_path(path):
+        if not self._filter.include_path(path):
             logger.info(f"skipping collection path {path}")
             return
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.22"
+version = "0.14.23"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/metabase/config_exclude_paths.yml
+++ b/tests/metabase/config_exclude_paths.yml
@@ -7,7 +7,7 @@ database_defaults:
     default_schema: SCH
   - id: 2
     default_schema: SCH2
-asset_filter:
+filter:
   includes:
     - a
     - b/c

--- a/tests/metabase/config_exclude_paths.yml
+++ b/tests/metabase/config_exclude_paths.yml
@@ -1,0 +1,17 @@
+---
+server_url: https://metaphor.metabaseapp.com
+username: foo
+password: bar
+database_defaults:
+  - id: 1
+    default_schema: SCH
+  - id: 2
+    default_schema: SCH2
+asset_filter:
+  includes:
+    - a
+    - b/c
+  excludes:
+    - a/1
+    - b/c/d
+output: {}

--- a/tests/metabase/test_config.py
+++ b/tests/metabase/test_config.py
@@ -21,17 +21,17 @@ def test_yaml_config(test_root_dir):
         ],
         output=OutputConfig(),
     )
-    assert config.asset_filter.include_path([])
-    assert config.asset_filter.include_path(["a"])
+    assert config.filter.include_path([])
+    assert config.filter.include_path(["a"])
 
 
 def test_excluded_paths(test_root_dir) -> None:
     config = MetabaseRunConfig.from_yaml_file(
         f"{test_root_dir}/metabase/config_exclude_paths.yml"
     )
-    assert not config.asset_filter.include_path(["1"])
-    assert not config.asset_filter.include_path(["a", "1"])
-    assert config.asset_filter.include_path(["a", "2"])
-    assert config.asset_filter.include_path(["b", "c"])
-    assert config.asset_filter.include_path(["b", "c", "1"])
-    assert not config.asset_filter.include_path(["b", "c", "d"])
+    assert not config.filter.include_path(["1"])
+    assert not config.filter.include_path(["a", "1"])
+    assert config.filter.include_path(["a", "2"])
+    assert config.filter.include_path(["b", "c"])
+    assert config.filter.include_path(["b", "c", "1"])
+    assert not config.filter.include_path(["b", "c", "d"])

--- a/tests/metabase/test_config.py
+++ b/tests/metabase/test_config.py
@@ -21,3 +21,17 @@ def test_yaml_config(test_root_dir):
         ],
         output=OutputConfig(),
     )
+    assert config.asset_filter.include_path([])
+    assert config.asset_filter.include_path(["a"])
+
+
+def test_excluded_paths(test_root_dir) -> None:
+    config = MetabaseRunConfig.from_yaml_file(
+        f"{test_root_dir}/metabase/config_exclude_paths.yml"
+    )
+    assert not config.asset_filter.include_path(["1"])
+    assert not config.asset_filter.include_path(["a", "1"])
+    assert config.asset_filter.include_path(["a", "2"])
+    assert config.asset_filter.include_path(["b", "c"])
+    assert config.asset_filter.include_path(["b", "c", "1"])
+    assert not config.asset_filter.include_path(["b", "c", "d"])


### PR DESCRIPTION
### 🤔 Why?

To be able to filter Metabase assets based on collection path

### 🤓 What?

- add asset_filter in metabase config
- support filtering assets based on collection path (directory)

### 🧪 Tested?

tested against Metaphor instance.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
