### PR TITLE
bugfix: Drop partially qualified dataset found during UC TLL

### DIFF
--- a/metaphor/common/sql/table_level_lineage/table.py
+++ b/metaphor/common/sql/table_level_lineage/table.py
@@ -16,8 +16,8 @@ class Table:
     @classmethod
     def from_sqlglot_table(cls, table: exp.Table):
         return cls(
-            db=table.catalog,
-            schema=table.db,
+            db=table.catalog if table.catalog else None,
+            schema=table.db if table.db else None,
             table=table.name,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.50"
+version = "0.14.51"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/unity_catalog/test_utils.py
+++ b/tests/unity_catalog/test_utils.py
@@ -154,7 +154,7 @@ def test_find_qualified_dataset():
 
     dataset = make_queried_dataset(("db", "sch", "tab"))
     found = find_qualified_dataset(dataset, {})
-    assert found.id == dataset.id
+    assert found and found.id == dataset.id
 
     dataset = make_queried_dataset((None, "sch", "tab"))
     found = find_qualified_dataset(
@@ -163,7 +163,7 @@ def test_find_qualified_dataset():
             "db.sch.tab": make_dataset(("db", "sch", "tab")),
         },
     )
-    assert found.id == make_queried_dataset(("db", "sch", "tab")).id
+    assert found and found.id == make_queried_dataset(("db", "sch", "tab")).id
 
     dataset = make_queried_dataset((None, "sch", "tab"))
     found = find_qualified_dataset(
@@ -173,7 +173,7 @@ def test_find_qualified_dataset():
             "db2.sch.tab": make_dataset(("db2", "sch", "tab")),
         },
     )
-    assert found.id == dataset.id
+    assert not found
 
 
 def test_list_table_lineage():


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

`QueriedDataset(db="", schema="", table="something")` causes the MCE validation to fail in our server application.

If a dataset isn't fully qualified, it is not an actually existing dataset. We'll just drop those from the TLL.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Drop partially qualified dataset found during UC TLL.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Modified unit test.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
