### PR TITLE
Handle misconfigured Monte Carlo monitors gracefully

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.63"
+version = "0.14.64"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/monte_carlo/expected.json
+++ b/tests/monte_carlo/expected.json
@@ -6,7 +6,7 @@
           "description": "Field Health for all fields in db:metaphor.test1",
           "lastRun": "2023-06-23T03:54:35.817000+00:00",
           "owner": "yi@metaphor.io",
-          "severity": "UNKNOWN",
+          "severity": "HIGH",
           "status": "UNKNOWN",
           "targets": [],
           "title": "auto_monitor_name_cd5b69bd-e465-4545-b3f9-a5d507ea766c",
@@ -30,7 +30,7 @@
           "description": "Field Health for all fields in db:metaphor.test2",
           "lastRun": "2023-06-23T03:54:35.817000+00:00",
           "owner": "yi@metaphor.io",
-          "severity": "UNKNOWN",
+          "severity": "MEDIUM",
           "status": "PASSED",
           "targets": [
             {
@@ -61,7 +61,7 @@
           "description": "Field Health for all fields in db:metaphor.test3",
           "lastRun": "2023-06-23T03:54:35.817000+00:00",
           "owner": "yi@metaphor.io",
-          "severity": "UNKNOWN",
+          "severity": "LOW",
           "status": "ERROR",
           "targets": [],
           "title": "auto_monitor_name_18637195-a3c4-416e-a3e2-a89cc10adbc8",

--- a/tests/monte_carlo/test_extractor.py
+++ b/tests/monte_carlo/test_extractor.py
@@ -66,7 +66,7 @@ async def test_extractor(mock_pycarlo_client: MagicMock, test_root_dir: str):
                     "entityMcons": [
                         "MCON++6418a1e2-9718-4413-9d2b-6a354e01ddf8++a19e22b4-7659-4064-8fd4-8d6122fabe1c++table++db:metaphor.test1"
                     ],
-                    "severity": None,
+                    "priority": "P1",
                     "monitorStatus": "MISCONFIGURED",
                     "monitorFields": None,
                     "creatorId": "yi@metaphor.io",
@@ -80,7 +80,7 @@ async def test_extractor(mock_pycarlo_client: MagicMock, test_root_dir: str):
                     "entityMcons": [
                         "MCON++6418a1e2-9718-4413-9d2b-6a354e01ddf8++a19e22b4-7659-4064-8fd4-8d6122fabe1c++table++db:metaphor.test2"
                     ],
-                    "severity": "LOW",
+                    "priority": "P2",
                     "monitorStatus": "SUCCESS",
                     "monitorFields": ["foo", "bar"],
                     "creatorId": "yi@metaphor.io",
@@ -94,7 +94,7 @@ async def test_extractor(mock_pycarlo_client: MagicMock, test_root_dir: str):
                     "entityMcons": [
                         "MCON++6418a1e2-9718-4413-9d2b-6a354e01ddf8++a19e22b4-7659-4064-8fd4-8d6122fabe1c++table++db:metaphor.test3"
                     ],
-                    "severity": None,
+                    "priority": "P3",
                     "monitorStatus": "ERROR",
                     "monitorFields": None,
                     "creatorId": "yi@metaphor.io",
@@ -108,7 +108,20 @@ async def test_extractor(mock_pycarlo_client: MagicMock, test_root_dir: str):
                     "entityMcons": [
                         "MCON++6418a1e2-9718-4413-9d2b-6a354e01ddf8++a19e22b4-7659-4064-8fd4-8d6122fabe1c++table++db:metaphor.test4"
                     ],
-                    "severity": None,
+                    "priority": None,
+                    "monitorStatus": "ERROR",
+                    "exceptions": "Ignore me",
+                    "monitorFields": None,
+                    "creatorId": "yi@metaphor.io",
+                    "prevExecutionTime": "2023-06-23T03:54:35.817000+00:00",
+                },
+                {
+                    "uuid": "d14af7d8-6342-420a-bb09-5805fad677f1",
+                    "name": "auto_monitor_name_693b98e3-950d-472b-83fe-8c8e5b5979fa",
+                    "description": "Monitor with no entities",
+                    "entities": None,
+                    "entityMcons": None,
+                    "priority": None,
                     "monitorStatus": "ERROR",
                     "exceptions": "Ignore me",
                     "monitorFields": None,


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

The MC connector throws the following exception when encountering a misconfigured MC monitor:
```
Traceback (most recent call last):
  File "/connectors/metaphor/monte_carlo/extractor.py", line 122, in _fetch_monitors
    self._parse_monitors(monitors)
  File "/connectors/metaphor/monte_carlo/extractor.py", line 208, in _parse_monitors
    for index, entity in enumerate(monitor["entities"]):
TypeError: 'NoneType' object is not iterable
```

Based the [API doc](https://apidocs.getmontecarlo.com/#definition-Monitor), both `entities` and `entityMcons` fields are optional.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Skip misconfigured monitors.
- Derive the monitor severity from the `priority` field, instead of the deprecated `severity` field.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified against a production instance.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
