### PR TITLE
[sc-27536] Allow ignoring `INSERT INTO ... VALUES` queries

### DIFF
--- a/metaphor/common/docs/process_query.md
+++ b/metaphor/common/docs/process_query.md
@@ -8,7 +8,7 @@ process_query:
 
   redacted_literal_placeholder: <redacted literal placeholder>  # The redacted values will be replaced by this placeholder string. Default is '<REDACTED>'.
 
-  ignore_insert_values_into: <ignore_insert_values_into>  #  Ignore `INSERT INTO ... VALUES` expressions. These expressions don't have any lineage information, and are often very large in size. Default is `true`.
+  ignore_insert_values_into: <ignore_insert_values_into>  #  Ignore `INSERT INTO ... VALUES` expressions. These expressions don't have any lineage information, and are often very large in size. Default is `false`.
 ```
 
 If any of the following boolean values is set to true, crawler will process the incoming SQL queries:

--- a/metaphor/common/docs/process_query.md
+++ b/metaphor/common/docs/process_query.md
@@ -7,8 +7,11 @@ process_query:
   redact_literal_values_in_where_clauses: <true | false>  # Whether to redact all literal values in WHERE clauses. Default is `false`.
 
   redacted_literal_placeholder: <redacted literal placeholder>  # The redacted values will be replaced by this placeholder string. Default is '<REDACTED>'.
+
+  ignore_insert_values_into: <ignore_insert_values_into>  #  Ignore `INSERT INTO ... VALUES` expressions. These expressions don't have any lineage information, and are often very large in size. Default is `true`.
 ```
 
 If any of the following boolean values is set to true, crawler will process the incoming SQL queries:
 
 - `redact_literal_values_in_where_clauses`
+- `ignore_insert_values_into`

--- a/metaphor/common/process_query/config.py
+++ b/metaphor/common/process_query/config.py
@@ -29,5 +29,5 @@ class ProcessQueryConfig:
         """
         return (
             self.redact_literal_values_in_where_clauses
-            and self.ignore_insert_values_into
+            or self.ignore_insert_values_into
         )

--- a/metaphor/common/process_query/config.py
+++ b/metaphor/common/process_query/config.py
@@ -16,9 +16,18 @@ class ProcessQueryConfig:
 
     redacted_literal_placeholder: str = "<REDACTED>"
 
+    ignore_insert_values_into: bool = True
+    """
+    Ignore `INSERT INTO ... VALUES` expressions. These expressions don't have any
+    lineage information, and are often very large in size.
+    """
+
     @property
     def should_process(self) -> bool:
         """
         Whether we should run the processing method at all.
         """
-        return self.redact_literal_values_in_where_clauses
+        return (
+            self.redact_literal_values_in_where_clauses
+            and self.ignore_insert_values_into
+        )

--- a/metaphor/common/process_query/config.py
+++ b/metaphor/common/process_query/config.py
@@ -16,7 +16,7 @@ class ProcessQueryConfig:
 
     redacted_literal_placeholder: str = "<REDACTED>"
 
-    ignore_insert_values_into: bool = True
+    ignore_insert_values_into: bool = False
     """
     Ignore `INSERT INTO ... VALUES` expressions. These expressions don't have any
     lineage information, and are often very large in size.

--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -815,33 +815,37 @@ class SnowflakeExtractor(BaseExtractor):
                 # User IDs can be an email address
                 user_id, email = user_id_or_email(username)
 
-                query_log = QueryLog(
-                    id=f"{DataPlatform.SNOWFLAKE.name}:{query_id}",
-                    query_id=query_id,
-                    platform=DataPlatform.SNOWFLAKE,
-                    account=self._account,
-                    start_time=start_time,
-                    duration=safe_float(elapsed_time / 1000.0),
-                    cost=safe_float(credit),
-                    user_id=user_id,
-                    email=email,
-                    default_database=default_database,
-                    default_schema=default_schema,
-                    rows_read=safe_float(rows_produced),
-                    rows_written=safe_float(rows_inserted) or safe_float(rows_updated),
-                    bytes_read=safe_float(bytes_scanned),
-                    bytes_written=safe_float(bytes_written),
-                    sources=sources,
-                    targets=targets,
-                    sql=process_query(
-                        query_text,
-                        DataPlatform.SNOWFLAKE,
-                        self._config.query_log.process_query,
-                    ),
-                    sql_hash=query_hash,
+                sql = process_query(
+                    query_text,
+                    DataPlatform.SNOWFLAKE,
+                    self._config.query_log.process_query,
                 )
 
-                yield query_log
+                if sql:
+                    query_log = QueryLog(
+                        id=f"{DataPlatform.SNOWFLAKE.name}:{query_id}",
+                        query_id=query_id,
+                        platform=DataPlatform.SNOWFLAKE,
+                        account=self._account,
+                        start_time=start_time,
+                        duration=safe_float(elapsed_time / 1000.0),
+                        cost=safe_float(credit),
+                        user_id=user_id,
+                        email=email,
+                        default_database=default_database,
+                        default_schema=default_schema,
+                        rows_read=safe_float(rows_produced),
+                        rows_written=safe_float(rows_inserted)
+                        or safe_float(rows_updated),
+                        bytes_read=safe_float(bytes_scanned),
+                        bytes_written=safe_float(bytes_written),
+                        sources=sources,
+                        targets=targets,
+                        sql=sql,
+                        sql_hash=query_hash,
+                    )
+
+                    yield query_log
             except Exception:
                 logger.exception(f"query log processing error, query id: {query_id}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.35"
+version = "0.14.36"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

`INSERT INTO ... VALUES` means we're inserting static, explicit values into a table. There's no lineage for these queries, so we should just exclude them from the crawled query logs.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Allow ignoring `INSERT INTO ... VALUES` queries. By default these are ignored.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Added unit test.

In our own environment there's no `INSERT INTO ... VALUES` query, so can't really test the crawler...

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
