### PR TITLE
[sc-28404] Add config to drop or pass through unparseable queries

### DIFF
--- a/metaphor/common/docs/process_query.md
+++ b/metaphor/common/docs/process_query.md
@@ -11,7 +11,7 @@ process_query:
 
   ignore_insert_values_into: <true | false>  # Ignore `INSERT INTO ... VALUES` expressions. These expressions don't have any lineage information, and are often very large in size. Default is `false`.
 
-  skip_unparsable_queries: <true | false>  # If this is set to `True`, when Sqlglot fails to parse a query we skip it from the collected MCE. Default is `false`, meaning we pass through any query we are unable to parse.
+  skip_unparsable_queries: <true | false>  # If this is set to `true`, when Sqlglot fails to parse a query we skip it from the collected MCE. Default is `false`, meaning we pass through any query we are unable to parse.
 ```
 
 If any of the following boolean values is set to true, crawler will process the incoming SQL queries:

--- a/metaphor/common/docs/process_query.md
+++ b/metaphor/common/docs/process_query.md
@@ -9,7 +9,9 @@ process_query:
 
     placeholder_literal: <placeholder literal>  # The redacted values will be replaced by this placeholder string. Default is '<REDACTED>'.
 
-  ignore_insert_values_into: <true | false>  #  Ignore `INSERT INTO ... VALUES` expressions. These expressions don't have any lineage information, and are often very large in size. Default is `false`.
+  ignore_insert_values_into: <true | false>  # Ignore `INSERT INTO ... VALUES` expressions. These expressions don't have any lineage information, and are often very large in size. Default is `false`.
+
+  skip_unparsable_queries: <true | false>  # If this is set to `True`, when Sqlglot fails to parse a query we skip it from the collected MCE. Default is `false`, meaning we pass through any query we are unable to parse.
 ```
 
 If any of the following boolean values is set to true, crawler will process the incoming SQL queries:

--- a/metaphor/common/sql/process_query/config.py
+++ b/metaphor/common/sql/process_query/config.py
@@ -60,6 +60,11 @@ class ProcessQueryConfig:
     lineage information, and are often very large in size.
     """
 
+    skip_unparsable_queries: bool = False
+    """
+    If this is set to `True`, when Sqlglot fails to parse a query we skip it from the collected MCE.
+    """
+
     @property
     def should_process(self) -> bool:
         """

--- a/metaphor/common/sql/process_query/process_query.py
+++ b/metaphor/common/sql/process_query/process_query.py
@@ -67,10 +67,10 @@ def process_query(
         expression: Expression = maybe_parse(updated, dialect=dialect)
     except SqlglotError as e:
         logger.debug(f"{sqlglot_error_message}: {e}")
-        return sql
+        return None if config.skip_unparsable_queries else sql
     except RecursionError:
         logger.debug(f"{sqlglot_error_message}: maximum recursion depth exceeded")
-        return sql
+        return None if config.skip_unparsable_queries else sql
 
     if config.ignore_insert_values_into and _is_insert_values_into(expression):
         return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.92"
+version = "0.14.93"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/common/sql/process_query/test_process_query.py
+++ b/tests/common/sql/process_query/test_process_query.py
@@ -57,3 +57,33 @@ VALUES
         config,
     )
     assert processed is None
+
+
+def test_skip_unparseable_queries():
+    sql = """
+    SELECT
+        { fn convert("D", SQL_DATE) } as DATE
+    FROM
+        db.sch.tab
+    """
+
+    # This skips the unparseable query
+    processed = process_query(
+        sql,
+        DataPlatform.SNOWFLAKE,
+        ProcessQueryConfig(
+            redact_literals=RedactPIILiteralsConfig(
+                enabled=True,
+            ),
+            skip_unparsable_queries=True,
+        ),
+    )
+    assert processed is None
+
+    # This passes through
+    processed = process_query(
+        sql,
+        DataPlatform.SNOWFLAKE,
+        config,
+    )
+    assert processed == sql


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

If we can't parse some queries, we want to be able to decide whether we want these queries to pass thru or be ignored altogether.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Added config to control whether to skip or pass through unparseable queries.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Added unit test.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
