### PR TITLE
Use source_info.main_url instead of crafting workbook url in tableau extractor

### DIFF
--- a/metaphor/tableau/extractor.py
+++ b/metaphor/tableau/extractor.py
@@ -525,7 +525,11 @@ class TableauExtractor(BaseExtractor):
                         custom_sql_source.account if custom_sql_source else None
                     ),
                     source_datasets=source_datasets or None,
-                    url=f"{self._base_url}/workbooks/{workbook.vizportalUrlId}",
+                    url=(
+                        dashboard.source_info.main_url
+                        if dashboard.source_info
+                        else None
+                    ),
                 ),
                 entity_upstream=(
                     EntityUpstream(source_entities=source_datasets)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.69"
+version = "0.14.70"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.70"
+version = "0.14.71"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Should use `source_info.main_url` for embedded datasource url instead.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Tested locally.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
