### PR TITLE
Handle "Infinity" values returned by DESCRIBE EXTENDED command

### DIFF
--- a/metaphor/unity_catalog/profile/extractor.py
+++ b/metaphor/unity_catalog/profile/extractor.py
@@ -262,7 +262,7 @@ class UnityCatalogProfileExtractor(BaseExtractor):
                         None,
                     )
                     if value:
-                        if value == "NULL":
+                        if value in ["NULL", "Infinity"]:
                             return None
                         return safe_float(value)
                     return value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.56"
+version = "0.14.57"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/unity_catalog/profile/expected.json
+++ b/tests/unity_catalog/profile/expected.json
@@ -5,8 +5,7 @@
         {
           "distinctValueCount": 1234.0,
           "fieldPath": "col2",
-          "maxValue": 9999.0,
-          "minValue": -9999.0
+          "maxValue": 9999.0
         }
       ]
     },

--- a/tests/unity_catalog/profile/test_extractor.py
+++ b/tests/unity_catalog/profile/test_extractor.py
@@ -69,7 +69,7 @@ async def test_extractor(
     mock_col2_stats = [
         SimpleNamespace(info_name="distinct_count", info_value="1234"),
         SimpleNamespace(info_name="max", info_value="9999"),
-        SimpleNamespace(info_name="min", info_value="-9999"),
+        SimpleNamespace(info_name="min", info_value="Infinity"),
         SimpleNamespace(info_name="num_nulls", info_value="NULL"),
     ]
 
@@ -184,7 +184,7 @@ async def test_should_handle_exception_column_stat(
     mock_col2_stats = [
         SimpleNamespace(info_name="distinct_count", info_value="1234"),
         SimpleNamespace(info_name="max", info_value="9999"),
-        SimpleNamespace(info_name="min", info_value="-9999"),
+        SimpleNamespace(info_name="min", info_value="Infinity"),
         SimpleNamespace(info_name="num_nulls", info_value="NULL"),
     ]
 


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

https://github.com/MetaphorData/connectors/pull/923 didn't handle all the infinity values returned by Unity Catalog's DESCRIBE EXTENDED command, which includes the string literal "Infinity".

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified against a production instance and inspected the generated MCEs.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->


- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
