### PR TITLE
Skip looker user folder hierarchies

### DIFF
--- a/metaphor/looker/folder.py
+++ b/metaphor/looker/folder.py
@@ -49,7 +49,7 @@ def build_directories(
 
 
 def _build_hierarchies(
-    directories: List[str], folder_map: FolderMap, folders: Dict[str, Hierarchy]
+    directories: List[str], folder_map: FolderMap, folder_hierarchies: Dict[str, Hierarchy]
 ):
     for i, folder_id in enumerate(directories):
         folder = folder_map.get(folder_id)

--- a/metaphor/looker/folder.py
+++ b/metaphor/looker/folder.py
@@ -24,7 +24,9 @@ logger = get_logger()
 
 
 def build_directories(
-    folder_id: str, folder_map: FolderMap, folders: Dict[str, Hierarchy]
+    folder_id: str,
+    folder_map: FolderMap,
+    folder_hierarchies: Dict[str, Hierarchy],
 ) -> List[str]:
     directories: List[str] = []
 
@@ -41,7 +43,7 @@ def build_directories(
 
         folder_id = folder.parent_id
 
-    _build_hierarchies(directories, folder_map, folders)
+    _build_hierarchies(directories, folder_map, folder_hierarchies)
 
     return directories
 

--- a/metaphor/looker/folder.py
+++ b/metaphor/looker/folder.py
@@ -49,7 +49,9 @@ def build_directories(
 
 
 def _build_hierarchies(
-    directories: List[str], folder_map: FolderMap, folder_hierarchies: Dict[str, Hierarchy]
+    directories: List[str],
+    folder_map: FolderMap,
+    folder_hierarchies: Dict[str, Hierarchy],
 ):
     for i, folder_id in enumerate(directories):
         folder = folder_map.get(folder_id)

--- a/metaphor/looker/folder.py
+++ b/metaphor/looker/folder.py
@@ -65,4 +65,4 @@ def _build_hierarchies(
             ),
         )
 
-        folders[folder_id] = hierarchy
+        folder_hierarchies[folder_id] = hierarchy

--- a/metaphor/looker/folder.py
+++ b/metaphor/looker/folder.py
@@ -53,7 +53,7 @@ def _build_hierarchies(
 ):
     for i, folder_id in enumerate(directories):
         folder = folder_map.get(folder_id)
-        if folder_id in folders or folder is None:
+        if folder_id in folder_hierarchies or folder is None:
             continue
 
         hierarchy = Hierarchy(

--- a/metaphor/looker/folder.py
+++ b/metaphor/looker/folder.py
@@ -41,12 +41,12 @@ def build_directories(
 
         folder_id = folder.parent_id
 
-    build_hierarchies(directories, folder_map, folders)
+    _build_hierarchies(directories, folder_map, folders)
 
     return directories
 
 
-def build_hierarchies(
+def _build_hierarchies(
     directories: List[str], folder_map: FolderMap, folders: Dict[str, Hierarchy]
 ):
     for i, folder_id in enumerate(directories):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.75"
+version = "0.14.76"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/looker/test_folder.py
+++ b/tests/looker/test_folder.py
@@ -9,12 +9,12 @@ def test_build_directories(test_root_dir) -> None:
         "3": FolderMetadata(id="3", name="folder3", parent_id="2"),
     }
 
-    folders: dict = {}
+    folder_hierarchies: dict = {}
 
-    assert build_directories("1", folder_map, folders) == ["1"]
-    assert build_directories("2", folder_map, folders) == ["1", "2"]
-    assert build_directories("3", folder_map, folders) == ["1", "2", "3"]
-    assert len(folders) == 3
+    assert build_directories("1", folder_map, folder_hierarchies) == ["1"]
+    assert build_directories("2", folder_map, folder_hierarchies) == ["1", "2"]
+    assert build_directories("3", folder_map, folder_hierarchies) == ["1", "2", "3"]
+    assert len(folder_hierarchies) == 3
 
 
 def test_build_hierarchy(test_root_dir) -> None:

--- a/tests/looker/test_folder.py
+++ b/tests/looker/test_folder.py
@@ -1,4 +1,4 @@
-from metaphor.looker.folder import FolderMetadata, build_directories
+from metaphor.looker.folder import FolderMetadata, _build_hierarchies, build_directories
 
 
 def test_build_directories(test_root_dir) -> None:
@@ -14,5 +14,24 @@ def test_build_directories(test_root_dir) -> None:
     assert build_directories("1", folder_map, folders) == ["1"]
     assert build_directories("2", folder_map, folders) == ["1", "2"]
     assert build_directories("3", folder_map, folders) == ["1", "2", "3"]
-
     assert len(folders) == 3
+
+
+def test_build_hierarchy(test_root_dir) -> None:
+
+    folder_map = {
+        "1": FolderMetadata(id="1", name="folder1", parent_id=None),
+        "2": FolderMetadata(id="2", name="folder2", parent_id="1"),
+        "3": FolderMetadata(id="3", name="folder3", parent_id="2"),
+    }
+
+    folders: dict = {}
+
+    _build_hierarchies(["1", "2", "3"], folder_map, folders)
+    assert len(folders) == 3
+    assert folders["1"].hierarchy_info.name == "folder1"
+    assert folders["1"].logical_id.path == ["LOOKER", "1"]
+    assert folders["2"].hierarchy_info.name == "folder2"
+    assert folders["2"].logical_id.path == ["LOOKER", "1", "2"]
+    assert folders["3"].hierarchy_info.name == "folder3"
+    assert folders["3"].logical_id.path == ["LOOKER", "1", "2", "3"]

--- a/tests/looker/test_folder.py
+++ b/tests/looker/test_folder.py
@@ -35,3 +35,6 @@ def test_build_hierarchy(test_root_dir) -> None:
     assert folders["2"].logical_id.path == ["LOOKER", "1", "2"]
     assert folders["3"].hierarchy_info.name == "folder3"
     assert folders["3"].logical_id.path == ["LOOKER", "1", "2", "3"]
+
+    _build_hierarchies(["4"], folder_map, folders)
+    assert len(folders) == 3

--- a/tests/looker/test_folder.py
+++ b/tests/looker/test_folder.py
@@ -9,6 +9,10 @@ def test_build_directories(test_root_dir) -> None:
         "3": FolderMetadata(id="3", name="folder3", parent_id="2"),
     }
 
-    assert build_directories("1", folder_map) == ["1"]
-    assert build_directories("2", folder_map) == ["1", "2"]
-    assert build_directories("3", folder_map) == ["1", "2", "3"]
+    folders: dict = {}
+
+    assert build_directories("1", folder_map, folders) == ["1"]
+    assert build_directories("2", folder_map, folders) == ["1", "2"]
+    assert build_directories("3", folder_map, folders) == ["1", "2", "3"]
+
+    assert len(folders) == 3


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

We populate all folders as hierarchies, and we should exclude the folder that is not used. So the `include_personal_folder` flag can also be applied to the hierarchy not just the dashboard.

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

- Refactor `build_directory` to populate hierarchies as well

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

Verified no personal folder hierarchy in the output MCEs

<!--
  Describe how the change was tested end-to-end.
-->

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
