### PR TITLE
All crawlers emit normalized fieldPath [sc-27452]

### DIFF
--- a/metaphor/bigquery/profile/extractor.py
+++ b/metaphor/bigquery/profile/extractor.py
@@ -180,7 +180,7 @@ class BigQueryProfileExtractor(BaseExtractor):
         query = ["SELECT COUNT(1)"]
 
         for field in schema.fields:
-            column = field.field_path
+            column = field.field_name
             data_type = field.native_type
 
             if (
@@ -229,7 +229,6 @@ class BigQueryProfileExtractor(BaseExtractor):
 
         index = 1
         for field in schema.fields:
-            column = field.field_path
             data_type = field.native_type
 
             unique_count = None
@@ -266,7 +265,7 @@ class BigQueryProfileExtractor(BaseExtractor):
 
             fields.append(
                 FieldStatistics(
-                    field_path=column,
+                    field_path=field.field_path,
                     distinct_value_count=unique_count,
                     null_value_count=nulls,
                     nonnull_value_count=non_nulls,

--- a/metaphor/common/fieldpath.py
+++ b/metaphor/common/fieldpath.py
@@ -1,4 +1,7 @@
 from enum import Enum
+from typing import Optional
+
+from metaphor.models.metadata_change_event import SchemaField
 
 
 class FieldDataType(Enum):
@@ -10,7 +13,9 @@ class FieldDataType(Enum):
 
 
 def build_field_path(
-    parent_field_path: str, field_name: str, field_type: FieldDataType
+    parent_field_path: str,
+    field_name: str,
+    field_type: FieldDataType = FieldDataType.PRIMITIVE,
 ) -> str:
     """
     Build field path for nested field based on parent field path and field type.
@@ -32,3 +37,23 @@ def build_field_path(
         )
     else:
         raise ValueError(f"Unsupported field data type {field_type}")
+
+
+def build_schema_field(
+    column_name: str,
+    field_type: Optional[str] = None,
+    description: Optional[str] = None,
+    nullable: Optional[bool] = None,
+    field_path: Optional[str] = None,
+) -> SchemaField:
+    """
+    Build a schema field for a simple (non-nested) field based on column information.
+    If no "field_path" is specified, it will use `column_name.lower()`
+    """
+    return SchemaField(
+        field_name=column_name,
+        field_path=field_path or column_name.lower(),
+        native_type=field_type or None,
+        description=description or None,
+        nullable=nullable,
+    )

--- a/metaphor/common/fieldpath.py
+++ b/metaphor/common/fieldpath.py
@@ -12,9 +12,12 @@ class FieldDataType(Enum):
 def build_field_path(
     parent_field_path: str, field_name: str, field_type: FieldDataType
 ) -> str:
-    path = parent_field_path
+    """
+    Build field path for nested field based on parent field path and field type.
+    Field path will be normalized to lowercase
+    """
     field_name_encoded = (
-        field_name.replace(".", "%2E").replace("<", "%3C").replace(">", "%3E")
+        field_name.lower().replace(".", "%2E").replace("<", "%3C").replace(">", "%3E")
     )
 
     if field_type in (
@@ -22,9 +25,10 @@ def build_field_path(
         FieldDataType.RECORD,
         FieldDataType.ARRAY,
     ):
-        path = f"{path}.{field_name_encoded}"
+        return (
+            f"{parent_field_path.lower()}.{field_name_encoded}"
+            if parent_field_path
+            else field_name_encoded
+        )
     else:
         raise ValueError(f"Unsupported field data type {field_type}")
-
-    # remove prefix "." if parent path is emtpy string (top-level field)
-    return path if parent_field_path != "" else path[1:]

--- a/metaphor/dbt/util.py
+++ b/metaphor/dbt/util.py
@@ -220,9 +220,11 @@ def init_schema(dataset: Dataset) -> None:
 
 
 def init_field(fields: List[SchemaField], column: str) -> SchemaField:
-    field = next((f for f in fields if f.field_path == column), None)
+    field = next((f for f in fields if f.field_name == column), None)
     if not field:
-        field = SchemaField(field_path=column, field_name=column, subfields=None)
+        field = SchemaField(
+            field_path=column.lower(), field_name=column, subfields=None
+        )
         fields.append(field)
     return field
 
@@ -244,13 +246,14 @@ def init_field_doc(dataset: Dataset, column: str) -> FieldDocumentation:
         (
             d
             for d in dataset.documentation.field_documentations
-            if d.field_path == column
+            if d.field_path == column.lower()
         ),
         None,
     )
     if not doc:
-        doc = FieldDocumentation()
-        doc.field_path = column
+        doc = FieldDocumentation(
+            field_path=column.lower(),
+        )
         dataset.documentation.field_documentations.append(doc)
     return doc
 

--- a/metaphor/dbt/util.py
+++ b/metaphor/dbt/util.py
@@ -12,6 +12,7 @@ from metaphor.common.entity_id import (
     to_person_entity_id,
     to_virtual_view_entity_id,
 )
+from metaphor.common.fieldpath import build_schema_field
 from metaphor.common.logger import get_logger
 from metaphor.common.utils import is_email
 from metaphor.dbt.config import MetaOwnership, MetaTag
@@ -222,9 +223,7 @@ def init_schema(dataset: Dataset) -> None:
 def init_field(fields: List[SchemaField], column: str) -> SchemaField:
     field = next((f for f in fields if f.field_name == column), None)
     if not field:
-        field = SchemaField(
-            field_path=column.lower(), field_name=column, subfields=None
-        )
+        field = build_schema_field(column)
         fields.append(field)
     return field
 
@@ -242,17 +241,18 @@ def init_field_doc(dataset: Dataset, column: str) -> FieldDocumentation:
         and dataset.documentation.field_documentations is not None
     )
 
+    field_path = column.lower()
     doc = next(
         (
             d
             for d in dataset.documentation.field_documentations
-            if d.field_path == column.lower()
+            if d.field_path == field_path
         ),
         None,
     )
     if not doc:
         doc = FieldDocumentation(
-            field_path=column.lower(),
+            field_path=field_path,
         )
         dataset.documentation.field_documentations.append(doc)
     return doc

--- a/metaphor/glue/extractor.py
+++ b/metaphor/glue/extractor.py
@@ -78,7 +78,7 @@ class GlueExtractor(BaseExtractor):
                 columns.append(
                     SchemaField(
                         field_name=column.get("Name"),
-                        field_path=column.get("Name"),
+                        field_path=column.get("Name").lower(),
                         native_type=column.get("Type"),
                         description=column.get("Comment"),
                         subfields=None,

--- a/metaphor/glue/extractor.py
+++ b/metaphor/glue/extractor.py
@@ -7,6 +7,7 @@ import boto3
 from metaphor.common.base_extractor import BaseExtractor
 from metaphor.common.entity_id import dataset_normalized_name
 from metaphor.common.event_util import ENTITY_TYPES
+from metaphor.common.fieldpath import build_schema_field
 from metaphor.common.logger import get_logger
 from metaphor.common.models import to_dataset_statistics
 from metaphor.common.utils import unique_list
@@ -71,17 +72,14 @@ class GlueExtractor(BaseExtractor):
                 database_names.append(database["Name"])
         return unique_list(database_names)
 
-    def _get_columns(self, storageDescriptor: Any) -> List[SchemaField]:
+    @staticmethod
+    def _get_columns(storageDescriptor: Any) -> List[SchemaField]:
         columns = []
         if storageDescriptor and "Columns" in storageDescriptor:
             for column in storageDescriptor.get("Columns"):
                 columns.append(
-                    SchemaField(
-                        field_name=column.get("Name"),
-                        field_path=column.get("Name").lower(),
-                        native_type=column.get("Type"),
-                        description=column.get("Comment"),
-                        subfields=None,
+                    build_schema_field(
+                        column.get("Name"), column.get("Type"), column.get("Comment")
                     )
                 )
         return columns

--- a/metaphor/hive/extractor.py
+++ b/metaphor/hive/extractor.py
@@ -5,6 +5,7 @@ from pyhive import hive
 from metaphor.common.base_extractor import BaseExtractor
 from metaphor.common.entity_id import dataset_normalized_name
 from metaphor.common.event_util import ENTITY_TYPES
+from metaphor.common.fieldpath import build_schema_field
 from metaphor.common.logger import get_logger
 from metaphor.common.models import to_dataset_statistics
 from metaphor.hive.config import HiveRunConfig
@@ -83,14 +84,7 @@ class HiveExtractor(BaseExtractor):
             fields: List[SchemaField] = []
             cursor.execute(f"describe {database}.{table}")
             for field_name, field_type, comment in cursor:
-                fields.append(
-                    SchemaField(
-                        field_path=field_name.lower(),
-                        field_name=field_name,
-                        native_type=field_type,
-                        description=comment if comment else None,
-                    )
-                )
+                fields.append(build_schema_field(field_name, field_type, comment))
 
             cursor.execute(f"show create table {database}.{table}")
             table_schema = "\n".join(

--- a/metaphor/hive/extractor.py
+++ b/metaphor/hive/extractor.py
@@ -82,10 +82,11 @@ class HiveExtractor(BaseExtractor):
             )
             fields: List[SchemaField] = []
             cursor.execute(f"describe {database}.{table}")
-            for field_path, field_type, comment in cursor:
+            for field_name, field_type, comment in cursor:
                 fields.append(
                     SchemaField(
-                        field_path=field_path,
+                        field_path=field_name.lower(),
+                        field_name=field_name,
                         native_type=field_type,
                         description=comment if comment else None,
                     )
@@ -130,7 +131,7 @@ class HiveExtractor(BaseExtractor):
     ) -> FieldStatistics:
         with self._connection.cursor() as cursor:
             raw_field_statistics: Dict[str, Any] = {
-                "fieldPath": field.field_path,
+                "fieldPath": field.field_name,
             }
 
             chosen_stats: Dict[str, str] = {}
@@ -146,7 +147,7 @@ class HiveExtractor(BaseExtractor):
             if chosen_stats:
                 # Gotta extract column stats calculated by Hive
                 cursor.execute(
-                    f"describe formatted {database}.{table} {field.field_path}"
+                    f"describe formatted {database}.{table} {field.field_name}"
                 )
                 for row in cursor:
                     field_stats_key = chosen_stats.get(row[0])
@@ -156,18 +157,18 @@ class HiveExtractor(BaseExtractor):
                         except Exception:
                             if HiveExtractor._is_numeric_field(field):
                                 logger.warning(
-                                    f"Cannot find {field_stats_key} for field {field.field_path}"
+                                    f"Cannot find {field_stats_key} for field {field.field_name}"
                                 )
 
             def _calculate_by_hand(function: str) -> Optional[float]:
                 try:
                     cursor.execute(
-                        f"select {function}({field.field_path}) from {database}.{table}"
+                        f"select {function}({field.field_name}) from {database}.{table}"
                     )
                     return float(next(cursor)[0])
                 except Exception:
                     logger.exception(
-                        f"Cannot calculate {function} for field {field.field_path}"
+                        f"Cannot calculate {function} for field {field.field_name}"
                     )
                     return None
 

--- a/metaphor/kafka/schema_parsers/avro_parser.py
+++ b/metaphor/kafka/schema_parsers/avro_parser.py
@@ -240,7 +240,7 @@ class AvroParser:
         models = [
             SchemaField(
                 field_name=field_name,
-                field_path=field_name,
+                field_path=field_name.lower(),
                 native_type=str(parsed_schema.type).upper(),
                 subfields=self.get_avro_fields(parsed_schema, field_name),
                 description=AvroParser._safe_get_doc(parsed_schema),

--- a/metaphor/kafka/schema_parsers/protobuf_parser.py
+++ b/metaphor/kafka/schema_parsers/protobuf_parser.py
@@ -9,8 +9,8 @@ from typing import List, Optional
 
 from google.protobuf.descriptor import FileDescriptor  # type: ignore
 
+from metaphor.common.fieldpath import build_field_path
 from metaphor.common.logger import get_logger
-from metaphor.kafka.schema_parsers.utils import get_field_path
 from metaphor.models.metadata_change_event import SchemaField
 
 logger = get_logger()
@@ -123,7 +123,7 @@ class ProtobufParser:
     def _parse_protobuf_fields(self, fields, cur_path: str) -> List[SchemaField]:
         schema_fields = []
         for field in fields:
-            field_path = get_field_path(cur_path, field.name)
+            field_path = build_field_path(cur_path, field.name)
 
             field_type = ProtobufDataTypes(field.type)
             schema_field = SchemaField(

--- a/metaphor/kafka/schema_parsers/utils.py
+++ b/metaphor/kafka/schema_parsers/utils.py
@@ -1,2 +1,0 @@
-def get_field_path(cur_path: str, field_name: str) -> str:
-    return f"{cur_path}.{field_name}".lower() if cur_path else field_name.lower()

--- a/metaphor/kafka/schema_parsers/utils.py
+++ b/metaphor/kafka/schema_parsers/utils.py
@@ -1,2 +1,2 @@
 def get_field_path(cur_path: str, field_name: str) -> str:
-    return ".".join([cur_path, field_name]) if cur_path else field_name
+    return f"{cur_path}.{field_name}".lower() if cur_path else field_name.lower()

--- a/metaphor/mssql/extractor.py
+++ b/metaphor/mssql/extractor.py
@@ -101,7 +101,7 @@ class MssqlExtractor(BaseExtractor):
                     SchemaField(
                         subfields=None,
                         field_name=column.name,
-                        field_path=column.name,
+                        field_path=column.name.lower(),
                         max_length=column.max_length if column.max_length > 0 else None,
                         nullable=column.is_nullable,
                         precision=column.precision,

--- a/metaphor/mysql/extractor.py
+++ b/metaphor/mysql/extractor.py
@@ -100,7 +100,7 @@ class MySQLExtractor(BaseExtractor):
                     SchemaField(
                         description=column.get("comment"),
                         field_name=column.get("name"),
-                        field_path=column.get("name"),
+                        field_path=column.get("name").lower(),
                         native_type=str(column.get("type")),
                         nullable=bool(column.get("nullable")),
                         subfields=None,

--- a/metaphor/mysql/extractor.py
+++ b/metaphor/mysql/extractor.py
@@ -6,6 +6,7 @@ from sqlalchemy.engine import URL, Inspector
 from metaphor.common.base_extractor import BaseExtractor
 from metaphor.common.entity_id import dataset_normalized_name
 from metaphor.common.event_util import ENTITY_TYPES
+from metaphor.common.fieldpath import build_schema_field
 from metaphor.common.filter import DatasetFilter
 from metaphor.common.logger import get_logger
 from metaphor.models.crawler_run_metadata import Platform
@@ -17,7 +18,6 @@ from metaphor.models.metadata_change_event import (
     DatasetStructure,
     ForeignKey,
     MaterializationType,
-    SchemaField,
     SchemaType,
     SQLSchema,
 )
@@ -97,13 +97,11 @@ class MySQLExtractor(BaseExtractor):
                 description=table_info.get("text"),
                 schema_type=SchemaType.SQL,
                 fields=[
-                    SchemaField(
-                        description=column.get("comment"),
-                        field_name=column.get("name"),
-                        field_path=column.get("name").lower(),
-                        native_type=str(column.get("type")),
-                        nullable=bool(column.get("nullable")),
-                        subfields=None,
+                    build_schema_field(
+                        column.get("name"),
+                        str(column.get("type")),
+                        column.get("comment"),
+                        bool(column.get("nullable")),
                     )
                     for column in columns
                 ],

--- a/metaphor/postgresql/extractor.py
+++ b/metaphor/postgresql/extractor.py
@@ -1,5 +1,7 @@
 from typing import Callable, Collection, Dict, List, Optional, Tuple
 
+from metaphor.common.fieldpath import build_schema_field
+
 try:
     import asyncpg
 except ImportError:
@@ -363,16 +365,15 @@ class PostgreSQLExtractor(BaseExtractor):
             native_type, column["format"]
         )
 
-        return SchemaField(
-            field_path=column["column_name"].lower(),
-            field_name=column["column_name"],
-            native_type=native_type,
-            nullable=(not column["not_null"]),
-            description=column["description"],
-            max_length=max_length,
-            precision=precision,
-            subfields=None,
+        field = build_schema_field(
+            column["column_name"],
+            native_type,
+            column["description"],
+            not column["not_null"],
         )
+        field.max_length = max_length
+        field.precision = precision
+        return field
 
     @staticmethod
     def _build_constraint(constraint: Dict, schema: SQLSchema) -> None:

--- a/metaphor/postgresql/extractor.py
+++ b/metaphor/postgresql/extractor.py
@@ -364,7 +364,7 @@ class PostgreSQLExtractor(BaseExtractor):
         )
 
         return SchemaField(
-            field_path=column["column_name"],
+            field_path=column["column_name"].lower(),
             field_name=column["column_name"],
             native_type=native_type,
             nullable=(not column["not_null"]),

--- a/metaphor/postgresql/profile/extractor.py
+++ b/metaphor/postgresql/profile/extractor.py
@@ -113,7 +113,7 @@ class PostgreSQLProfileExtractor(PostgreSQLExtractor):
 
         entities = ["COUNT(1)"]
         for field in dataset.schema.fields:
-            column = f'"{field.field_path}"'
+            column = f'"{field.field_name}"'
             nullable = field.nullable
             is_numeric = field.precision is not None
 
@@ -153,7 +153,6 @@ class PostgreSQLProfileExtractor(PostgreSQLExtractor):
         row_count = int(results[0])
         index = 1
         for field in dataset.schema.fields:
-            column = field.field_path
             nullable = field.nullable
             is_numeric = field.precision is not None
 
@@ -181,7 +180,7 @@ class PostgreSQLProfileExtractor(PostgreSQLExtractor):
 
             dataset.field_statistics.field_statistics.append(
                 FieldStatistics(
-                    field_path=column,
+                    field_path=field.field_path,
                     distinct_value_count=unique_values,
                     null_value_count=nulls,
                     nonnull_value_count=(row_count - nulls),

--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -13,6 +13,8 @@ from typing import (
     Tuple,
 )
 
+from metaphor.common.fieldpath import build_schema_field
+
 try:
     from snowflake.connector.cursor import DictCursor, SnowflakeCursor
     from snowflake.connector.errors import ProgrammingError
@@ -53,7 +55,6 @@ from metaphor.models.metadata_change_event import (
     Hierarchy,
     HierarchyLogicalID,
     QueryLog,
-    SchemaField,
     SchemaType,
     SnowflakeStreamInfo,
     SourceInfo,
@@ -303,18 +304,11 @@ class SnowflakeExtractor(BaseExtractor):
 
             assert dataset.schema is not None and dataset.schema.fields is not None
 
-            dataset.schema.fields.append(
-                SchemaField(
-                    field_path=column.lower(),
-                    field_name=column,
-                    native_type=data_type,
-                    max_length=safe_float(max_length),
-                    precision=safe_float(precision),
-                    nullable=nullable == "YES",
-                    description=comment,
-                    subfields=None,
-                )
-            )
+            field = build_schema_field(column, data_type, comment, nullable == "YES")
+            field.max_length = safe_float(max_length)
+            field.precision = safe_float(precision)
+
+            dataset.schema.fields.append(field)
 
     def _fetch_table_info(
         self,

--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -305,7 +305,7 @@ class SnowflakeExtractor(BaseExtractor):
 
             dataset.schema.fields.append(
                 SchemaField(
-                    field_path=column,
+                    field_path=column.lower(),
                     field_name=column,
                     native_type=data_type,
                     max_length=safe_float(max_length),

--- a/metaphor/trino/extractor.py
+++ b/metaphor/trino/extractor.py
@@ -9,6 +9,7 @@ from trino.dbapi import connect
 from metaphor.common.base_extractor import BaseExtractor
 from metaphor.common.entity_id import dataset_normalized_name, to_dataset_entity_id
 from metaphor.common.event_util import ENTITY_TYPES
+from metaphor.common.fieldpath import build_schema_field
 from metaphor.common.filter import DatasetFilter
 from metaphor.common.logger import get_logger
 from metaphor.common.utils import md5_digest
@@ -174,11 +175,8 @@ class TrinoExtractor(BaseExtractor):
             rows = cursor.fetchall()
             for schema, name, column_name, column_nullable, column_type in rows:
                 table_fields[_Table(catalog, schema, name)].append(
-                    SchemaField(
-                        field_path=column_name.lower(),
-                        field_name=column_name,
-                        nullable=column_nullable == "YES",
-                        native_type=column_type,
+                    build_schema_field(
+                        column_name, column_type, None, column_nullable == "YES"
                     )
                 )
             for table, fields in table_fields.items():

--- a/metaphor/trino/extractor.py
+++ b/metaphor/trino/extractor.py
@@ -175,7 +175,8 @@ class TrinoExtractor(BaseExtractor):
             for schema, name, column_name, column_nullable, column_type in rows:
                 table_fields[_Table(catalog, schema, name)].append(
                     SchemaField(
-                        field_path=column_name,
+                        field_path=column_name.lower(),
+                        field_name=column_name,
                         nullable=column_nullable == "YES",
                         native_type=column_type,
                     )

--- a/metaphor/unity_catalog/models.py
+++ b/metaphor/unity_catalog/models.py
@@ -15,7 +15,7 @@ def extract_schema_field_from_column_info(column: ColumnInfo) -> SchemaField:
     return SchemaField(
         subfields=None,
         field_name=column.name,
-        field_path=column.name,
+        field_path=column.name.lower(),
         native_type=column.type_name.value.lower(),
         precision=(
             float(column.type_precision)

--- a/metaphor/unity_catalog/models.py
+++ b/metaphor/unity_catalog/models.py
@@ -3,6 +3,7 @@ from typing import List, Optional, Union
 from databricks.sdk.service.catalog import ColumnInfo
 from pydantic import BaseModel, field_validator
 
+from metaphor.common.fieldpath import build_schema_field
 from metaphor.common.logger import get_logger
 from metaphor.models.metadata_change_event import SchemaField
 
@@ -10,20 +11,18 @@ logger = get_logger()
 
 
 def extract_schema_field_from_column_info(column: ColumnInfo) -> SchemaField:
-    if column.type_name is None:
+    if column.name is None or column.type_name is None:
         raise ValueError(f"Invalid column {column.name}, no type_name found")
-    return SchemaField(
-        subfields=None,
-        field_name=column.name,
-        field_path=column.name.lower(),
-        native_type=column.type_name.value.lower(),
-        precision=(
-            float(column.type_precision)
-            if column.type_precision is not None
-            else float("nan")
-        ),
-        description=column.comment,
+
+    field = build_schema_field(
+        column.name, column.type_name.value.lower(), column.comment
     )
+    field.precision = (
+        float(column.type_precision)
+        if column.type_precision is not None
+        else float("nan")
+    )
+    return field
 
 
 class NoPermission(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.33"
+version = "0.14.34"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/common/test_fieldpath.py
+++ b/tests/common/test_fieldpath.py
@@ -6,8 +6,8 @@ def test_build_field_path():
     assert build_field_path("", "b", FieldDataType.ARRAY) == "b"
     assert build_field_path("", "c", FieldDataType.RECORD) == "c"
 
-    assert build_field_path("f1", "f2", FieldDataType.RECORD) == "f1.f2"
-    assert build_field_path("f1", "f.<2>", FieldDataType.ARRAY) == "f1.f%2E%3C2%3E"
+    assert build_field_path("F1", "F2", FieldDataType.RECORD) == "f1.f2"
+    assert build_field_path("f1", "F.<2>", FieldDataType.ARRAY) == "f1.f%2E%3C2%3E"
     assert (
         build_field_path("f1.f2.f3", "..<<f4>>", FieldDataType.ARRAY)
         == "f1.f2.f3.%2E%2E%3C%3Cf4%3E%3E"

--- a/tests/hive/expected.json
+++ b/tests/hive/expected.json
@@ -8,6 +8,7 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "id",
           "fieldPath": "id",
           "nativeType": "int"
         }
@@ -43,14 +44,17 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "deptno",
           "fieldPath": "deptno",
           "nativeType": "int"
         },
         {
+          "fieldName": "deptname",
           "fieldPath": "deptname",
           "nativeType": "varchar(256)"
         },
         {
+          "fieldName": "locationid",
           "fieldPath": "locationid",
           "nativeType": "int"
         }
@@ -100,22 +104,27 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "empid",
           "fieldPath": "empid",
           "nativeType": "int"
         },
         {
+          "fieldName": "deptno",
           "fieldPath": "deptno",
           "nativeType": "int"
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(256)"
         },
         {
+          "fieldName": "salary",
           "fieldPath": "salary",
           "nativeType": "float"
         },
         {
+          "fieldName": "hire_date",
           "fieldPath": "hire_date",
           "nativeType": "timestamp"
         }
@@ -179,14 +188,17 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "empid",
           "fieldPath": "empid",
           "nativeType": "int"
         },
         {
+          "fieldName": "deptname",
           "fieldPath": "deptname",
           "nativeType": "varchar(256)"
         },
         {
+          "fieldName": "hire_date",
           "fieldPath": "hire_date",
           "nativeType": "timestamp"
         }
@@ -232,18 +244,22 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "userid",
           "fieldPath": "userid",
           "nativeType": "int"
         },
         {
+          "fieldName": "movieid",
           "fieldPath": "movieid",
           "nativeType": "int"
         },
         {
+          "fieldName": "rating",
           "fieldPath": "rating",
           "nativeType": "int"
         },
         {
+          "fieldName": "unixtime",
           "fieldPath": "unixtime",
           "nativeType": "string"
         }
@@ -264,10 +280,12 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "id",
           "fieldPath": "id",
           "nativeType": "int"
         },
         {
+          "fieldName": "type_name",
           "fieldPath": "type_name",
           "nativeType": "string"
         }
@@ -308,14 +326,17 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "id",
           "fieldPath": "id",
           "nativeType": "int"
         },
         {
+          "fieldName": "ship_type_id",
           "fieldPath": "ship_type_id",
           "nativeType": "int"
         },
         {
+          "fieldName": "crew_size",
           "fieldPath": "crew_size",
           "nativeType": "int"
         }
@@ -369,14 +390,17 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "id",
           "fieldPath": "id",
           "nativeType": "int"
         },
         {
+          "fieldName": "ship_id",
           "fieldPath": "ship_id",
           "nativeType": "int"
         },
         {
+          "fieldName": "admiral_id",
           "fieldPath": "admiral_id",
           "nativeType": "int"
         }
@@ -430,18 +454,22 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "userid",
           "fieldPath": "userid",
           "nativeType": "int"
         },
         {
+          "fieldName": "movieid",
           "fieldPath": "movieid",
           "nativeType": "int"
         },
         {
+          "fieldName": "rating",
           "fieldPath": "rating",
           "nativeType": "int"
         },
         {
+          "fieldName": "unixtime",
           "fieldPath": "unixtime",
           "nativeType": "string"
         }

--- a/tests/hive/test_extractor.py
+++ b/tests/hive/test_extractor.py
@@ -1,3 +1,4 @@
+import json
 import re
 import time
 
@@ -75,6 +76,8 @@ async def test_extractor(test_root_dir: str) -> None:
             events.append(EventUtil.trim_event(entity))
 
         events.sort(key=lambda event: event.get("logicalId", {}).get("name", ""))
+        logger.info(json.dumps(events))
+
         expected = f"{test_root_dir}/hive/expected.json"
 
         assert events == load_json(expected)

--- a/tests/hive/test_extractor.py
+++ b/tests/hive/test_extractor.py
@@ -1,4 +1,3 @@
-import json
 import re
 import time
 
@@ -76,8 +75,6 @@ async def test_extractor(test_root_dir: str) -> None:
             events.append(EventUtil.trim_event(entity))
 
         events.sort(key=lambda event: event.get("logicalId", {}).get("name", ""))
-        logger.info(json.dumps(events))
-
         expected = f"{test_root_dir}/hive/expected.json"
 
         assert events == load_json(expected)

--- a/tests/kafka/schema_parsers/account_event/expected.json
+++ b/tests/kafka/schema_parsers/account_event/expected.json
@@ -1,57 +1,57 @@
 [
   {
     "fieldName": "AccountEvent",
-    "fieldPath": "AccountEvent",
+    "fieldPath": "accountevent",
     "nativeType": "RECORD",
     "subfields": [
       {
         "fieldName": "accountNumber",
-        "fieldPath": "AccountEvent.accountNumber",
+        "fieldPath": "accountevent.accountnumber",
         "nativeType": "STRING"
       },
       {
         "fieldName": "address",
-        "fieldPath": "AccountEvent.address",
+        "fieldPath": "accountevent.address",
         "nativeType": "STRING"
       },
       {
         "fieldName": "accountList",
-        "fieldPath": "AccountEvent.accountList",
+        "fieldPath": "accountevent.accountlist",
         "nativeType": "ARRAY<record>",
         "subfields": [
           {
             "fieldName": "Account",
-            "fieldPath": "AccountEvent.accountList.Account",
+            "fieldPath": "accountevent.accountlist.account",
             "nativeType": "RECORD",
             "subfields": [
               {
                 "fieldName": "accountNumber",
-                "fieldPath": "AccountEvent.accountList.Account.accountNumber",
+                "fieldPath": "accountevent.accountlist.account.accountnumber",
                 "nativeType": "STRING"
               },
               {
                 "fieldName": "id",
-                "fieldPath": "AccountEvent.accountList.Account.id",
+                "fieldPath": "accountevent.accountlist.account.id",
                 "nativeType": "STRING"
               },
               {
                 "fieldName": "accountOwner",
-                "fieldPath": "AccountEvent.accountList.Account.accountOwner",
+                "fieldPath": "accountevent.accountlist.account.accountowner",
                 "nativeType": "RECORD",
                 "subfields": [
                   {
                     "fieldName": "OwnerRecord",
-                    "fieldPath": "AccountEvent.accountList.Account.accountOwner.OwnerRecord",
+                    "fieldPath": "accountevent.accountlist.account.accountowner.ownerrecord",
                     "nativeType": "RECORD",
                     "subfields": [
                       {
                         "fieldName": "name",
-                        "fieldPath": "AccountEvent.accountList.Account.accountOwner.OwnerRecord.name",
+                        "fieldPath": "accountevent.accountlist.account.accountowner.ownerrecord.name",
                         "nativeType": "STRING"
                       },
                       {
                         "fieldName": "email",
-                        "fieldPath": "AccountEvent.accountList.Account.accountOwner.OwnerRecord.email",
+                        "fieldPath": "accountevent.accountlist.account.accountowner.ownerrecord.email",
                         "nativeType": "STRING"
                       }
                     ]

--- a/tests/kafka/schema_parsers/complex/expected.json
+++ b/tests/kafka/schema_parsers/complex/expected.json
@@ -2,59 +2,59 @@
   {
     "description": "application messages",
     "fieldName": "myRecord",
-    "fieldPath": "myRecord",
+    "fieldPath": "myrecord",
     "nativeType": "RECORD",
     "subfields": [
       {
         "fieldName": "requestResponse",
-        "fieldPath": "myRecord.requestResponse",
+        "fieldPath": "myrecord.requestresponse",
         "nativeType": "UNION<record,record>",
         "subfields": [
           {
             "fieldName": "record_request",
-            "fieldPath": "myRecord.requestResponse.record_request",
+            "fieldPath": "myrecord.requestresponse.record_request",
             "nativeType": "RECORD",
             "subfields": [
               {
                 "fieldName": "request_id",
-                "fieldPath": "myRecord.requestResponse.record_request.request_id",
+                "fieldPath": "myrecord.requestresponse.record_request.request_id",
                 "nativeType": "INT"
               },
               {
                 "fieldName": "message_type",
-                "fieldPath": "myRecord.requestResponse.record_request.message_type",
+                "fieldPath": "myrecord.requestresponse.record_request.message_type",
                 "nativeType": "INT"
               },
               {
                 "fieldName": "users",
-                "fieldPath": "myRecord.requestResponse.record_request.users",
+                "fieldPath": "myrecord.requestresponse.record_request.users",
                 "nativeType": "STRING"
               }
             ]
           },
           {
             "fieldName": "request_response",
-            "fieldPath": "myRecord.requestResponse.request_response",
+            "fieldPath": "myrecord.requestresponse.request_response",
             "nativeType": "RECORD",
             "subfields": [
               {
                 "fieldName": "request_id",
-                "fieldPath": "myRecord.requestResponse.request_response.request_id",
+                "fieldPath": "myrecord.requestresponse.request_response.request_id",
                 "nativeType": "INT"
               },
               {
                 "fieldName": "response_code",
-                "fieldPath": "myRecord.requestResponse.request_response.response_code",
+                "fieldPath": "myrecord.requestresponse.request_response.response_code",
                 "nativeType": "STRING"
               },
               {
                 "fieldName": "response_count",
-                "fieldPath": "myRecord.requestResponse.request_response.response_count",
+                "fieldPath": "myrecord.requestresponse.request_response.response_count",
                 "nativeType": "INT"
               },
               {
                 "fieldName": "reason_code",
-                "fieldPath": "myRecord.requestResponse.request_response.reason_code",
+                "fieldPath": "myrecord.requestresponse.request_response.reason_code",
                 "nativeType": "STRING"
               }
             ]

--- a/tests/kafka/schema_parsers/nested_arrays/expected.json
+++ b/tests/kafka/schema_parsers/nested_arrays/expected.json
@@ -1,27 +1,27 @@
 [
   {
     "fieldName": "Top",
-    "fieldPath": "Top",
+    "fieldPath": "top",
     "nativeType": "RECORD",
     "subfields": [
       {
         "fieldName": "FirstLayer",
-        "fieldPath": "Top.FirstLayer",
+        "fieldPath": "top.firstlayer",
         "nativeType": "ARRAY<ARRAY<ARRAY<record>>>",
         "subfields": [
           {
             "fieldName": "Leaf",
-            "fieldPath": "Top.FirstLayer.Leaf",
+            "fieldPath": "top.firstlayer.leaf",
             "nativeType": "RECORD",
             "subfields": [
               {
                 "fieldName": "id",
-                "fieldPath": "Top.FirstLayer.Leaf.id",
+                "fieldPath": "top.firstlayer.leaf.id",
                 "nativeType": "STRING"
               },
               {
                 "fieldName": "LeafArray",
-                "fieldPath": "Top.FirstLayer.Leaf.LeafArray",
+                "fieldPath": "top.firstlayer.leaf.leafarray",
                 "nativeType": "ARRAY<ARRAY<string>>"
               }
             ]

--- a/tests/kafka/schema_parsers/simple_union/expected.json
+++ b/tests/kafka/schema_parsers/simple_union/expected.json
@@ -1,17 +1,17 @@
 [
   {
     "fieldName": "FullName",
-    "fieldPath": "FullName",
+    "fieldPath": "fullname",
     "nativeType": "RECORD",
     "subfields": [
       {
         "fieldName": "first",
-        "fieldPath": "FullName.first",
+        "fieldPath": "fullname.first",
         "nativeType": "UNION<string,null>"
       },
       {
         "fieldName": "last",
-        "fieldPath": "FullName.last",
+        "fieldPath": "fullname.last",
         "nativeType": "STRING"
       }
     ]

--- a/tests/kafka/schema_parsers/union/expected.json
+++ b/tests/kafka/schema_parsers/union/expected.json
@@ -1,27 +1,27 @@
 [
   {
     "fieldName": "UnionRecord",
-    "fieldPath": "UnionRecord",
+    "fieldPath": "unionrecord",
     "nativeType": "RECORD",
     "subfields": [
       {
         "fieldName": "field",
-        "fieldPath": "UnionRecord.field",
+        "fieldPath": "unionrecord.field",
         "nativeType": "UNION<record,int,string,null>",
         "subfields": [
           {
             "fieldName": "Record",
-            "fieldPath": "UnionRecord.field.Record",
+            "fieldPath": "unionrecord.field.record",
             "nativeType": "RECORD",
             "subfields": [
               {
                 "fieldName": "ID",
-                "fieldPath": "UnionRecord.field.Record.ID",
+                "fieldPath": "unionrecord.field.record.id",
                 "nativeType": "STRING"
               },
               {
                 "fieldName": "name",
-                "fieldPath": "UnionRecord.field.Record.name",
+                "fieldPath": "unionrecord.field.record.name",
                 "nativeType": "STRING"
               }
             ]

--- a/tests/kafka/test_schema_resolver.py
+++ b/tests/kafka/test_schema_resolver.py
@@ -92,7 +92,7 @@ def test_schema_resolver(
         fields=[
             SchemaField(
                 field_name="<NA>",
-                field_path="<NA>",
+                field_path="<na>",
                 native_type="STRING",
                 subfields=[],
             )
@@ -105,7 +105,7 @@ def test_schema_resolver(
         fields=[
             SchemaField(
                 field_name="<NA>",
-                field_path="<NA>",
+                field_path="<na>",
                 native_type="DOUBLE",
                 subfields=[],
             )
@@ -122,7 +122,7 @@ def test_schema_resolver(
         fields=[
             SchemaField(
                 field_name="<NA>",
-                field_path="<NA>",
+                field_path="<na>",
                 native_type="STRING",
                 subfields=[],
             )

--- a/tests/trino/expected.json
+++ b/tests/trino/expected.json
@@ -9,26 +9,31 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "partkey",
           "fieldPath": "partkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "suppkey",
           "fieldPath": "suppkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "availqty",
           "fieldPath": "availqty",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "supplycost",
           "fieldPath": "supplycost",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(199)",
           "nullable": false
@@ -46,36 +51,43 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "suppkey",
           "fieldPath": "suppkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "address",
           "fieldPath": "address",
           "nativeType": "varchar(40)",
           "nullable": false
         },
         {
+          "fieldName": "nationkey",
           "fieldPath": "nationkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "phone",
           "fieldPath": "phone",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "acctbal",
           "fieldPath": "acctbal",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(101)",
           "nullable": false
@@ -93,36 +105,43 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "suppkey",
           "fieldPath": "suppkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "address",
           "fieldPath": "address",
           "nativeType": "varchar(40)",
           "nullable": false
         },
         {
+          "fieldName": "nationkey",
           "fieldPath": "nationkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "phone",
           "fieldPath": "phone",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "acctbal",
           "fieldPath": "acctbal",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(101)",
           "nullable": false
@@ -140,26 +159,31 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "partkey",
           "fieldPath": "partkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "suppkey",
           "fieldPath": "suppkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "availqty",
           "fieldPath": "availqty",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "supplycost",
           "fieldPath": "supplycost",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(199)",
           "nullable": false
@@ -177,26 +201,31 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "partkey",
           "fieldPath": "partkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "suppkey",
           "fieldPath": "suppkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "availqty",
           "fieldPath": "availqty",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "supplycost",
           "fieldPath": "supplycost",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(199)",
           "nullable": false
@@ -214,46 +243,55 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "orderkey",
           "fieldPath": "orderkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "custkey",
           "fieldPath": "custkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "orderstatus",
           "fieldPath": "orderstatus",
           "nativeType": "varchar(1)",
           "nullable": false
         },
         {
+          "fieldName": "totalprice",
           "fieldPath": "totalprice",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "orderdate",
           "fieldPath": "orderdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "orderpriority",
           "fieldPath": "orderpriority",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "clerk",
           "fieldPath": "clerk",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "shippriority",
           "fieldPath": "shippriority",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(79)",
           "nullable": false
@@ -271,16 +309,19 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "regionkey",
           "fieldPath": "regionkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(152)",
           "nullable": false
@@ -298,26 +339,31 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "partkey",
           "fieldPath": "partkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "suppkey",
           "fieldPath": "suppkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "availqty",
           "fieldPath": "availqty",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "supplycost",
           "fieldPath": "supplycost",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(199)",
           "nullable": false
@@ -335,81 +381,97 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "orderkey",
           "fieldPath": "orderkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "partkey",
           "fieldPath": "partkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "suppkey",
           "fieldPath": "suppkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "linenumber",
           "fieldPath": "linenumber",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "quantity",
           "fieldPath": "quantity",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "extendedprice",
           "fieldPath": "extendedprice",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "discount",
           "fieldPath": "discount",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "tax",
           "fieldPath": "tax",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "returnflag",
           "fieldPath": "returnflag",
           "nativeType": "varchar(1)",
           "nullable": false
         },
         {
+          "fieldName": "linestatus",
           "fieldPath": "linestatus",
           "nativeType": "varchar(1)",
           "nullable": false
         },
         {
+          "fieldName": "shipdate",
           "fieldPath": "shipdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "commitdate",
           "fieldPath": "commitdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "receiptdate",
           "fieldPath": "receiptdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "shipinstruct",
           "fieldPath": "shipinstruct",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "shipmode",
           "fieldPath": "shipmode",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(44)",
           "nullable": false
@@ -427,46 +489,55 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "partkey",
           "fieldPath": "partkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(55)",
           "nullable": false
         },
         {
+          "fieldName": "mfgr",
           "fieldPath": "mfgr",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "brand",
           "fieldPath": "brand",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "type",
           "fieldPath": "type",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "size",
           "fieldPath": "size",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "container",
           "fieldPath": "container",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "retailprice",
           "fieldPath": "retailprice",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(23)",
           "nullable": false
@@ -484,21 +555,25 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "nationkey",
           "fieldPath": "nationkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "regionkey",
           "fieldPath": "regionkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(152)",
           "nullable": false
@@ -516,46 +591,55 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "orderkey",
           "fieldPath": "orderkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "custkey",
           "fieldPath": "custkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "orderstatus",
           "fieldPath": "orderstatus",
           "nativeType": "varchar(1)",
           "nullable": false
         },
         {
+          "fieldName": "totalprice",
           "fieldPath": "totalprice",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "orderdate",
           "fieldPath": "orderdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "orderpriority",
           "fieldPath": "orderpriority",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "clerk",
           "fieldPath": "clerk",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "shippriority",
           "fieldPath": "shippriority",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(79)",
           "nullable": false
@@ -573,36 +657,43 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "suppkey",
           "fieldPath": "suppkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "address",
           "fieldPath": "address",
           "nativeType": "varchar(40)",
           "nullable": false
         },
         {
+          "fieldName": "nationkey",
           "fieldPath": "nationkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "phone",
           "fieldPath": "phone",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "acctbal",
           "fieldPath": "acctbal",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(101)",
           "nullable": false
@@ -620,16 +711,19 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "regionkey",
           "fieldPath": "regionkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(152)",
           "nullable": false
@@ -647,41 +741,49 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "custkey",
           "fieldPath": "custkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "address",
           "fieldPath": "address",
           "nativeType": "varchar(40)",
           "nullable": false
         },
         {
+          "fieldName": "nationkey",
           "fieldPath": "nationkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "phone",
           "fieldPath": "phone",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "acctbal",
           "fieldPath": "acctbal",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "mktsegment",
           "fieldPath": "mktsegment",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(117)",
           "nullable": false
@@ -699,81 +801,97 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "orderkey",
           "fieldPath": "orderkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "partkey",
           "fieldPath": "partkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "suppkey",
           "fieldPath": "suppkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "linenumber",
           "fieldPath": "linenumber",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "quantity",
           "fieldPath": "quantity",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "extendedprice",
           "fieldPath": "extendedprice",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "discount",
           "fieldPath": "discount",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "tax",
           "fieldPath": "tax",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "returnflag",
           "fieldPath": "returnflag",
           "nativeType": "varchar(1)",
           "nullable": false
         },
         {
+          "fieldName": "linestatus",
           "fieldPath": "linestatus",
           "nativeType": "varchar(1)",
           "nullable": false
         },
         {
+          "fieldName": "shipdate",
           "fieldPath": "shipdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "commitdate",
           "fieldPath": "commitdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "receiptdate",
           "fieldPath": "receiptdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "shipinstruct",
           "fieldPath": "shipinstruct",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "shipmode",
           "fieldPath": "shipmode",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(44)",
           "nullable": false
@@ -791,46 +909,55 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "partkey",
           "fieldPath": "partkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(55)",
           "nullable": false
         },
         {
+          "fieldName": "mfgr",
           "fieldPath": "mfgr",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "brand",
           "fieldPath": "brand",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "type",
           "fieldPath": "type",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "size",
           "fieldPath": "size",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "container",
           "fieldPath": "container",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "retailprice",
           "fieldPath": "retailprice",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(23)",
           "nullable": false
@@ -848,36 +975,43 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "suppkey",
           "fieldPath": "suppkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "address",
           "fieldPath": "address",
           "nativeType": "varchar(40)",
           "nullable": false
         },
         {
+          "fieldName": "nationkey",
           "fieldPath": "nationkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "phone",
           "fieldPath": "phone",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "acctbal",
           "fieldPath": "acctbal",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(101)",
           "nullable": false
@@ -895,36 +1029,43 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "suppkey",
           "fieldPath": "suppkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "address",
           "fieldPath": "address",
           "nativeType": "varchar(40)",
           "nullable": false
         },
         {
+          "fieldName": "nationkey",
           "fieldPath": "nationkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "phone",
           "fieldPath": "phone",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "acctbal",
           "fieldPath": "acctbal",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(101)",
           "nullable": false
@@ -942,81 +1083,97 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "orderkey",
           "fieldPath": "orderkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "partkey",
           "fieldPath": "partkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "suppkey",
           "fieldPath": "suppkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "linenumber",
           "fieldPath": "linenumber",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "quantity",
           "fieldPath": "quantity",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "extendedprice",
           "fieldPath": "extendedprice",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "discount",
           "fieldPath": "discount",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "tax",
           "fieldPath": "tax",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "returnflag",
           "fieldPath": "returnflag",
           "nativeType": "varchar(1)",
           "nullable": false
         },
         {
+          "fieldName": "linestatus",
           "fieldPath": "linestatus",
           "nativeType": "varchar(1)",
           "nullable": false
         },
         {
+          "fieldName": "shipdate",
           "fieldPath": "shipdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "commitdate",
           "fieldPath": "commitdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "receiptdate",
           "fieldPath": "receiptdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "shipinstruct",
           "fieldPath": "shipinstruct",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "shipmode",
           "fieldPath": "shipmode",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(44)",
           "nullable": false
@@ -1034,36 +1191,43 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "suppkey",
           "fieldPath": "suppkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "address",
           "fieldPath": "address",
           "nativeType": "varchar(40)",
           "nullable": false
         },
         {
+          "fieldName": "nationkey",
           "fieldPath": "nationkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "phone",
           "fieldPath": "phone",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "acctbal",
           "fieldPath": "acctbal",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(101)",
           "nullable": false
@@ -1081,41 +1245,49 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "custkey",
           "fieldPath": "custkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "address",
           "fieldPath": "address",
           "nativeType": "varchar(40)",
           "nullable": false
         },
         {
+          "fieldName": "nationkey",
           "fieldPath": "nationkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "phone",
           "fieldPath": "phone",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "acctbal",
           "fieldPath": "acctbal",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "mktsegment",
           "fieldPath": "mktsegment",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(117)",
           "nullable": false
@@ -1133,46 +1305,55 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "partkey",
           "fieldPath": "partkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(55)",
           "nullable": false
         },
         {
+          "fieldName": "mfgr",
           "fieldPath": "mfgr",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "brand",
           "fieldPath": "brand",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "type",
           "fieldPath": "type",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "size",
           "fieldPath": "size",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "container",
           "fieldPath": "container",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "retailprice",
           "fieldPath": "retailprice",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(23)",
           "nullable": false
@@ -1190,41 +1371,49 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "custkey",
           "fieldPath": "custkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "address",
           "fieldPath": "address",
           "nativeType": "varchar(40)",
           "nullable": false
         },
         {
+          "fieldName": "nationkey",
           "fieldPath": "nationkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "phone",
           "fieldPath": "phone",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "acctbal",
           "fieldPath": "acctbal",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "mktsegment",
           "fieldPath": "mktsegment",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(117)",
           "nullable": false
@@ -1242,21 +1431,25 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "nationkey",
           "fieldPath": "nationkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "regionkey",
           "fieldPath": "regionkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(152)",
           "nullable": false
@@ -1274,26 +1467,31 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "partkey",
           "fieldPath": "partkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "suppkey",
           "fieldPath": "suppkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "availqty",
           "fieldPath": "availqty",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "supplycost",
           "fieldPath": "supplycost",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(199)",
           "nullable": false
@@ -1311,16 +1509,19 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "regionkey",
           "fieldPath": "regionkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(152)",
           "nullable": false
@@ -1338,41 +1539,49 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "custkey",
           "fieldPath": "custkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "address",
           "fieldPath": "address",
           "nativeType": "varchar(40)",
           "nullable": false
         },
         {
+          "fieldName": "nationkey",
           "fieldPath": "nationkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "phone",
           "fieldPath": "phone",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "acctbal",
           "fieldPath": "acctbal",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "mktsegment",
           "fieldPath": "mktsegment",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(117)",
           "nullable": false
@@ -1390,46 +1599,55 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "orderkey",
           "fieldPath": "orderkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "custkey",
           "fieldPath": "custkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "orderstatus",
           "fieldPath": "orderstatus",
           "nativeType": "varchar(1)",
           "nullable": false
         },
         {
+          "fieldName": "totalprice",
           "fieldPath": "totalprice",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "orderdate",
           "fieldPath": "orderdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "orderpriority",
           "fieldPath": "orderpriority",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "clerk",
           "fieldPath": "clerk",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "shippriority",
           "fieldPath": "shippriority",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(79)",
           "nullable": false
@@ -1447,16 +1665,19 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "regionkey",
           "fieldPath": "regionkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(152)",
           "nullable": false
@@ -1474,46 +1695,55 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "orderkey",
           "fieldPath": "orderkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "custkey",
           "fieldPath": "custkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "orderstatus",
           "fieldPath": "orderstatus",
           "nativeType": "varchar(1)",
           "nullable": false
         },
         {
+          "fieldName": "totalprice",
           "fieldPath": "totalprice",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "orderdate",
           "fieldPath": "orderdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "orderpriority",
           "fieldPath": "orderpriority",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "clerk",
           "fieldPath": "clerk",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "shippriority",
           "fieldPath": "shippriority",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(79)",
           "nullable": false
@@ -1531,46 +1761,55 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "partkey",
           "fieldPath": "partkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(55)",
           "nullable": false
         },
         {
+          "fieldName": "mfgr",
           "fieldPath": "mfgr",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "brand",
           "fieldPath": "brand",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "type",
           "fieldPath": "type",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "size",
           "fieldPath": "size",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "container",
           "fieldPath": "container",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "retailprice",
           "fieldPath": "retailprice",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(23)",
           "nullable": false
@@ -1588,21 +1827,25 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "nationkey",
           "fieldPath": "nationkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "regionkey",
           "fieldPath": "regionkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(152)",
           "nullable": false
@@ -1620,46 +1863,55 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "orderkey",
           "fieldPath": "orderkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "custkey",
           "fieldPath": "custkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "orderstatus",
           "fieldPath": "orderstatus",
           "nativeType": "varchar(1)",
           "nullable": false
         },
         {
+          "fieldName": "totalprice",
           "fieldPath": "totalprice",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "orderdate",
           "fieldPath": "orderdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "orderpriority",
           "fieldPath": "orderpriority",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "clerk",
           "fieldPath": "clerk",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "shippriority",
           "fieldPath": "shippriority",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(79)",
           "nullable": false
@@ -1677,21 +1929,25 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "nationkey",
           "fieldPath": "nationkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "regionkey",
           "fieldPath": "regionkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(152)",
           "nullable": false
@@ -1709,46 +1965,55 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "orderkey",
           "fieldPath": "orderkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "custkey",
           "fieldPath": "custkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "orderstatus",
           "fieldPath": "orderstatus",
           "nativeType": "varchar(1)",
           "nullable": false
         },
         {
+          "fieldName": "totalprice",
           "fieldPath": "totalprice",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "orderdate",
           "fieldPath": "orderdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "orderpriority",
           "fieldPath": "orderpriority",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "clerk",
           "fieldPath": "clerk",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "shippriority",
           "fieldPath": "shippriority",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(79)",
           "nullable": false
@@ -1766,81 +2031,97 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "orderkey",
           "fieldPath": "orderkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "partkey",
           "fieldPath": "partkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "suppkey",
           "fieldPath": "suppkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "linenumber",
           "fieldPath": "linenumber",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "quantity",
           "fieldPath": "quantity",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "extendedprice",
           "fieldPath": "extendedprice",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "discount",
           "fieldPath": "discount",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "tax",
           "fieldPath": "tax",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "returnflag",
           "fieldPath": "returnflag",
           "nativeType": "varchar(1)",
           "nullable": false
         },
         {
+          "fieldName": "linestatus",
           "fieldPath": "linestatus",
           "nativeType": "varchar(1)",
           "nullable": false
         },
         {
+          "fieldName": "shipdate",
           "fieldPath": "shipdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "commitdate",
           "fieldPath": "commitdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "receiptdate",
           "fieldPath": "receiptdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "shipinstruct",
           "fieldPath": "shipinstruct",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "shipmode",
           "fieldPath": "shipmode",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(44)",
           "nullable": false
@@ -1858,36 +2139,43 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "suppkey",
           "fieldPath": "suppkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "address",
           "fieldPath": "address",
           "nativeType": "varchar(40)",
           "nullable": false
         },
         {
+          "fieldName": "nationkey",
           "fieldPath": "nationkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "phone",
           "fieldPath": "phone",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "acctbal",
           "fieldPath": "acctbal",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(101)",
           "nullable": false
@@ -1905,41 +2193,49 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "custkey",
           "fieldPath": "custkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "address",
           "fieldPath": "address",
           "nativeType": "varchar(40)",
           "nullable": false
         },
         {
+          "fieldName": "nationkey",
           "fieldPath": "nationkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "phone",
           "fieldPath": "phone",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "acctbal",
           "fieldPath": "acctbal",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "mktsegment",
           "fieldPath": "mktsegment",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(117)",
           "nullable": false
@@ -1957,16 +2253,19 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "regionkey",
           "fieldPath": "regionkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(152)",
           "nullable": false
@@ -1984,26 +2283,31 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "partkey",
           "fieldPath": "partkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "suppkey",
           "fieldPath": "suppkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "availqty",
           "fieldPath": "availqty",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "supplycost",
           "fieldPath": "supplycost",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(199)",
           "nullable": false
@@ -2021,41 +2325,49 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "custkey",
           "fieldPath": "custkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "address",
           "fieldPath": "address",
           "nativeType": "varchar(40)",
           "nullable": false
         },
         {
+          "fieldName": "nationkey",
           "fieldPath": "nationkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "phone",
           "fieldPath": "phone",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "acctbal",
           "fieldPath": "acctbal",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "mktsegment",
           "fieldPath": "mktsegment",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(117)",
           "nullable": false
@@ -2073,36 +2385,43 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "suppkey",
           "fieldPath": "suppkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "address",
           "fieldPath": "address",
           "nativeType": "varchar(40)",
           "nullable": false
         },
         {
+          "fieldName": "nationkey",
           "fieldPath": "nationkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "phone",
           "fieldPath": "phone",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "acctbal",
           "fieldPath": "acctbal",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(101)",
           "nullable": false
@@ -2120,16 +2439,19 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "regionkey",
           "fieldPath": "regionkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(152)",
           "nullable": false
@@ -2147,16 +2469,19 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "regionkey",
           "fieldPath": "regionkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(152)",
           "nullable": false
@@ -2174,46 +2499,55 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "partkey",
           "fieldPath": "partkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(55)",
           "nullable": false
         },
         {
+          "fieldName": "mfgr",
           "fieldPath": "mfgr",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "brand",
           "fieldPath": "brand",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "type",
           "fieldPath": "type",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "size",
           "fieldPath": "size",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "container",
           "fieldPath": "container",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "retailprice",
           "fieldPath": "retailprice",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(23)",
           "nullable": false
@@ -2231,26 +2565,31 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "partkey",
           "fieldPath": "partkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "suppkey",
           "fieldPath": "suppkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "availqty",
           "fieldPath": "availqty",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "supplycost",
           "fieldPath": "supplycost",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(199)",
           "nullable": false
@@ -2268,81 +2607,97 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "orderkey",
           "fieldPath": "orderkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "partkey",
           "fieldPath": "partkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "suppkey",
           "fieldPath": "suppkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "linenumber",
           "fieldPath": "linenumber",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "quantity",
           "fieldPath": "quantity",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "extendedprice",
           "fieldPath": "extendedprice",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "discount",
           "fieldPath": "discount",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "tax",
           "fieldPath": "tax",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "returnflag",
           "fieldPath": "returnflag",
           "nativeType": "varchar(1)",
           "nullable": false
         },
         {
+          "fieldName": "linestatus",
           "fieldPath": "linestatus",
           "nativeType": "varchar(1)",
           "nullable": false
         },
         {
+          "fieldName": "shipdate",
           "fieldPath": "shipdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "commitdate",
           "fieldPath": "commitdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "receiptdate",
           "fieldPath": "receiptdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "shipinstruct",
           "fieldPath": "shipinstruct",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "shipmode",
           "fieldPath": "shipmode",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(44)",
           "nullable": false
@@ -2360,46 +2715,55 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "partkey",
           "fieldPath": "partkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(55)",
           "nullable": false
         },
         {
+          "fieldName": "mfgr",
           "fieldPath": "mfgr",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "brand",
           "fieldPath": "brand",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "type",
           "fieldPath": "type",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "size",
           "fieldPath": "size",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "container",
           "fieldPath": "container",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "retailprice",
           "fieldPath": "retailprice",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(23)",
           "nullable": false
@@ -2417,81 +2781,97 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "orderkey",
           "fieldPath": "orderkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "partkey",
           "fieldPath": "partkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "suppkey",
           "fieldPath": "suppkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "linenumber",
           "fieldPath": "linenumber",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "quantity",
           "fieldPath": "quantity",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "extendedprice",
           "fieldPath": "extendedprice",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "discount",
           "fieldPath": "discount",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "tax",
           "fieldPath": "tax",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "returnflag",
           "fieldPath": "returnflag",
           "nativeType": "varchar(1)",
           "nullable": false
         },
         {
+          "fieldName": "linestatus",
           "fieldPath": "linestatus",
           "nativeType": "varchar(1)",
           "nullable": false
         },
         {
+          "fieldName": "shipdate",
           "fieldPath": "shipdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "commitdate",
           "fieldPath": "commitdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "receiptdate",
           "fieldPath": "receiptdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "shipinstruct",
           "fieldPath": "shipinstruct",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "shipmode",
           "fieldPath": "shipmode",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(44)",
           "nullable": false
@@ -2509,46 +2889,55 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "orderkey",
           "fieldPath": "orderkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "custkey",
           "fieldPath": "custkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "orderstatus",
           "fieldPath": "orderstatus",
           "nativeType": "varchar(1)",
           "nullable": false
         },
         {
+          "fieldName": "totalprice",
           "fieldPath": "totalprice",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "orderdate",
           "fieldPath": "orderdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "orderpriority",
           "fieldPath": "orderpriority",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "clerk",
           "fieldPath": "clerk",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "shippriority",
           "fieldPath": "shippriority",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(79)",
           "nullable": false
@@ -2566,46 +2955,55 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "partkey",
           "fieldPath": "partkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(55)",
           "nullable": false
         },
         {
+          "fieldName": "mfgr",
           "fieldPath": "mfgr",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "brand",
           "fieldPath": "brand",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "type",
           "fieldPath": "type",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "size",
           "fieldPath": "size",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "container",
           "fieldPath": "container",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "retailprice",
           "fieldPath": "retailprice",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(23)",
           "nullable": false
@@ -2623,81 +3021,97 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "orderkey",
           "fieldPath": "orderkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "partkey",
           "fieldPath": "partkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "suppkey",
           "fieldPath": "suppkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "linenumber",
           "fieldPath": "linenumber",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "quantity",
           "fieldPath": "quantity",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "extendedprice",
           "fieldPath": "extendedprice",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "discount",
           "fieldPath": "discount",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "tax",
           "fieldPath": "tax",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "returnflag",
           "fieldPath": "returnflag",
           "nativeType": "varchar(1)",
           "nullable": false
         },
         {
+          "fieldName": "linestatus",
           "fieldPath": "linestatus",
           "nativeType": "varchar(1)",
           "nullable": false
         },
         {
+          "fieldName": "shipdate",
           "fieldPath": "shipdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "commitdate",
           "fieldPath": "commitdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "receiptdate",
           "fieldPath": "receiptdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "shipinstruct",
           "fieldPath": "shipinstruct",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "shipmode",
           "fieldPath": "shipmode",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(44)",
           "nullable": false
@@ -2715,46 +3129,55 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "partkey",
           "fieldPath": "partkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(55)",
           "nullable": false
         },
         {
+          "fieldName": "mfgr",
           "fieldPath": "mfgr",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "brand",
           "fieldPath": "brand",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "type",
           "fieldPath": "type",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "size",
           "fieldPath": "size",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "container",
           "fieldPath": "container",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "retailprice",
           "fieldPath": "retailprice",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(23)",
           "nullable": false
@@ -2772,81 +3195,97 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "orderkey",
           "fieldPath": "orderkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "partkey",
           "fieldPath": "partkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "suppkey",
           "fieldPath": "suppkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "linenumber",
           "fieldPath": "linenumber",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "quantity",
           "fieldPath": "quantity",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "extendedprice",
           "fieldPath": "extendedprice",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "discount",
           "fieldPath": "discount",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "tax",
           "fieldPath": "tax",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "returnflag",
           "fieldPath": "returnflag",
           "nativeType": "varchar(1)",
           "nullable": false
         },
         {
+          "fieldName": "linestatus",
           "fieldPath": "linestatus",
           "nativeType": "varchar(1)",
           "nullable": false
         },
         {
+          "fieldName": "shipdate",
           "fieldPath": "shipdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "commitdate",
           "fieldPath": "commitdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "receiptdate",
           "fieldPath": "receiptdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "shipinstruct",
           "fieldPath": "shipinstruct",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "shipmode",
           "fieldPath": "shipmode",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(44)",
           "nullable": false
@@ -2864,21 +3303,25 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "nationkey",
           "fieldPath": "nationkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "regionkey",
           "fieldPath": "regionkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(152)",
           "nullable": false
@@ -2896,41 +3339,49 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "custkey",
           "fieldPath": "custkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "address",
           "fieldPath": "address",
           "nativeType": "varchar(40)",
           "nullable": false
         },
         {
+          "fieldName": "nationkey",
           "fieldPath": "nationkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "phone",
           "fieldPath": "phone",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "acctbal",
           "fieldPath": "acctbal",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "mktsegment",
           "fieldPath": "mktsegment",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(117)",
           "nullable": false
@@ -2948,46 +3399,55 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "orderkey",
           "fieldPath": "orderkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "custkey",
           "fieldPath": "custkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "orderstatus",
           "fieldPath": "orderstatus",
           "nativeType": "varchar(1)",
           "nullable": false
         },
         {
+          "fieldName": "totalprice",
           "fieldPath": "totalprice",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "orderdate",
           "fieldPath": "orderdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "orderpriority",
           "fieldPath": "orderpriority",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "clerk",
           "fieldPath": "clerk",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "shippriority",
           "fieldPath": "shippriority",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(79)",
           "nullable": false
@@ -3005,26 +3465,31 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "partkey",
           "fieldPath": "partkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "suppkey",
           "fieldPath": "suppkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "availqty",
           "fieldPath": "availqty",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "supplycost",
           "fieldPath": "supplycost",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(199)",
           "nullable": false
@@ -3042,26 +3507,31 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "partkey",
           "fieldPath": "partkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "suppkey",
           "fieldPath": "suppkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "availqty",
           "fieldPath": "availqty",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "supplycost",
           "fieldPath": "supplycost",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(199)",
           "nullable": false
@@ -3079,16 +3549,19 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "regionkey",
           "fieldPath": "regionkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(152)",
           "nullable": false
@@ -3106,16 +3579,19 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "regionkey",
           "fieldPath": "regionkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(152)",
           "nullable": false
@@ -3133,81 +3609,97 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "orderkey",
           "fieldPath": "orderkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "partkey",
           "fieldPath": "partkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "suppkey",
           "fieldPath": "suppkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "linenumber",
           "fieldPath": "linenumber",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "quantity",
           "fieldPath": "quantity",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "extendedprice",
           "fieldPath": "extendedprice",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "discount",
           "fieldPath": "discount",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "tax",
           "fieldPath": "tax",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "returnflag",
           "fieldPath": "returnflag",
           "nativeType": "varchar(1)",
           "nullable": false
         },
         {
+          "fieldName": "linestatus",
           "fieldPath": "linestatus",
           "nativeType": "varchar(1)",
           "nullable": false
         },
         {
+          "fieldName": "shipdate",
           "fieldPath": "shipdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "commitdate",
           "fieldPath": "commitdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "receiptdate",
           "fieldPath": "receiptdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "shipinstruct",
           "fieldPath": "shipinstruct",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "shipmode",
           "fieldPath": "shipmode",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(44)",
           "nullable": false
@@ -3225,21 +3717,25 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "nationkey",
           "fieldPath": "nationkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "regionkey",
           "fieldPath": "regionkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(152)",
           "nullable": false
@@ -3257,41 +3753,49 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "custkey",
           "fieldPath": "custkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "address",
           "fieldPath": "address",
           "nativeType": "varchar(40)",
           "nullable": false
         },
         {
+          "fieldName": "nationkey",
           "fieldPath": "nationkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "phone",
           "fieldPath": "phone",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "acctbal",
           "fieldPath": "acctbal",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "mktsegment",
           "fieldPath": "mktsegment",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(117)",
           "nullable": false
@@ -3309,21 +3813,25 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "nationkey",
           "fieldPath": "nationkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "regionkey",
           "fieldPath": "regionkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(152)",
           "nullable": false
@@ -3341,46 +3849,55 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "orderkey",
           "fieldPath": "orderkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "custkey",
           "fieldPath": "custkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "orderstatus",
           "fieldPath": "orderstatus",
           "nativeType": "varchar(1)",
           "nullable": false
         },
         {
+          "fieldName": "totalprice",
           "fieldPath": "totalprice",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "orderdate",
           "fieldPath": "orderdate",
           "nativeType": "date",
           "nullable": false
         },
         {
+          "fieldName": "orderpriority",
           "fieldPath": "orderpriority",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "clerk",
           "fieldPath": "clerk",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "shippriority",
           "fieldPath": "shippriority",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(79)",
           "nullable": false
@@ -3398,21 +3915,25 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "nationkey",
           "fieldPath": "nationkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "regionkey",
           "fieldPath": "regionkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(152)",
           "nullable": false
@@ -3430,46 +3951,55 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "partkey",
           "fieldPath": "partkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(55)",
           "nullable": false
         },
         {
+          "fieldName": "mfgr",
           "fieldPath": "mfgr",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "brand",
           "fieldPath": "brand",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "type",
           "fieldPath": "type",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "size",
           "fieldPath": "size",
           "nativeType": "integer",
           "nullable": false
         },
         {
+          "fieldName": "container",
           "fieldPath": "container",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "retailprice",
           "fieldPath": "retailprice",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(23)",
           "nullable": false
@@ -3487,21 +4017,25 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "nationkey",
           "fieldPath": "nationkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "regionkey",
           "fieldPath": "regionkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(152)",
           "nullable": false
@@ -3519,36 +4053,43 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "suppkey",
           "fieldPath": "suppkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "address",
           "fieldPath": "address",
           "nativeType": "varchar(40)",
           "nullable": false
         },
         {
+          "fieldName": "nationkey",
           "fieldPath": "nationkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "phone",
           "fieldPath": "phone",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "acctbal",
           "fieldPath": "acctbal",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(101)",
           "nullable": false
@@ -3566,41 +4107,49 @@
     "schema": {
       "fields": [
         {
+          "fieldName": "custkey",
           "fieldPath": "custkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "name",
           "fieldPath": "name",
           "nativeType": "varchar(25)",
           "nullable": false
         },
         {
+          "fieldName": "address",
           "fieldPath": "address",
           "nativeType": "varchar(40)",
           "nullable": false
         },
         {
+          "fieldName": "nationkey",
           "fieldPath": "nationkey",
           "nativeType": "bigint",
           "nullable": false
         },
         {
+          "fieldName": "phone",
           "fieldPath": "phone",
           "nativeType": "varchar(15)",
           "nullable": false
         },
         {
+          "fieldName": "acctbal",
           "fieldPath": "acctbal",
           "nativeType": "double",
           "nullable": false
         },
         {
+          "fieldName": "mktsegment",
           "fieldPath": "mktsegment",
           "nativeType": "varchar(10)",
           "nullable": false
         },
         {
+          "fieldName": "comment",
           "fieldPath": "comment",
           "nativeType": "varchar(117)",
           "nullable": false


### PR DESCRIPTION
### 🤔 Why?

to support more efficient regex matching on column path

### 🤓 What?

- all crawlers emit column `fieldpath` as lowercase, and use `fieldName` to store the original string

### 🧪 Tested?

tested various crawlers against metaphor instances

### ☑️ Checks


- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
