### PR TITLE
Extract Unity Catalog table & column lineage from system tables

### DIFF
--- a/metaphor/unity_catalog/README.md
+++ b/metaphor/unity_catalog/README.md
@@ -4,11 +4,11 @@ This connector extracts technical metadata from Unity Catalog using the [Unity C
 
 ## Setup
 
-Create an access token in the Databrick workspace > `User setting` > `Access tokens`.
+Create an access token in the Databrick workspace > `User setting` > `Developer` > `Access tokens`.
 
-Data lineage should be enabled by default for all workspaces that reference Unity Catalog. You can manually enable it by following [these instructions](https://docs.databricks.com/data-governance/unity-catalog/enable-workspaces.html)
+To extract [data lineage](https://docs.databricks.com/en/data-governance/unity-catalog/data-lineage.html) from Unity Catalog, you'll need to [enable system.access schema]() and [grant required permissions](https://docs.databricks.com/en/admin/system-tables/index.html#grant-access-to-system-tables) to the user. Please also read and understand the feature's [limitations](https://docs.databricks.com/data-governance/unity-catalog/data-lineage.html#limitations).
 
-> Refer to [this document](https://docs.databricks.com/data-governance/unity-catalog/data-lineage.html#limitations) to understand the limitations of Unity Catalog's data lineage.
+Make sure to grant the user BROWSE (or SELECT) privilege to all tables in order to retrieve the complete lineage graph. See [this section](https://docs.databricks.com/en/data-governance/unity-catalog/data-lineage.html#lineage-permissions) for more details.
 
 ## Config File
 

--- a/metaphor/unity_catalog/extractor.py
+++ b/metaphor/unity_catalog/extractor.py
@@ -198,7 +198,6 @@ class UnityCatalogExtractor(BaseExtractor):
 
                 for table_info in self._get_table_infos(catalog, schema):
                     table_name = f"{catalog}.{schema}.{table_info.name}"
-
                     if table_info.name is None:
                         logger.error(f"Ignoring table without name: {table_info}")
                         continue

--- a/metaphor/unity_catalog/models.py
+++ b/metaphor/unity_catalog/models.py
@@ -1,7 +1,7 @@
-from typing import List, Optional, Union
+from typing import Dict, List
 
 from databricks.sdk.service.catalog import ColumnInfo
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel
 
 from metaphor.common.fieldpath import build_schema_field
 from metaphor.common.logger import get_logger
@@ -25,49 +25,14 @@ def extract_schema_field_from_column_info(column: ColumnInfo) -> SchemaField:
     return field
 
 
-class NoPermission(BaseModel):
-    has_permission: bool = False
-
-    @field_validator("has_permission")
-    @classmethod
-    def has_permission_must_be_false(cls, value):
-        if value is False:
-            return value
-
-        raise ValueError("has_permission must be False")
+class TableLineage(BaseModel):
+    upstream_tables: List[str] = []
 
 
-class LineageColumnInfo(BaseModel):
-    name: str
-    catalog_name: str
-    schema_name: str
+class Column(BaseModel):
+    column_name: str
     table_name: str
 
 
 class ColumnLineage(BaseModel):
-    upstream_cols: List[Union[LineageColumnInfo, NoPermission]] = []
-    downstream_cols: List[Union[LineageColumnInfo, NoPermission]] = []
-
-
-class FileInfo(BaseModel):
-    path: str
-    has_permission: bool
-    securable_name: Optional[str] = None
-    securable_type: Optional[str] = None
-    storage_location: Optional[str] = None
-
-
-class TableInfo(BaseModel):
-    name: str
-    catalog_name: str
-    schema_name: str
-
-
-class LineageInfo(BaseModel):
-    tableInfo: Optional[Union[TableInfo, NoPermission]] = None
-    fileInfo: Optional[FileInfo] = None
-
-
-class TableLineage(BaseModel):
-    upstreams: List[LineageInfo] = []
-    downstreams: List[LineageInfo] = []
+    upstream_columns: Dict[str, List[Column]] = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.41"
+version = "0.14.42"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/unity_catalog/expected.json
+++ b/tests/unity_catalog/expected.json
@@ -82,9 +82,7 @@
   },
   {
     "entityUpstream": {
-      "sourceEntities": [
-        "DATASET~FDF012DB00302C39651E2FF173405230"
-      ]
+      "sourceEntities": []
     },
     "logicalId": {
       "name": "/Volumes/catalog2/schema/volume/output.csv",
@@ -108,10 +106,6 @@
           "destination": "col1",
           "sources": [
             {
-              "dataset": {
-                "name": "db.schema.upstream",
-                "platform": "UNITY_CATALOG"
-              },
               "field": "col1",
               "sourceEntityId": "DATASET~4B3CF34E5B62D97FAF33F75C7B32BB84"
             }
@@ -336,18 +330,6 @@
       "name": "catalog2.schema.table2",
       "platform": "UNITY_CATALOG"
     },
-    "entityUpstream": {
-      "fieldMappings": [
-        {
-          "destination": "col1",
-          "sources": []
-        }
-      ],
-      "sourceEntities": [
-        "DATASET~C109145C4035631CA68E19687464C80A",
-        "DATASET~7027DB17D7A88FC1442608A7E5F79984"
-      ]
-    },
     "schema": {
       "description": "example",
       "fields": [
@@ -391,21 +373,6 @@
         "storageLocation": "s3://path",
         "type": "MANAGED"
       }
-    }
-  },
-  {
-    "entityUpstream": {
-      "sourceEntities": []
-    },
-    "logicalId": {
-      "name": "s3://path/input2.csv",
-      "platform": "S3"
-    },
-    "sourceInfo": {
-      "mainUrl": "https://dummy.host/explore/location/input2/browse"
-    },
-    "unityCatalog": {
-      "datasetType": "UNITY_CATALOG_EXTERNAL_LOCATION"
     }
   },
   {

--- a/tests/unity_catalog/mocks.py
+++ b/tests/unity_catalog/mocks.py
@@ -1,0 +1,26 @@
+from typing import Any
+from unittest.mock import MagicMock
+
+
+def mock_sql_connection(
+    fetch_all_side_effect: Any, execute_side_effect=None
+) -> MagicMock:
+
+    mock_cursor = MagicMock()
+
+    mock_cursor.execute = MagicMock()
+    if execute_side_effect is not None:
+        mock_cursor.execute.side_effect = execute_side_effect
+
+    mock_cursor.fetchall = MagicMock()
+    mock_cursor.fetchall.side_effect = fetch_all_side_effect
+
+    mock_cursor_ctx = MagicMock()
+    mock_cursor_ctx.__enter__ = MagicMock()
+    mock_cursor_ctx.__enter__.return_value = mock_cursor
+
+    mock_connection = MagicMock()
+    mock_connection.cursor = MagicMock()
+    mock_connection.cursor.return_value = mock_cursor_ctx
+
+    return mock_connection

--- a/tests/unity_catalog/test_models.py
+++ b/tests/unity_catalog/test_models.py
@@ -1,15 +1,7 @@
 import pytest
 from databricks.sdk.service.catalog import ColumnInfo
 
-from metaphor.unity_catalog.models import (
-    NoPermission,
-    extract_schema_field_from_column_info,
-)
-
-
-def test_no_permission_cannot_have_permission() -> None:
-    with pytest.raises(ValueError):
-        NoPermission(has_permission=True)
+from metaphor.unity_catalog.models import extract_schema_field_from_column_info
 
 
 def test_parse_schema_field_from_invalid_column_info() -> None:


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Using the [REST API](https://docs.databricks.com/en/data-governance/unity-catalog/data-lineage.html#retrieve-table-lineage) to extract table & column lineage turns out to be highly inefficient and can take an unacceptably long time for large number of tables & columns. It seems that the recommended way is to use [Lineage system tables](https://docs.databricks.com/en/admin/system-tables/lineage.html) instead.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Refactor `list_table_lineage` & `list_column_lineage` util functions to batch fetch lineage information from the system tables at the schema level. 
- Add logging to help monitor the crawler progress.
- Factor out common SQL connection mocking in tests to a reusable function.

Note: The change broke the support for volume lineage, which will be restored in a follow-up PR.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified end-to-end against a large production instance with 3000+ tables. Took < 30 mins to run.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
