### PR TITLE
Should not fill out last update time in the UC profile crawler

### DIFF
--- a/metaphor/unity_catalog/profile/extractor.py
+++ b/metaphor/unity_catalog/profile/extractor.py
@@ -179,12 +179,6 @@ class UnityCatalogProfileExtractor(BaseExtractor):
                 )
                 field_statistics.field_statistics.append(stats)
 
-            cursor.execute(f"DESCRIBE HISTORY {escaped_name}")
-            for history in cursor.fetchall():
-                if history["operation"] not in NON_MODIFICATION_OPERATIONS:
-                    dataset_statistics.last_updated = history["timestamp"]
-                    break
-
         return (
             dataset_statistics,
             None if not field_statistics.field_statistics else field_statistics,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.29"
+version = "0.14.30"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/unity_catalog/profile/expected.json
+++ b/tests/unity_catalog/profile/expected.json
@@ -16,7 +16,6 @@
     },
     "statistics": {
       "dataSizeBytes": 5566.0,
-      "lastUpdated": "2023-10-30T12:06:19+00:00",
       "recordCount": 9487.0
     }
   }

--- a/tests/unity_catalog/profile/test_extractor.py
+++ b/tests/unity_catalog/profile/test_extractor.py
@@ -1,4 +1,3 @@
-import datetime
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -72,19 +71,11 @@ async def test_extractor(
         SimpleNamespace(info_name="num_nulls", info_value="NULL"),
     ]
 
-    mock_latest_history = [
-        {
-            "timestamp": datetime.datetime.fromisoformat("2023-10-30T12:06:19+00:00"),
-            "operation": "CREATE TABLE",
-        }
-    ]
-
     mock_cursor = MagicMock()
     mock_cursor.fetchall = MagicMock()
     mock_cursor.fetchall.side_effect = [
         mock_rows,
         mock_col2_stats,
-        mock_latest_history,
     ]
 
     mock_cursor_ctx = MagicMock()


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

Because the the updated time is moved to `SourceInfo` so we need to remove these lines of code. We can't fill the `sourceInfo.lastUpdated` because the two crawler will overwrite this aspect. The UC connector already has the update time of tables so I think it's safe to remove it from the profile connector

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

- Stop filling `statistics.lastUpdated`

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

Unit tests

<!--
  Describe how the change was tested end-to-end.
-->

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
