### PR TITLE
[sc-28341] Populate systemTags.tags only when there are really tags

### DIFF
--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -902,8 +902,6 @@ class SnowflakeExtractor(BaseExtractor):
             database=database, schema=schema, table=table
         )
 
-        dataset.system_tags = SystemTags(tags=[])
-
         return dataset
 
     @staticmethod

--- a/metaphor/snowflake/utils.py
+++ b/metaphor/snowflake/utils.py
@@ -16,6 +16,7 @@ from metaphor.models.metadata_change_event import (
     SnowflakeStreamSourceType,
     SnowflakeStreamType,
     SystemTag,
+    SystemTags,
 )
 
 logger = logging.getLogger(__name__)
@@ -239,11 +240,13 @@ def _update_field_system_tag(field: SchemaField, system_tag: SystemTag) -> None:
 
 
 def append_dataset_system_tag(dataset: Dataset, system_tag: SystemTag) -> None:
-    assert (
-        dataset.schema is not None
-        and dataset.system_tags
-        and dataset.system_tags.tags is not None
-    )
+    assert dataset.schema is not None
+
+    if dataset.system_tags is None:
+        dataset.system_tags = SystemTags()
+    if dataset.system_tags.tags is None:
+        dataset.system_tags.tags = []
+
     # Always override exisiting tag, since we process database tags first, then schema tags and
     # then finally table tags
     other_tags = [t for t in dataset.system_tags.tags if t.key != system_tag.key]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.91"
+version = "0.14.92"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/snowflake/test_extractor.py
+++ b/tests/snowflake/test_extractor.py
@@ -434,7 +434,7 @@ def test_fetch_hierarchy_system_tags(mock_connect: MagicMock):
 
     extractor._fetch_tags(mock_cursor)
 
-    assert dataset.system_tags and dataset.system_tags.tags is not None
+    assert dataset.system_tags is None
     assert extractor._hierarchies.get(dataset_normalized_name(table_name)) is not None
     db_hierarchy = extractor._hierarchies[dataset_normalized_name(table_name)]
     assert db_hierarchy.logical_id == HierarchyLogicalID(


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Populating `system_tags.tags` in `_init_dataset` will set the aspect's `createdAt` field to the day the crawler run and saw the dataset, thus making datasets that are supposed to be soft deleted appear to be constantly updated with each crawler run.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Only populate `systemTags.tags` when there's a tag that's associated to the dataset.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

- Modified unit test. If there is no tag for a dataset, its `system_tags` will be `None`.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
