### PR TITLE
Add validator to catch datetime azure_openai.version

### DIFF
--- a/metaphor/common/embeddings_config.py
+++ b/metaphor/common/embeddings_config.py
@@ -11,7 +11,7 @@ supported_sources = ["azure_openai", "openai"]
 class AzureOpenAIConfig(BaseModel):
     key: Optional[str] = None
     endpoint: Optional[str] = None
-    version: Optional[str] = "2024-03-01-preview"
+    version: Optional[str] = "2024-06-01"
     model: Optional[str] = "text-embedding-3-small"
     deployment_name: Optional[str] = "Embedding_3_small"
 

--- a/metaphor/common/embeddings_config.py
+++ b/metaphor/common/embeddings_config.py
@@ -1,6 +1,7 @@
+from datetime import datetime
 from typing import Any, Optional
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, model_validator, validator
 
 from metaphor.common.utils import must_set_exactly_one
 
@@ -13,6 +14,15 @@ class AzureOpenAIConfig(BaseModel):
     version: Optional[str] = "2024-03-01-preview"
     model: Optional[str] = "text-embedding-3-small"
     deployment_name: Optional[str] = "Embedding_3_small"
+
+    @validator("version", pre=True)
+    def ensure_version_is_string(cls, value):
+        """
+        Handle the case where the version is a datetime object.
+        """
+        if isinstance(value, datetime):
+            return value.strftime("%Y-%m-%d")
+        return str(value)
 
 
 class OpenAIConfig(BaseModel):

--- a/metaphor/common/embeddings_config.py
+++ b/metaphor/common/embeddings_config.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Any, Optional
 
-from pydantic import BaseModel, model_validator, validator
+from pydantic import BaseModel, field_validator, model_validator
 
 from metaphor.common.utils import must_set_exactly_one
 
@@ -15,7 +15,7 @@ class AzureOpenAIConfig(BaseModel):
     model: Optional[str] = "text-embedding-3-small"
     deployment_name: Optional[str] = "Embedding_3_small"
 
-    @validator("version", pre=True)
+    @field_validator("version", mode="before")
     def ensure_version_is_string(cls, value):
         """
         Handle the case where the version is a datetime object.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1417,13 +1417,13 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "faker"
-version = "27.3.0"
+version = "27.4.0"
 description = "Faker is a Python package that generates fake data for you."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "Faker-27.3.0-py3-none-any.whl", hash = "sha256:e3a3b843c9df828cea8cc91c84390a20294da084bef9d004ac9b985554fd58b7"},
-    {file = "faker-27.3.0.tar.gz", hash = "sha256:3015bcdc61e648e55f97f397ed8b49ee4c8dd69ad8c9a6bb782b624e862b9cf2"},
+    {file = "Faker-27.4.0-py3-none-any.whl", hash = "sha256:1c44d4bdcad7237516c9a829b6a0bcb031c6a4cb0506207c480c79f74d8922bf"},
+    {file = "faker-27.4.0.tar.gz", hash = "sha256:4ce108fc96053bbba3abf848e3a2885f05faa938deb987f97e4420deaec541c4"},
 ]
 
 [package.dependencies]
@@ -2605,13 +2605,13 @@ files = [
 
 [[package]]
 name = "llama-cloud"
-version = "0.0.13"
+version = "0.0.14"
 description = ""
 optional = true
 python-versions = "<4,>=3.8"
 files = [
-    {file = "llama_cloud-0.0.13-py3-none-any.whl", hash = "sha256:b641450308b80c85eeae7ef9cb5a3b4a3b1823d5cde05b626ce33f7494ec6229"},
-    {file = "llama_cloud-0.0.13.tar.gz", hash = "sha256:0e3165a22f8df34a00d13f1f5739438ba4d620f2d8a9289df830078a39fe6f1f"},
+    {file = "llama_cloud-0.0.14-py3-none-any.whl", hash = "sha256:356143a9d88d59ed8f0474841fcfba053fe8b56ff8bb3771e570d583869061f8"},
+    {file = "llama_cloud-0.0.14.tar.gz", hash = "sha256:44157bd3fc84099365181fb0254b7b533a502f2a8b97d5f87e86d1cccc1501d8"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.82"
+version = "0.14.83"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/common/test_embeddings_config.py
+++ b/tests/common/test_embeddings_config.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from pydantic import ValidationError
 
 from metaphor.common.embeddings_config import (
@@ -13,7 +15,7 @@ def test_default_initialization():
     )
     assert config.azure_openai.key == "key"
     assert config.azure_openai.endpoint == "endpoint"
-    assert config.azure_openai.version == "2024-03-01-preview"
+    assert config.azure_openai.version == "2024-06-01"
     assert config.azure_openai.model == "text-embedding-3-small"
     assert config.azure_openai.deployment_name == "Embedding_3_small"
     assert config.openai is None
@@ -65,3 +67,14 @@ def test_handling_both_configs():
         _ = EmbeddingModelConfig(**user_configuration)
     except ValidationError:
         assert True  # expect this to fail with two configuration
+
+
+def test_azure_openai_config_version_as_datetime():
+    # Create a datetime object
+    version_datetime = datetime(2024, 6, 1)
+
+    # Initialize AzureOpenAIConfig with the datetime object
+    config = AzureOpenAIConfig(key="key", version=version_datetime)
+
+    # Assert that the version is correctly converted to a string
+    assert config.version == "2024-06-01"


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

If the `azure_openai.version` set in the app is a regular version e.g. `2024-06-01` instead of a `-preview` version it can be misinterpreted as a datetime when the config is loaded, causing validation errors.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Adds a validator to force datetime to string to catch pesky validation errors.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Connector tested locally with a YAML file generated by `app`, runs successfuly.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
