### PR TITLE
Fix platform enum for Snowflake connector

### DIFF
--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -100,7 +100,7 @@ class SnowflakeExtractor(BaseExtractor):
     """Snowflake metadata extractor"""
 
     _description = "Snowflake metadata crawler"
-    _platform = Platform.REDSHIFT
+    _platform = Platform.SNOWFLAKE
 
     @staticmethod
     def from_config_file(config_file: str) -> "SnowflakeExtractor":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.80"
+version = "0.14.81"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

It was set to `REDSHIFT` incorrectly

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

As titled.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified the generated `metadata.run` file:
```
{
    "crawlerName": "metaphor.snowflake.extractor.SnowflakeExtractor",
    "description": "Snowflake metadata crawler",
    "endTime": "2024-08-20T07:19:29.901330",
    "entityCount": 193.0,
    "platform": "SNOWFLAKE",
    "startTime": "2024-08-20T07:18:57.189945",
    "status": "SUCCESS"
}
```

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
