### PR TITLE
[sc-27547] Point embedded datasource url to workbook

### DIFF
--- a/metaphor/tableau/extractor.py
+++ b/metaphor/tableau/extractor.py
@@ -525,6 +525,7 @@ class TableauExtractor(BaseExtractor):
                         custom_sql_source.account if custom_sql_source else None
                     ),
                     source_datasets=source_datasets or None,
+                    url=f"{self._base_url}/workbooks/{workbook.vizportalUrlId}",
                 ),
                 entity_upstream=(
                     EntityUpstream(source_entities=source_datasets)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.67"
+version = "0.14.68"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/tableau/expected.json
+++ b/tests/tableau/expected.json
@@ -127,7 +127,8 @@
       "name": "default.source2",
       "sourceDatasets": [
         "DATASET~F9D8E5963019975462CB6CB2002D247B"
-      ]
+      ],
+      "url": "https://10ax.online.tableau.com/#/site/abc/workbooks/123"
     }
   },
   {
@@ -166,7 +167,8 @@
       "source_platform": "BIGQUERY",
       "sourceDatasets": [
         "DATASET~5375BC53A82C65FD48653B9418094BB0"
-      ]
+      ],
+      "url": "https://10ax.online.tableau.com/#/site/abc/workbooks/123"
     }
   },
   {

--- a/tests/tableau/test_extractor.py
+++ b/tests/tableau/test_extractor.py
@@ -443,4 +443,5 @@ async def test_extractor(
 
     events = [EventUtil.trim_event(e) for e in await extractor.extract()]
 
-    assert events == load_json(f"{test_root_dir}/tableau/expected.json")
+    expected = f"{test_root_dir}/tableau/expected.json"
+    assert events == load_json(expected)


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

An embedded datasource is always in a workbook, so for its URL we just use the workbook's.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

For embedded tableau datasources, their url should point to the workbooks containing them.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

- Updated unit test.
- Ran crawler locally.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
