### PR TITLE
Map service principals to user_id field

### DIFF
--- a/metaphor/unity_catalog/extractor.py
+++ b/metaphor/unity_catalog/extractor.py
@@ -462,6 +462,7 @@ class UnityCatalogExtractor(BaseExtractor):
             self._connection,
             self._query_log_config.lookback_days,
             self._query_log_config.excluded_usernames,
+            self._service_principals,
             self._datasets,
         ):
             yield query_log

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.51"
+version = "0.14.53"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/unity_catalog/expected_query_logs.json
+++ b/tests/unity_catalog/expected_query_logs.json
@@ -36,7 +36,7 @@
         "bytesRead": 78922.0,
         "bytesWritten": 78911.0,
         "duration": 12345.0,
-        "email": "jane.doe@metaphor.io",
+        "userId": "service principal 1",
         "platform": "UNITY_CATALOG",
         "queryId": "query2",
         "rowsRead": 45678.0,

--- a/tests/unity_catalog/test_utils.py
+++ b/tests/unity_catalog/test_utils.py
@@ -72,7 +72,7 @@ GROUP BY
             "rows_written": 45691,
             "bytes_read": 78922,
             "bytes_written": 78911,
-            "email": "jane.doe@metaphor.io",
+            "email": "sp1",
         },
     ]
 
@@ -89,6 +89,7 @@ GROUP BY
             mock_connection,
             1,
             set(),
+            {"sp1": ServicePrincipal(display_name="service principal 1")},
             {
                 "mydb.myschema.orders": Dataset(
                     structure=DatasetStructure(


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Similar to https://github.com/MetaphorData/connectors/pull/918, the service principal IDs should be resolved to the display names and stored in the correct field (`user_id` instead of `email`) in query logs.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified against a production instance.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [ ] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
