### PR TITLE
[sc-27808] Undo workaround for CICD build

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -75,8 +75,6 @@ jobs:
 
       - name: Test
         run: |
-          echo "setuptools<72" > constraints.txt
-          poetry run pip install --constraint constraints.txt pyhive==0.7.0
           poetry install -E all
           poetry run coverage run --source=metaphor -m pytest
           poetry run coverage xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,6 @@ jobs:
 
       - name: Lint & Type Check
         run: |
-          echo "setuptools<72" > constraints.txt
-          poetry run pip install --constraint constraints.txt pyhive==0.7.0
           poetry install -E all
           poetry run flake8
           poetry run black --check .


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Looks like python core team has reverted the setuptools changes that broke our CICD pipeline: https://github.com/pypa/setuptools/issues/4519

If our CICD is no longer failing, might as well remove the workaround.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Remove workaround for CICD pipelines.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

N/A.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [ ] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
