### PR TITLE
[sc-28036] Oracle query logs need to have _id and sql_hash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.73"
+version = "0.14.74"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/oracle/expected_query_logs.json
+++ b/tests/oracle/expected_query_logs.json
@@ -1,10 +1,12 @@
 [
   {
+    "_id": "ORACLE:sql-id",
     "duration": 10.0,
     "platform": "ORACLE",
     "queryId": "sql-id",
     "sql": "SELECT...",
     "startTime": "2024-07-30T15:31:33+00:00",
+    "sqlHash": "191df6d782898cbb739c413fa5868422",
     "userId": "DEV"
   }
 ]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

In order to make Metaphor's validator work, these properties need to be populated in the crawler.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Added `_id` and `sql_hash` properties in Oracle QueryLog.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Updated unit test.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
