### PR TITLE
[sc-28233] Redacted values should be strings

### DIFF
--- a/metaphor/common/sql/process_query/process_query.py
+++ b/metaphor/common/sql/process_query/process_query.py
@@ -19,6 +19,7 @@ def _redact_literal_values_in_where_clauses(
     for where in expression.find_all(exp.Where):
         for lit in where.find_all(exp.Literal):
             lit.args["this"] = config.redact_literals.placeholder_literal
+            lit.args["is_string"] = True
 
 
 def _redact_literal_values_in_case_clauses(
@@ -27,6 +28,7 @@ def _redact_literal_values_in_case_clauses(
     for case in expression.find_all(exp.Case):
         for lit in case.find_all(exp.Literal):
             lit.args["this"] = config.redact_literals.placeholder_literal
+            lit.args["is_string"] = True
 
 
 def _redact_literal_values_in_when_not_matched_insert_clauses(
@@ -45,6 +47,7 @@ def _redact_literal_values_in_when_not_matched_insert_clauses(
 
         for lit in values.find_all(exp.Literal):
             lit.args["this"] = config.redact_literals.placeholder_literal
+            lit.args["is_string"] = True
 
 
 def _is_insert_values_into(expression: Expression) -> bool:

--- a/metaphor/common/sql/process_query/process_query.py
+++ b/metaphor/common/sql/process_query/process_query.py
@@ -13,13 +13,17 @@ from metaphor.models.metadata_change_event import DataPlatform
 logger = get_logger()
 
 
+def _redact_literal(lit: exp.Literal, config: ProcessQueryConfig) -> None:
+    lit.args["this"] = config.redact_literals.placeholder_literal
+    lit.args["is_string"] = True
+
+
 def _redact_literal_values_in_where_clauses(
     expression: Expression, config: ProcessQueryConfig
 ) -> None:
     for where in expression.find_all(exp.Where):
         for lit in where.find_all(exp.Literal):
-            lit.args["this"] = config.redact_literals.placeholder_literal
-            lit.args["is_string"] = True
+            _redact_literal(lit, config)
 
 
 def _redact_literal_values_in_case_clauses(
@@ -27,8 +31,7 @@ def _redact_literal_values_in_case_clauses(
 ) -> None:
     for case in expression.find_all(exp.Case):
         for lit in case.find_all(exp.Literal):
-            lit.args["this"] = config.redact_literals.placeholder_literal
-            lit.args["is_string"] = True
+            _redact_literal(lit, config)
 
 
 def _redact_literal_values_in_when_not_matched_insert_clauses(
@@ -46,8 +49,7 @@ def _redact_literal_values_in_when_not_matched_insert_clauses(
             continue
 
         for lit in values.find_all(exp.Literal):
-            lit.args["this"] = config.redact_literals.placeholder_literal
-            lit.args["is_string"] = True
+            _redact_literal(lit, config)
 
 
 def _is_insert_values_into(expression: Expression) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.83"
+version = "0.14.84"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/common/sql/process_query/process_query/redact_literal_values_in_where_clauses/expected.sql
+++ b/tests/common/sql/process_query/process_query/redact_literal_values_in_where_clauses/expected.sql
@@ -1,0 +1,31 @@
+WITH q AS (
+    SELECT
+        *
+    FROM
+        (
+            SELECT
+                foo,
+                bar
+            FROM
+                (
+                    SELECT
+                        *
+                    FROM
+                        db.sch.src
+                    WHERE
+                        col > '<REDACTED>'
+                        AND col < '<REDACTED>'
+                )
+            WHERE
+                col2 = '<REDACTED>'
+        )
+    WHERE
+        foo = '<REDACTED>'
+)
+SELECT
+    foo,
+    bar
+FROM
+    q
+WHERE
+    bar <> '<REDACTED>'

--- a/tests/common/sql/process_query/process_query/redact_literal_values_in_where_clauses/query.sql
+++ b/tests/common/sql/process_query/process_query/redact_literal_values_in_where_clauses/query.sql
@@ -1,0 +1,31 @@
+WITH q AS (
+    SELECT
+        *
+    FROM
+        (
+            SELECT
+                foo,
+                bar
+            FROM
+                (
+                    SELECT
+                        *
+                    FROM
+                        db.sch.src
+                    WHERE
+                        col > 1234
+                        AND col < 9999
+                )
+            WHERE
+                col2 == 'some value'
+        )
+    WHERE
+        foo == 'not really foo'
+)
+SELECT
+    foo,
+    bar
+FROM
+    q
+WHERE
+    bar != 'this cannot be bar'

--- a/tests/common/sql/process_query/process_query/redact_literals_in_where_in/expected.sql
+++ b/tests/common/sql/process_query/process_query/redact_literals_in_where_in/expected.sql
@@ -1,0 +1,1 @@
+SELECT p.FirstName, p.LastName, e.JobTitle FROM Person.Person AS p JOIN HumanResources.Employee AS e ON p.BusinessEntityID = e.BusinessEntityID WHERE e.JobTitle IN ('<REDACTED>', '<REDACTED>', '<REDACTED>')

--- a/tests/common/sql/process_query/process_query/redact_literals_in_where_in/query.sql
+++ b/tests/common/sql/process_query/process_query/redact_literals_in_where_in/query.sql
@@ -1,0 +1,5 @@
+SELECT p.FirstName, p.LastName, e.JobTitle
+FROM Person.Person AS p
+JOIN HumanResources.Employee AS e
+    ON p.BusinessEntityID = e.BusinessEntityID
+WHERE e.JobTitle IN ('Design Engineer', 'Tool Designer', 'Marketing Assistant')

--- a/tests/common/sql/process_query/process_query/redact_literals_in_where_or/expected.sql
+++ b/tests/common/sql/process_query/process_query/redact_literals_in_where_or/expected.sql
@@ -1,0 +1,1 @@
+SELECT p.FirstName, p.LastName, e.JobTitle FROM Person.Person AS p JOIN HumanResources.Employee AS e ON p.BusinessEntityID = e.BusinessEntityID WHERE e.JobTitle = '<REDACTED>' OR e.JobTitle = '<REDACTED>' OR e.JobTitle = '<REDACTED>'

--- a/tests/common/sql/process_query/process_query/redact_literals_in_where_or/query.sql
+++ b/tests/common/sql/process_query/process_query/redact_literals_in_where_or/query.sql
@@ -1,0 +1,7 @@
+SELECT p.FirstName, p.LastName, e.JobTitle
+FROM Person.Person AS p
+JOIN HumanResources.Employee AS e
+    ON p.BusinessEntityID = e.BusinessEntityID
+WHERE e.JobTitle = 'Design Engineer'
+   OR e.JobTitle = 'Tool Designer'
+   OR e.JobTitle = 'Marketing Assistant'

--- a/tests/common/sql/process_query/process_query/redact_merge_insert_when_not_matched/expected.sql
+++ b/tests/common/sql/process_query/process_query/redact_merge_insert_when_not_matched/expected.sql
@@ -1,0 +1,11 @@
+MERGE INTO TargetProducts AS Target USING SourceProducts AS Source ON Source.ProductID = Target.ProductID /* For Inserts */
+WHEN NOT MATCHED THEN
+INSERT
+    (ProductID, ProductName, Price)
+VALUES
+    ('<REDACTED>', '<REDACTED>', '<REDACTED>') /* For Updates */
+    WHEN MATCHED THEN
+UPDATE
+SET
+    Target.ProductName = Source.ProductName,
+    Target.Price = Source.Price

--- a/tests/common/sql/process_query/process_query/redact_merge_insert_when_not_matched/query.sql
+++ b/tests/common/sql/process_query/process_query/redact_merge_insert_when_not_matched/query.sql
@@ -1,0 +1,11 @@
+MERGE TargetProducts AS Target USING SourceProducts AS Source ON Source.ProductID = Target.ProductID -- For Inserts
+WHEN NOT MATCHED BY Target THEN
+INSERT
+    (ProductID, ProductName, Price)
+VALUES
+    (1, 'awesome product', 0.1) -- For Updates
+    WHEN MATCHED THEN
+UPDATE
+SET
+    Target.ProductName = Source.ProductName,
+    Target.Price = Source.Price;

--- a/tests/common/sql/process_query/process_query/redact_simple/expected.sql
+++ b/tests/common/sql/process_query/process_query/redact_simple/expected.sql
@@ -1,0 +1,1 @@
+SELECT col FROM src WHERE col > '<REDACTED>' AND col < '<REDACTED>'

--- a/tests/common/sql/process_query/process_query/redact_simple/query.sql
+++ b/tests/common/sql/process_query/process_query/redact_simple/query.sql
@@ -1,0 +1,1 @@
+SELECT col FROM src WHERE col > 12345 AND col < 99999

--- a/tests/common/sql/process_query/process_query/redact_where_clauses/expected.sql
+++ b/tests/common/sql/process_query/process_query/redact_where_clauses/expected.sql
@@ -1,0 +1,16 @@
+INSERT INTO
+    target_table (first_name, last_name, email, status)
+SELECT
+    first_name,
+    last_name,
+    email,
+    CASE
+        WHEN age < '<REDACTED>' THEN '<REDACTED>'
+        WHEN age >= '<REDACTED>'
+        AND age < '<REDACTED>' THEN '<REDACTED>'
+        ELSE '<REDACTED>'
+    END AS status
+FROM
+    source_table
+WHERE
+    NOT email IS NULL

--- a/tests/common/sql/process_query/process_query/redact_where_clauses/query.sql
+++ b/tests/common/sql/process_query/process_query/redact_where_clauses/query.sql
@@ -1,0 +1,12 @@
+INSERT INTO target_table (first_name, last_name, email, status)
+SELECT
+    first_name,
+    last_name,
+    email,
+    CASE
+        WHEN age < 18 THEN 'Minor'
+        WHEN age >= 18 AND age < 65 THEN 'Adult'
+        ELSE 'Senior'
+    END as status
+FROM source_table
+WHERE email IS NOT NULL;

--- a/tests/common/sql/process_query/process_query/snowflake_copy_into/expected.sql
+++ b/tests/common/sql/process_query/process_query/snowflake_copy_into/expected.sql
@@ -1,0 +1,1 @@
+COPY INTO tgt (foo, bar) FROM (SELECT * FROM src)

--- a/tests/common/sql/process_query/process_query/snowflake_copy_into/query.sql
+++ b/tests/common/sql/process_query/process_query/snowflake_copy_into/query.sql
@@ -1,0 +1,13 @@
+COPY INTO tgt
+(
+    foo,
+    bar
+)
+FROM
+    (
+        SELECT
+            *
+        FROM
+            src
+    )
+FILES = ('1') REGION = 'us-east-1' CREDENTIALS = (AWS_KEY_ID = 'id' AWS_SECRET_KEY = 'key' AWS_TOKEN='tok') ENCRYPTION = (MASTER_KEY = '') FILE_FORMAT = ( BINARY_FORMAT = BASE64 TYPE = 'csv' ESCAPE = NONE ESCAPE_UNENCLOSED_FIELD = NONE FIELD_OPTIONALLY_ENCLOSED_BY = '\"' COMPRESSION = 'zstd' NULL_IF = 'null-vba3aoqjpgeovgjvmzn5cklcstanclr' SKIP_HEADER = 1 ) PURGE = TRUE ON_ERROR = abort_statement

--- a/tests/common/sql/process_query/test_process_query.py
+++ b/tests/common/sql/process_query/test_process_query.py
@@ -1,3 +1,9 @@
+from pathlib import Path
+
+import pytest
+import sqlglot
+
+from metaphor.common.sql.dialect import PLATFORM_TO_DIALECT
 from metaphor.common.sql.process_query import process_query
 from metaphor.common.sql.process_query.config import (
     ProcessQueryConfig,
@@ -15,112 +21,28 @@ config = ProcessQueryConfig(
 )
 
 
-def test_redact_literal_values_in_where_clauses():
-    sql = "SELECT col FROM src WHERE col > 12345 AND col < 99999"
-    processed = process_query(sql, DataPlatform.SNOWFLAKE, config)
-    assert (
-        processed
-        == f"SELECT col FROM src WHERE col > {config.redact_literals.placeholder_literal} AND col < {config.redact_literals.placeholder_literal}"
-    )
-
-    sql = """
-    WITH q AS (
-        SELECT
-            *
-        FROM (
-            SELECT
-                foo,
-                bar
-            FROM (
-                SELECT
-                    *
-                FROM
-                    db.sch.src
-                WHERE
-                    col > 1234 AND col < 9999
-            )
-            WHERE
-                col2 == 'some value'
-        )
-        WHERE
-            foo == 'not really foo'
-    )
-    SELECT
-        foo,
-        bar
-    FROM
-        q
-    WHERE
-        bar != 'this cannot be bar'
-    """
-    processed = process_query(sql, DataPlatform.SNOWFLAKE, config)
-    # Notice `==` becomes `=` and `!=` becomes `<>`
-    expected = "WITH q AS (SELECT * FROM (SELECT foo, bar FROM (SELECT * FROM db.sch.src WHERE col > <REDACTED> AND col < <REDACTED>) WHERE col2 = '<REDACTED>') WHERE foo = '<REDACTED>') SELECT foo, bar FROM q WHERE bar <> '<REDACTED>'"
-    assert processed == expected
-
-
-def test_handle_snowflake_copy_into():
-    sql = """
-    COPY INTO tgt
-(
-    foo,
-    bar
+@pytest.mark.parametrize(
+    ["name", "platform"],
+    [
+        ("redact_literal_values_in_where_clauses", DataPlatform.SNOWFLAKE),
+        ("redact_simple", DataPlatform.SNOWFLAKE),
+        ("snowflake_copy_into", DataPlatform.SNOWFLAKE),
+        ("redact_literals_in_where_in", DataPlatform.MSSQL),
+        ("redact_literals_in_where_or", DataPlatform.MSSQL),
+        ("redact_merge_insert_when_not_matched", DataPlatform.MSSQL),
+    ],
 )
-FROM
-    (
-        SELECT
-            *
-        FROM
-            src
-    )
-FILES = ('1') REGION = 'us-east-1' CREDENTIALS = (AWS_KEY_ID = 'id' AWS_SECRET_KEY = 'key' AWS_TOKEN='tok') ENCRYPTION = (MASTER_KEY = '') FILE_FORMAT = ( BINARY_FORMAT = BASE64 TYPE = 'csv' ESCAPE = NONE ESCAPE_UNENCLOSED_FIELD = NONE FIELD_OPTIONALLY_ENCLOSED_BY = '\"' COMPRESSION = 'zstd' NULL_IF = 'null-vba3aoqjpgeovgjvmzn5cklcstanclr' SKIP_HEADER = 1 ) PURGE = TRUE ON_ERROR = abort_statement
-    """
-    processed = process_query(
-        sql,
-        DataPlatform.SNOWFLAKE,
-        config,
-    )
-    assert processed == "COPY INTO tgt (foo, bar) FROM (SELECT * FROM src)"
-
-
-def test_scrub_literals_in_where_in():
-    sql = """
-    SELECT p.FirstName, p.LastName, e.JobTitle
-FROM Person.Person AS p
-JOIN HumanResources.Employee AS e
-    ON p.BusinessEntityID = e.BusinessEntityID
-WHERE e.JobTitle IN ('Design Engineer', 'Tool Designer', 'Marketing Assistant')
-    """
-    processed = process_query(
-        sql,
-        DataPlatform.MSSQL,
-        config,
-    )
-    assert (
-        processed
-        == "SELECT p.FirstName, p.LastName, e.JobTitle FROM Person.Person AS p JOIN HumanResources.Employee AS e ON p.BusinessEntityID = e.BusinessEntityID WHERE e.JobTitle IN ('<REDACTED>', '<REDACTED>', '<REDACTED>')"
-    )
-
-
-def test_scrub_literals_in_where_or():
-    sql = """
-SELECT p.FirstName, p.LastName, e.JobTitle
-FROM Person.Person AS p
-JOIN HumanResources.Employee AS e
-    ON p.BusinessEntityID = e.BusinessEntityID
-WHERE e.JobTitle = 'Design Engineer'
-   OR e.JobTitle = 'Tool Designer'
-   OR e.JobTitle = 'Marketing Assistant'
-    """
-    processed = process_query(
-        sql,
-        DataPlatform.MSSQL,
-        config,
-    )
-    assert (
-        processed
-        == "SELECT p.FirstName, p.LastName, e.JobTitle FROM Person.Person AS p JOIN HumanResources.Employee AS e ON p.BusinessEntityID = e.BusinessEntityID WHERE e.JobTitle = '<REDACTED>' OR e.JobTitle = '<REDACTED>' OR e.JobTitle = '<REDACTED>'"
-    )
+def test_process_query(name: str, platform: DataPlatform):
+    dir = Path(__file__).parent / "process_query" / name
+    with open(dir / "query.sql") as f:
+        sql = f.read()
+    processed = process_query(sql, platform, config)
+    assert processed
+    dialect = PLATFORM_TO_DIALECT.get(platform)
+    actual = sqlglot.maybe_parse(processed, dialect=dialect)
+    with open(dir / "expected.sql") as f:
+        expected = sqlglot.maybe_parse(f.read(), dialect=dialect)
+    assert actual.sql(dialect=dialect) == expected.sql(dialect=dialect)
 
 
 def test_ignore_insert_value_into():
@@ -137,56 +59,3 @@ VALUES
         config,
     )
     assert processed is None
-
-
-def test_merge_insert_when_not_matched():
-    sql = """
-    MERGE TargetProducts AS Target
-    USING SourceProducts	AS Source
-    ON Source.ProductID = Target.ProductID
-
-    -- For Inserts
-    WHEN NOT MATCHED BY Target THEN
-        INSERT (ProductID,ProductName, Price)
-        VALUES (1,'awesome product', 0.1)
-
-    -- For Updates
-    WHEN MATCHED THEN UPDATE SET
-        Target.ProductName	= Source.ProductName,
-        Target.Price		= Source.Price;
-    """
-    processed = process_query(
-        sql,
-        DataPlatform.MSSQL,
-        config,
-    )
-    assert (
-        processed
-        == "MERGE INTO TargetProducts AS Target USING SourceProducts AS Source ON Source.ProductID = Target.ProductID WHEN NOT MATCHED THEN INSERT (ProductID, ProductName, Price) VALUES (<REDACTED>, '<REDACTED>', <REDACTED>) WHEN MATCHED THEN UPDATE SET Target.ProductName = Source.ProductName, Target.Price = Source.Price"
-    )
-
-
-def test_redact_where_clauses():
-    sql = """
-INSERT INTO target_table (first_name, last_name, email, status)
-SELECT
-    first_name,
-    last_name,
-    email,
-    CASE
-        WHEN age < 18 THEN 'Minor'
-        WHEN age >= 18 AND age < 65 THEN 'Adult'
-        ELSE 'Senior'
-    END as status
-FROM source_table
-WHERE email IS NOT NULL;
-    """
-    processed = process_query(
-        sql,
-        DataPlatform.SNOWFLAKE,
-        config,
-    )
-    assert (
-        processed
-        == "INSERT INTO target_table (first_name, last_name, email, status) SELECT first_name, last_name, email, CASE WHEN age < <REDACTED> THEN '<REDACTED>' WHEN age >= <REDACTED> AND age < <REDACTED> THEN '<REDACTED>' ELSE '<REDACTED>' END AS status FROM source_table WHERE NOT email IS NULL"
-    )

--- a/tests/common/sql/process_query/test_process_query.py
+++ b/tests/common/sql/process_query/test_process_query.py
@@ -39,9 +39,9 @@ def test_process_query(name: str, platform: DataPlatform):
     processed = process_query(sql, platform, config)
     assert processed
     dialect = PLATFORM_TO_DIALECT.get(platform)
-    actual = sqlglot.maybe_parse(processed, dialect=dialect)
+    actual: sqlglot.Expression = sqlglot.maybe_parse(processed, dialect=dialect)
     with open(dir / "expected.sql") as f:
-        expected = sqlglot.maybe_parse(f.read(), dialect=dialect)
+        expected: sqlglot.Expression = sqlglot.maybe_parse(f.read(), dialect=dialect)
     assert actual.sql(dialect=dialect) == expected.sql(dialect=dialect)
 
 


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

If a literal value should be redacted, we use the placeholder string `<REDACTED>`. However, if we are redacting a numeric value we need to turn it into a string, otherwise SQLGlot will think `<` is LT, and would not parse the thing.

For example, SQLGlot will not parse this:
```sql
INSERT INTO target_table (first_name, last_name, email, status)
SELECT
    first_name,
    last_name,
    email,
    CASE
        WHEN age < <REDACTED> THEN '<REDACTED>'
        WHEN age >= <REDACTED> AND age < <REDACTED> THEN '<REDACTED>'
        ELSE '<REDACTED>'
    END AS status
FROM source_table
WHERE NOT email IS NULL
```

On the other hand, this works:
```sql
INSERT INTO target_table (first_name, last_name, email, status)
SELECT
    first_name,
    last_name,
    email,
    CASE
        WHEN age < '<REDACTED>' THEN '<REDACTED>'
        WHEN age >= '<REDACTED>' AND age < '<REDACTED>' THEN '<REDACTED>'
        ELSE '<REDACTED>'
    END AS status
FROM source_table
WHERE NOT email IS NULL
```
```

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- When redacting a literal, set its `is_string` arg to `True`.
- Refactored tests.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Modified unit tests.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
