### PR TITLE
Add temporary try-catch to handle snapshot time parsing issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.61"
+version = "0.14.62"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.62"
+version = "0.14.63"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

A [bug](https://github.com/googleapis/python-bigquery/issues/1986) in `google-cloud-bigquery` caused the bigquery connector to throw the following error  when processing some snapshot tables: 
```
  File "/usr/local/lib/python3.8/site-packages/google/cloud/bigquery/table.py", line 976, in snapshot_definition
    snapshot_info = SnapshotDefinition(snapshot_info)
  File "/usr/local/lib/python3.8/site-packages/google/cloud/bigquery/table.py", line 1372, in __init__
    self.snapshot_time = google.cloud._helpers._rfc3339_to_datetime(
  File "/usr/local/lib/python3.8/site-packages/google/cloud/_helpers/__init__.py", line 252, in _rfc3339_to_datetime
    return datetime.datetime.strptime(dt_str, _RFC3339_MICROS).replace(tzinfo=UTC)
  File "/usr/local/lib/python3.8/_strptime.py", line 568, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
  File "/usr/local/lib/python3.8/_strptime.py", line 349, in _strptime
    raise ValueError("time data %r does not match format %r" %
ValueError: time data '2024-07-23T09:09:09Z' does not match format '%Y-%m-%dT%H:%M:%S.%fZ'
```

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Add a try-catch around snapshot time retrieval.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified against a production instance with known issues.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
