### PR TITLE
Exception is not handled causing the crawler stuck 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.54"
+version = "0.14.55"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

We try to format `None` as a float which will raise an exception in the threaded function. So the crawler stuck

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

- Handle the exception
- Fix the logging format

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

- Change the code to raise a exception in the helper function, and the crawler can finish
- Test against prod 
```
2024-07-23 14:34:31:INFO:metaphor:Ended running with RunStatus.SUCCESS at 2024-07-23 14:34:31.223049, fetched 2169 entities, took 2654.9s
```

<!--
  Describe how the change was tested end-to-end.
-->

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
