### PR TITLE
Bump up default batch size for Unity Catalog query log fetching

### DIFF
--- a/metaphor/unity_catalog/config.py
+++ b/metaphor/unity_catalog/config.py
@@ -16,8 +16,9 @@ class UnityCatalogQueryLogConfig:
     # Query log filter to exclude certain usernames
     excluded_usernames: Set[str] = field(default_factory=lambda: set())
 
-    # Limit the number of results returned in one page. The default is 100.
-    max_results: Optional[int] = 100
+    # Limit the number of results returned in one page.
+    # The default is 1000, max allowed by the API.
+    max_results: Optional[int] = 1000
 
 
 @dataclass(config=ConnectorConfig)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.42"
+version = "0.14.43"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Fetching 100 query logs at a time is rather inefficient.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Bumpt the default batch size to 1000 (max allowed by the API)
- Add logging to improve progress monitoring

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Tested against a production instance with 250k+ queries. Took < 4 mins.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
