### PR TITLE
[sc-27082] Do the query text concatenation as CTE

### DIFF
--- a/metaphor/redshift/access_event.py
+++ b/metaphor/redshift/access_event.py
@@ -5,41 +5,28 @@ from typing import AsyncIterator
 from asyncpg import Connection, Record
 
 REDSHIFT_USAGE_SQL_TEMPLATE = """
-WITH queries as (
+WITH queries AS (
     SELECT
         *,
         SUM(LEN(text)) OVER (PARTITION BY query) AS length
     FROM
         stl_querytext
-), filtered_queries as (
+), filtered AS (
     SELECT
-        *
+        q.query,
+        LISTAGG(
+            CASE
+                WHEN LEN(RTRIM(q.text)) = 0 THEN q.text
+                ELSE RTRIM(q.text)
+            END,
+            ''
+        ) WITHIN GROUP (ORDER BY q.sequence) AS querytxt
     FROM
-        queries
+        queries AS q
     WHERE
-        length < 65536
-), concatenated_queries as (
-    SELECT
-        query,
-        REPLACE(
-            REPLACE(
-                LISTAGG(
-                    CASE
-                        WHEN LEN(RTRIM(text)) = 0 THEN text
-                        ELSE RTRIM(text)
-                    END,
-                    ''
-                )
-                WITHIN GROUP (ORDER BY sequence)
-                OVER (
-                    PARTITION BY userid, xid, pid, query
-                ),
-                '\r', ''
-            ),
-            '\\n', ''
-        ) AS querytxt
-    FROM
-        filtered_queries
+        q.length < 65536
+    GROUP BY
+        q.query
 )
 SELECT DISTINCT
     ss.userid,
@@ -58,24 +45,11 @@ SELECT DISTINCT
 FROM stl_scan ss
     JOIN svv_table_info sti ON ss.tbl = sti.table_id
     JOIN stl_query sq ON ss.query = sq.query
-    JOIN concatenated_queries q ON ss.query = q.query
+    JOIN filtered q ON ss.query = q.query
     JOIN svl_user_info sui ON sq.userid = sui.usesysid
-WHERE sq.aborted = 0
-GROUP BY
-    ss.userid,
-    ss.query,
-    sui.usename,
-    ss.rows,
-    ss.bytes,
-    ss.tbl,
-    sti.database,
-    sti.schema,
-    sti.table,
-    sq.starttime,
-    sq.endtime,
-    sq.aborted,
-    ss.endtime,
-    q.querytxt
+WHERE ss.starttime >= '{start_time}'
+    AND ss.starttime < '{end_time}'
+    AND sq.aborted = 0
 ORDER BY ss.endtime DESC;
 """
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.26"
+version = "0.14.27"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

I don't know why it is still failing, I guess it has to do with the order of execution within the entire SELECT statement?

Anyway I think the safest approach is to split the query collection into multiple stages:
1. Get the length of the queries
2. Filter out the queries that are too long
3. Do the LISTAGG
We then combine the queries back into the main SELECT.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Fix the access event query.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

- Tested against our own redshift cluster.
- Tested on production: 
<img width="1190" alt="截圖 2024-07-04 下午5 01 22" src="https://github.com/MetaphorData/connectors/assets/6112039/0e0264da-f014-44c8-a707-24e91df1c2fe">

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
