### PR TITLE
Resolve service principal owners to their display names

### DIFF
--- a/metaphor/unity_catalog/utils.py
+++ b/metaphor/unity_catalog/utils.py
@@ -5,6 +5,7 @@ from typing import Collection, Dict, List, Optional, Tuple
 
 from databricks import sql
 from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.iam import ServicePrincipal
 from databricks.sql.client import Connection
 
 from metaphor.common.logger import get_logger, json_dump_to_debug_file
@@ -121,6 +122,7 @@ def list_query_log(
     connection: Connection, lookback_days: int, excluded_usernames: Collection[str]
 ):
     """
+    Fetch query logs from system.query.history table
     See https://docs.databricks.com/en/admin/system-tables/query-history.html
     """
     start = start_of_day(lookback_days)
@@ -268,3 +270,23 @@ def create_connection_pool(
 
 def create_api(host: str, token: str) -> WorkspaceClient:
     return WorkspaceClient(host=host, token=token)
+
+
+def list_service_principals(api: WorkspaceClient) -> Dict[str, ServicePrincipal]:
+    """
+    List all service principals
+    See https://docs.databricks.com/api/workspace/groups/list
+    """
+
+    # See https://databricks-sdk-py.readthedocs.io/en/latest/dbdataclasses/iam.html#databricks.sdk.service.iam.Group
+    excluded_attributes = "entitlements,groups,roles,schemas"
+
+    try:
+        principals = list(
+            api.service_principals.list(excluded_attributes=excluded_attributes)
+        )
+        json_dump_to_debug_file(principals, "list-principals.json")
+        return {p.application_id: p for p in principals}
+    except Exception as e:
+        logger.error(f"Failed to list principals: {e}")
+        return {}

--- a/metaphor/unity_catalog/utils.py
+++ b/metaphor/unity_catalog/utils.py
@@ -286,7 +286,13 @@ def list_service_principals(api: WorkspaceClient) -> Dict[str, ServicePrincipal]
             api.service_principals.list(excluded_attributes=excluded_attributes)
         )
         json_dump_to_debug_file(principals, "list-principals.json")
-        return {p.application_id: p for p in principals}
+
+        principal_map: Dict[str, ServicePrincipal] = {}
+        for p in principals:
+            if p.application_id is not None:
+                principal_map[p.application_id] = p
+
+        return principal_map
     except Exception as e:
         logger.error(f"Failed to list principals: {e}")
         return {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.48"
+version = "0.14.49"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/unity_catalog/expected.json
+++ b/tests/unity_catalog/expected.json
@@ -374,7 +374,7 @@
     "systemContacts": {
       "contacts": [
         {
-          "email": "user3@foo.com",
+          "email": "service principal 1",
           "systemContactSource": "UNITY_CATALOG"
         }
       ]
@@ -386,7 +386,7 @@
       "datasetType": "UNITY_CATALOG_TABLE",
       "tableInfo": {
         "dataSourceFormat": "DELTA",
-        "owner": "user3@foo.com",
+        "owner": "sp1",
         "properties": [
           {
             "key": "delta.lastCommitTimestamp",

--- a/tests/unity_catalog/test_extractor.py
+++ b/tests/unity_catalog/test_extractor.py
@@ -12,6 +12,7 @@ from databricks.sdk.service.catalog import (
 )
 from databricks.sdk.service.catalog import TableInfo as Table
 from databricks.sdk.service.catalog import TableType, VolumeInfo, VolumeType
+from databricks.sdk.service.iam import ServicePrincipal
 from pytest_snapshot.plugin import Snapshot
 
 from metaphor.common.base_config import OutputConfig
@@ -39,8 +40,10 @@ def dummy_config():
 @patch("metaphor.unity_catalog.extractor.list_table_lineage")
 @patch("metaphor.unity_catalog.extractor.list_column_lineage")
 @patch("metaphor.unity_catalog.extractor.list_query_log")
+@patch("metaphor.unity_catalog.extractor.list_service_principals")
 @pytest.mark.asyncio
 async def test_extractor(
+    mock_list_service_principals: MagicMock,
     mock_list_query_log: MagicMock,
     mock_list_column_lineage: MagicMock,
     mock_list_table_lineage: MagicMock,
@@ -50,6 +53,9 @@ async def test_extractor(
     mock_batch_get_last_refreshed_time: MagicMock,
     test_root_dir: str,
 ):
+    mock_list_service_principals.return_value = {
+        "sp1": ServicePrincipal(display_name="service principal 1")
+    }
 
     def mock_list_catalogs():
         return [CatalogInfo(name="catalog")]
@@ -137,7 +143,7 @@ async def test_extractor(
                     )
                 ],
                 storage_location="s3://path",
-                owner="user3@foo.com",
+                owner="sp1",
                 comment="example",
                 updated_at=0,
                 updated_by="foo@bar.com",

--- a/tests/unity_catalog/test_utils.py
+++ b/tests/unity_catalog/test_utils.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
+from databricks.sdk.service.iam import ServicePrincipal
 from freezegun import freeze_time
 from pytest_snapshot.plugin import Snapshot
 
@@ -11,6 +12,7 @@ from metaphor.unity_catalog.utils import (
     get_last_refreshed_time,
     list_column_lineage,
     list_query_log,
+    list_service_principals,
     list_table_lineage,
 )
 from tests.unity_catalog.mocks import mock_connection_pool, mock_sql_connection
@@ -150,6 +152,20 @@ def test_batch_get_last_refreshed_time():
     result_map = batch_get_last_refreshed_time(connection_pool, ["a.b.c", "d.e.f"], 10)
 
     assert result_map == {"a.b.c": datetime(2020, 1, 1), "d.e.f": datetime(2020, 1, 1)}
+
+
+def test_list_service_principals():
+
+    sp1 = ServicePrincipal(application_id="sp1", display_name="SP1")
+    sp2 = ServicePrincipal(application_id="sp2", display_name="SP2")
+
+    mock_api = MagicMock()
+    mock_api.service_principals = MagicMock()
+    mock_api.service_principals.list.return_value = [sp1, sp2]
+
+    principals = list_service_principals(mock_api)
+
+    assert principals == {"sp1": sp1, "sp2": sp2}
 
 
 def test_escape_special_characters():


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

If a Unity Catalog table is owned by a group, the [API](https://docs.databricks.com/api/workspace/tables/list) will automatically resolve the group's name. However, if the table is owned by a service principal, the API returns its [application ID](https://docs.databricks.com/en/admin/users-groups/service-principals.html) instead. 

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Use the [API](https://docs.databricks.com/api/workspace/serviceprincipals/list) to build a list of service principals and resolve the application ID to the corresponding display name when processing the ownership info.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified end-to-end against a production instance.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
