### PR TITLE
Add account_usage config to query a alternate schema

### DIFF
--- a/metaphor/snowflake/README.md
+++ b/metaphor/snowflake/README.md
@@ -110,6 +110,14 @@ See [Output Config](../common/docs/output.md) for more information.
 
 See [Filter Config](../common/docs/filter.md) for more information on the optional `filter` config.
 
+#### Alternative ACCOUNT_USAGE Schema
+
+By default, the connector will read the [QUERY_HISTORY](https://docs.snowflake.com/en/sql-reference/account-usage/query_history), [ACCESS_HISTORY](https://docs.snowflake.com/en/sql-reference/account-usage/access_history), and [TAG_REFERENCES](https://docs.snowflake.com/en/sql-reference/account-usage/tag_references) views from [SNOWFLAKE.ACCOUNT_USAGE](https://docs.snowflake.com/en/sql-reference/account-usage) schema. If you do not wish to grant read access to the entire SNOWFLAKE database, you can mirror these views to a different schema and ask the connector to read from it instead:
+
+```yaml
+account_usage_schema: <db_name>.<schema_name>
+```
+
 #### Tag Assignment
 
 See [Tag Matcher Config](../common/docs/tag_matcher.md) for more information on the optional `tag_matcher` config.

--- a/metaphor/snowflake/config.py
+++ b/metaphor/snowflake/config.py
@@ -70,3 +70,6 @@ class SnowflakeConfig(SnowflakeBaseConfig):
     streams: SnowflakeStreamsConfig = field(
         default_factory=lambda: SnowflakeStreamsConfig()
     )
+
+    # The fully qualified schema that contains all the account_usage views
+    account_usage_schema: str = "SNOWFLAKE.ACCOUNT_USAGE"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.64"
+version = "0.14.65"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/snowflake/config.yml
+++ b/tests/snowflake/config.yml
@@ -5,6 +5,7 @@ password: password
 role: role
 warehouse: warehouse
 default_database: database
+account_usage_schema: db.schema
 filter:
   includes:
     db1:

--- a/tests/snowflake/test_config.py
+++ b/tests/snowflake/test_config.py
@@ -17,6 +17,7 @@ def test_yaml_config(test_root_dir):
         role="role",
         warehouse="warehouse",
         default_database="database",
+        account_usage_schema="db.schema",
         filter=DatasetFilter(
             includes={
                 "db1": {


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Granting access to the entire SNOWFLAKE database may not always be desirable. The connector should be able to query from a different schema that mirrors the minimally needed views (QUERY_HISTORY, ACCESS_HISTORY, TAG_REFERENCES).

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified against a production instance with mirrored views.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
