### PR TITLE
[sc-27082] Filter out the query texts that go beyond the size limit

### DIFF
--- a/metaphor/redshift/access_event.py
+++ b/metaphor/redshift/access_event.py
@@ -73,6 +73,11 @@ GROUP BY
     q.sequence
 ORDER BY ss.endtime DESC;
 """
+"""
+The condition `q.length < 65536` is because Redshift's LISTAGG method
+is unable to process the query if it is over 65535 characters long.
+See https://docs.aws.amazon.com/redshift/latest/dg/r_WF_LISTAGG.html#r_WF_LISTAGG-data-types
+"""
 
 
 @dataclass(frozen=True)

--- a/metaphor/redshift/access_event.py
+++ b/metaphor/redshift/access_event.py
@@ -5,6 +5,13 @@ from typing import AsyncIterator
 from asyncpg import Connection, Record
 
 REDSHIFT_USAGE_SQL_TEMPLATE = """
+WITH queries as (
+    SELECT
+        sqt.*,
+        SUM(LEN(sqt.text)) OVER (PARTITION BY sqt.query) AS length
+    FROM stl_querytext as sqt
+    ORDER BY length DESC, sqt.sequence
+)
 SELECT DISTINCT
     ss.userid,
     ss.query,
@@ -16,14 +23,14 @@ SELECT DISTINCT
         REPLACE(
             LISTAGG(
                 CASE
-                    WHEN LEN(RTRIM(sqt.text)) = 0 THEN sqt.text
-                    ELSE RTRIM(sqt.text)
+                    WHEN LEN(RTRIM(q.text)) = 0 THEN q.text
+                    ELSE RTRIM(q.text)
                 END,
                 ''
             )
-            WITHIN GROUP (ORDER BY sqt.sequence)
+            WITHIN GROUP (ORDER BY q.sequence)
             OVER (
-                PARTITION BY sqt.userid, sqt.xid, sqt.pid, sqt.query
+                PARTITION BY q.userid, q.xid, q.pid, q.query
             ),
             '\r', ''
         ),
@@ -38,11 +45,12 @@ SELECT DISTINCT
 FROM stl_scan ss
     JOIN svv_table_info sti ON ss.tbl = sti.table_id
     JOIN stl_query sq ON ss.query = sq.query
-    JOIN stl_querytext sqt ON ss.query = sqt.query
+    JOIN queries q ON ss.query = q.query
     JOIN svl_user_info sui ON sq.userid = sui.usesysid
 WHERE ss.starttime >= '{start_time}'
     AND ss.starttime < '{end_time}'
     AND sq.aborted = 0
+    AND q.length < 65536
 GROUP BY
     ss.userid,
     ss.query,
@@ -57,12 +65,12 @@ GROUP BY
     sq.endtime,
     sq.aborted,
     ss.endtime,
-    sqt.text,
-    sqt.userid,
-    sqt.xid,
-    sqt.pid,
-    sqt.query,
-    sqt.sequence
+    q.text,
+    q.userid,
+    q.xid,
+    q.pid,
+    q.query,
+    q.sequence
 ORDER BY ss.endtime DESC;
 """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.24"
+version = "0.14.25"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.23"
+version = "0.14.24"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

The `LISTAGG` expression was failing because there are SQL queries that are longer than 65535 characters. These really long queries are generated by things like DBT or Hex, and very likely not have any lineage in them.

Instead of trying to concatenate these queries in crawler code, it is perhaps better to just ignore them.

This PR stems from a Slack conversation with BioRender. _**This PR should not be merged until someone else gives the green light!**_

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Filter out the queries that go beyond 65535 characters.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Tested on our own Redshift cluster:
- Import a large dataset
- Do a bunch of selects
- Set the size limit to 100
- Run the modified query in console
- Observe there are only a few queries that are below the size limit

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
