### PR TITLE
Improve unity catalog profiler speed

### DIFF
--- a/metaphor/unity_catalog/config.py
+++ b/metaphor/unity_catalog/config.py
@@ -39,3 +39,6 @@ class UnityCatalogRunConfig(BaseConfig):
     query_log: UnityCatalogQueryLogConfig = field(
         default_factory=lambda: UnityCatalogQueryLogConfig()
     )
+
+    # Max number of connection to the database
+    max_concurrency: int = 10

--- a/metaphor/unity_catalog/profile/README.md
+++ b/metaphor/unity_catalog/profile/README.md
@@ -32,6 +32,14 @@ See [Filter Configurations](../../common/docs/filter.md) for more information on
 
 See [Output Config](../../common/docs/output.md) for more information on the optional `output` config.
 
+#### Concurrency
+
+The max number of concurrent queries to the databricks compute node can be configured as follows,
+
+```yaml
+max_concurrency: <max_number_of_queries> # Default to 10
+```
+
 ## Testing
 
 Follow the [Installation](../../README.md) instructions to install `metaphor-connectors` in your environment (or virtualenv). Make sure to include either `all` or `unity_catalog` extra.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.43"
+version = "0.14.44"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

To speed up the UC profile connector. Getting a table's stat takes about 5 seconds, not investigating too deep on the UC side. We can take the first step by executing the query in parallel.

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

Run the profile function in threads.

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

Verified against prod env. 5x improvement with 10 threads.

<!--
  Describe how the change was tested end-to-end.
-->

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
