### PR TITLE
Use safe_float in UC profiler to avoid outputting INF in MCEs

### DIFF
--- a/metaphor/unity_catalog/profile/extractor.py
+++ b/metaphor/unity_catalog/profile/extractor.py
@@ -25,6 +25,7 @@ from metaphor.common.base_extractor import BaseExtractor
 from metaphor.common.entity_id import normalize_full_dataset_name
 from metaphor.common.event_util import ENTITY_TYPES
 from metaphor.common.logger import get_logger
+from metaphor.common.utils import safe_float
 from metaphor.models.crawler_run_metadata import Platform
 from metaphor.models.metadata_change_event import (
     DataPlatform,
@@ -259,7 +260,7 @@ class UnityCatalogProfileExtractor(BaseExtractor):
                     if value:
                         if value == "NULL":
                             return None
-                        return float(value)
+                        return safe_float(value)
                     return value
 
                 stats = FieldStatistics(

--- a/metaphor/unity_catalog/profile/extractor.py
+++ b/metaphor/unity_catalog/profile/extractor.py
@@ -273,7 +273,10 @@ class UnityCatalogProfileExtractor(BaseExtractor):
                 field_statistics.field_statistics.append(stats)
 
         logger.info(
-            f"Profiled {table_info.full_name}, {dataset_statistics.data_size_bytes}, {dataset_statistics.record_count}, {time.time() - start_time} seconds"
+            f"Profiled {table_info.full_name} "
+            f"({dataset_statistics.data_size_bytes:.0f} bytes, "
+            f"{dataset_statistics.record_count:.0f} rows) "
+            f"in {(time.time() - start_time):.1f} seconds"
         )
 
         return (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.53"
+version = "0.14.54"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Unity Catalog profiler can output INF in MCEs, causing validation errors.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified against a production instance.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
