### PR TITLE
Better logging when parsing column type attributes

### DIFF
--- a/metaphor/postgresql/extractor.py
+++ b/metaphor/postgresql/extractor.py
@@ -429,17 +429,23 @@ class PostgreSQLExtractor(BaseExtractor):
     ) -> Tuple[Optional[float], Optional[float]]:
         precision, max_length = None, None
 
-        excluded_types = (
-            "timestamp",
-            "timestamp with time zone",
-            "timestamp without time zone",
-            "boolean",
-            "date",
-            "text",
+        known_types = (
+            "time without time zone",
+            "time with time zone",
+            "interval",
+            "uuid",
+            "json",
+            "jsonb",
+            "xml",
+            "bytea",
+            "ARRAY",
+            "USER-DEFINED",
+            "point",
+            "inet",
+            "macaddr",
+            "tsquery",
+            "tsvector",
         )
-
-        if native_type in excluded_types:
-            return precision, max_length
 
         if native_type == "integer" or native_type == "int":
             precision = 32.0
@@ -457,7 +463,9 @@ class PostgreSQLExtractor(BaseExtractor):
             precision = PostgreSQLExtractor._parse_precision(type_str)
         elif native_type == "character varying" or native_type == "character":
             max_length = PostgreSQLExtractor._parse_max_length(type_str)
-        else:
-            logger.warning(f"Not supported native type: {native_type}")
+        elif native_type not in known_types:
+            logger.debug(
+                f"Not parsing precision and length for unknown type: {native_type}"
+            )
 
         return precision, max_length

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.89"
+version = "0.14.90"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

Postgres crawler is spamming a lot of warning logs when parsing precision

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

As title

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

Verified against sample table that contains these column types.

<!--
  Describe how the change was tested end-to-end.
-->

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
