### PR TITLE
[sc-28135] Redact literal values in CASE clauses

### DIFF
--- a/metaphor/common/docs/process_query.md
+++ b/metaphor/common/docs/process_query.md
@@ -7,6 +7,8 @@ process_query:
   redact_literals:
     where_clauses: <true | false>  # Whether to redact all literal values in WHERE clauses. Default is `false`.
 
+    case_clauses: <true | false>  # Whether to redact all literal values in CASE clauses. Default is `false`.
+
     when_not_matched_insert_clauses: <true | false>  # Whether to redact literal values in WHEN NOT MATCHED INSERT clauses. If set to `True`, all literal values will be redacted to a predefined string value. Default is `false`.
 
     placeholder_literal: <placeholder literal>  # The redacted values will be replaced by this placeholder string. Default is '<REDACTED>'.

--- a/metaphor/common/sql/process_query/config.py
+++ b/metaphor/common/sql/process_query/config.py
@@ -16,6 +16,11 @@ class RedactPIILiteralsConfig:
     Whether to redact literal values in WHERE clauses. If set to `True`, all literal values will be redacted to a predefined string value.
     """
 
+    case_clauses: bool = False
+    """
+    Whether to redact literal values in CASE clauses. If set to `True`, all literal values will be redacted to a predefined string value.
+    """
+
     when_not_matched_insert_clauses: bool = False
     """
     Whether to redact literal values in WHEN NOT MATCHED INSERT clauses. If set to `True`, all literal values will be redacted to a predefined string value.

--- a/metaphor/common/sql/process_query/process_query.py
+++ b/metaphor/common/sql/process_query/process_query.py
@@ -21,6 +21,14 @@ def _redact_literal_values_in_where_clauses(
             lit.args["this"] = config.redact_literals.placeholder_literal
 
 
+def _redact_literal_values_in_case_clauses(
+    expression: Expression, config: ProcessQueryConfig
+) -> None:
+    for case in expression.find_all(exp.Case):
+        for lit in case.find_all(exp.Literal):
+            lit.args["this"] = config.redact_literals.placeholder_literal
+
+
 def _redact_literal_values_in_when_not_matched_insert_clauses(
     expression: Expression,
     config: ProcessQueryConfig,
@@ -89,6 +97,9 @@ def process_query(
 
     if config.redact_literals.where_clauses:
         _redact_literal_values_in_where_clauses(expression, config)
+
+    if config.redact_literals.case_clauses:
+        _redact_literal_values_in_case_clauses(expression, config)
 
     if config.redact_literals.when_not_matched_insert_clauses:
         _redact_literal_values_in_when_not_matched_insert_clauses(expression, config)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.79"
+version = "0.14.80"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

It is possible to have PII values in CASE clauses. Our processor should be able to redact these.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Added logic to redact PII values in CASE clauses.
- Unit test.
- Added config value.
- Updated readme.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Added unit test.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
