### PR TITLE
Query log extraction for Postgres crawler

### DIFF
--- a/metaphor/postgresql/README.md
+++ b/metaphor/postgresql/README.md
@@ -43,7 +43,7 @@ port: <port_number>
 
 ### Query Log Extraction Configurations
 
-The connector support extract query log history from CloudWatch for RDS postgres. Please follow the [documentation](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_LogAccess.Concepts.PostgreSQL.Query_Logging.html) to configure RDS to log SQL statement to CloudWatch.
+The connector supports extracting query log history from CloudWatch for RDS PostgreSQL. Please follow [this documentation](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_LogAccess.Concepts.PostgreSQL.Query_Logging.html) to configure RDS to log SQL statements to CloudWatch.
 
 ```yaml
 query_log:

--- a/metaphor/postgresql/README.md
+++ b/metaphor/postgresql/README.md
@@ -41,6 +41,30 @@ By default, the connector will connect using the default PostgreSQL port 5432. Y
 port: <port_number>
 ```
 
+### Query Log Extraction Configurations
+
+The connector support extract query log history from CloudWatch for RDS postgres.
+
+```yaml
+query_log:
+  aws:
+    access_key_id: <aws_access_key_id>
+    secret_access_key: <aws_secret_access_key>
+    region_name: <aws_region_name>
+    assume_role_arn: <aws_role_arn>  # If using IAM role
+    session_token: <aws_session_token>  # If using session token
+    profile_name: <aws_profile_name>  # If using AWS profile
+  logs_group: <aws_cloud_watch_logs_group>
+
+  # (Optional) Number of days of query logs to fetch. Default to 1. If 0, the no query logs will be fetched.
+  lookback_days: <days>
+    
+  # (Optional) A list of users whose queries will be excluded from the log fetching.
+  excluded_usernames:
+    - <user_name1>
+    - <user_name2>
+```
+
 See [Filter Configurations](../common/docs/filter.md) for more information on the optional `filter` config.
 
 #### Output Destination

--- a/metaphor/postgresql/README.md
+++ b/metaphor/postgresql/README.md
@@ -52,8 +52,6 @@ query_log:
     secret_access_key: <aws_secret_access_key>
     region_name: <aws_region_name>
     assume_role_arn: <aws_role_arn>  # If using IAM role
-    session_token: <aws_session_token>  # If using session token
-    profile_name: <aws_profile_name>  # If using AWS profile
   logs_group: <aws_cloud_watch_logs_group>
 
   # (Optional) Number of days of query logs to fetch. Default to 1. If 0, the no query logs will be fetched.

--- a/metaphor/postgresql/README.md
+++ b/metaphor/postgresql/README.md
@@ -43,7 +43,7 @@ port: <port_number>
 
 ### Query Log Extraction Configurations
 
-The connector support extract query log history from CloudWatch for RDS postgres.
+The connector support extract query log history from CloudWatch for RDS postgres. Please follow the [documentation](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_LogAccess.Concepts.PostgreSQL.Query_Logging.html) to configure RDS to log SQL statement to CloudWatch.
 
 ```yaml
 query_log:

--- a/metaphor/postgresql/config.py
+++ b/metaphor/postgresql/config.py
@@ -10,20 +10,16 @@ from metaphor.common.filter import DatasetFilter
 
 
 @dataclass(config=ConnectorConfig)
-class PostgreSQLQueryLogConfig:
+class QueryLogConfig:
     # Number of days back of query logs to fetch, if 0, don't fetch query logs
     lookback_days: int = 1
 
     # Query log filter to exclude certain usernames
     excluded_usernames: Set[str] = field(default_factory=lambda: set())
 
-    aws: Optional[AwsCredentials] = None
-
-    logs_group: Optional[str] = None
-
 
 @dataclass(config=ConnectorConfig)
-class PostgreSQLRunConfig(BaseConfig):
+class BasePostgreSQLRunConfig(BaseConfig):
     host: str
     database: str
     user: str
@@ -33,8 +29,20 @@ class PostgreSQLRunConfig(BaseConfig):
     filter: DatasetFilter = field(default_factory=lambda: DatasetFilter())
 
     # configs for fetching query logs
+    query_log: QueryLogConfig = field(default_factory=lambda: QueryLogConfig())
+
+    port: int = 5432
+
+
+@dataclass(config=ConnectorConfig)
+class PostgreSQLQueryLogConfig(QueryLogConfig):
+    aws: Optional[AwsCredentials] = None
+    logs_group: Optional[str] = None
+
+
+@dataclass(config=ConnectorConfig)
+class PostgreSQLRunConfig(BasePostgreSQLRunConfig):
+    # configs for fetching query logs
     query_log: PostgreSQLQueryLogConfig = field(
         default_factory=lambda: PostgreSQLQueryLogConfig()
     )
-
-    port: int = 5432

--- a/metaphor/postgresql/config.py
+++ b/metaphor/postgresql/config.py
@@ -1,10 +1,25 @@
 from dataclasses import field
+from typing import Optional, Set
 
 from pydantic.dataclasses import dataclass
 
+from metaphor.common.aws import AwsCredentials
 from metaphor.common.base_config import BaseConfig
 from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.filter import DatasetFilter
+
+
+@dataclass(config=ConnectorConfig)
+class PostgreSQLQueryLogConfig:
+    # Number of days back of query logs to fetch, if 0, don't fetch query logs
+    lookback_days: int = 1
+
+    # Query log filter to exclude certain usernames
+    excluded_usernames: Set[str] = field(default_factory=lambda: set())
+
+    aws: Optional[AwsCredentials] = None
+
+    logs_group: Optional[str] = None
 
 
 @dataclass(config=ConnectorConfig)
@@ -16,5 +31,10 @@ class PostgreSQLRunConfig(BaseConfig):
 
     # Include or exclude specific databases/schemas/tables
     filter: DatasetFilter = field(default_factory=lambda: DatasetFilter())
+
+    # configs for fetching query logs
+    query_log: PostgreSQLQueryLogConfig = field(
+        default_factory=lambda: PostgreSQLQueryLogConfig()
+    )
 
     port: int = 5432

--- a/metaphor/postgresql/extractor.py
+++ b/metaphor/postgresql/extractor.py
@@ -34,7 +34,7 @@ from metaphor.models.metadata_change_event import (
     SchemaType,
     SQLSchema,
 )
-from metaphor.postgresql.config import PostgreSQLRunConfig
+from metaphor.postgresql.config import PostgreSQLQueryLogConfig, PostgreSQLRunConfig
 from metaphor.postgresql.log_parser import ParsedLog, parse_postgres_log
 
 logger = get_logger()
@@ -94,7 +94,8 @@ class PostgreSQLExtractor(BaseExtractor):
 
     def collect_query_logs(self) -> Iterator[QueryLog]:
         if (
-            self._query_log_config.aws
+            isinstance(self._query_log_config, PostgreSQLQueryLogConfig)
+            and self._query_log_config.aws
             and self._query_log_config.lookback_days > 0
             and self._query_log_config.logs_group is not None
         ):

--- a/metaphor/postgresql/extractor.py
+++ b/metaphor/postgresql/extractor.py
@@ -98,12 +98,11 @@ class PostgreSQLExtractor(BaseExtractor):
             and self._query_log_config.lookback_days > 0
             and self._query_log_config.logs_group is not None
         ):
-            return self._collect_query_logs_from_cloud_watch(
+            yield from self._collect_query_logs_from_cloud_watch(
                 client=self._query_log_config.aws.get_session().client("logs"),
                 lookback_days=self._query_log_config.lookback_days,
                 logs_group=self._query_log_config.logs_group,
             )
-        yield from []
 
     async def _connect_database(self, database: str) -> asyncpg.Connection:
         logger.info(f"Connecting to DB {database}")

--- a/metaphor/postgresql/log_parser.py
+++ b/metaphor/postgresql/log_parser.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import List, Optional
+
+
+@dataclass
+class ParsedLog:
+    log_time: datetime
+    user: str
+    database: str
+    session: str
+    log_level: str
+    log_body: List[str]
+
+
+def parse_postgres_log(log: str) -> Optional[ParsedLog]:
+    """
+    log prefix format: %t:%r:%u@%d:[%p]:
+    log message format: [message type]: [log body]
+    """
+    parts = log.split(":")
+
+    if len(parts) < 8:
+        # log did not match the format
+        return None
+
+    user, database = parts[4].split("@")
+
+    return ParsedLog(
+        log_time=datetime.strptime(":".join(parts[:3]), "%Y-%m-%d %H:%M:%S %Z").replace(
+            tzinfo=timezone.utc
+        ),
+        log_level=parts[6],
+        session=parts[5],
+        user=user,
+        database=database,
+        log_body=parts[7:],
+    )

--- a/metaphor/postgresql/profile/config.py
+++ b/metaphor/postgresql/profile/config.py
@@ -5,11 +5,11 @@ from pydantic.dataclasses import dataclass
 from metaphor.common.column_statistics import ColumnStatistics
 from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.sampling import SamplingConfig
-from metaphor.redshift.config import PostgreSQLRunConfig
+from metaphor.postgresql.config import BasePostgreSQLRunConfig
 
 
 @dataclass(config=ConnectorConfig)
-class PostgreSQLProfileRunConfig(PostgreSQLRunConfig):
+class PostgreSQLProfileRunConfig(BasePostgreSQLRunConfig):
     # Compute specific types of statistics for each column
     column_statistics: ColumnStatistics = dataclass_field(
         default_factory=lambda: ColumnStatistics()

--- a/metaphor/postgresql/usage/config.py
+++ b/metaphor/postgresql/usage/config.py
@@ -1,9 +1,9 @@
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.dataclass import ConnectorConfig
-from metaphor.redshift.config import PostgreSQLRunConfig
+from metaphor.postgresql.config import BasePostgreSQLRunConfig
 
 
 @dataclass(config=ConnectorConfig)
-class PostgreSQLUsageRunConfig(PostgreSQLRunConfig):
+class PostgreSQLUsageRunConfig(BasePostgreSQLRunConfig):
     pass

--- a/metaphor/redshift/config.py
+++ b/metaphor/redshift/config.py
@@ -1,11 +1,11 @@
 from dataclasses import field
-from typing import List, Set
+from typing import List
 
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.tag_matcher import TagMatcher
-from metaphor.postgresql.config import BasePostgreSQLRunConfig, QueryLogConfig
+from metaphor.postgresql.config import BasePostgreSQLRunConfig
 
 
 @dataclass(config=ConnectorConfig)

--- a/metaphor/redshift/config.py
+++ b/metaphor/redshift/config.py
@@ -5,26 +5,12 @@ from pydantic.dataclasses import dataclass
 
 from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.tag_matcher import TagMatcher
-from metaphor.postgresql.config import PostgreSQLRunConfig
+from metaphor.postgresql.config import BasePostgreSQLRunConfig, QueryLogConfig
 
 
 @dataclass(config=ConnectorConfig)
-class RedshiftQueryLogConfig:
-    # Number of days back of query logs to fetch, if 0, don't fetch query logs
-    lookback_days: int = 1
-
-    # Query log filter to exclude certain usernames
-    excluded_usernames: Set[str] = field(default_factory=lambda: set())
-
-
-@dataclass(config=ConnectorConfig)
-class RedshiftRunConfig(PostgreSQLRunConfig):
+class RedshiftRunConfig(BasePostgreSQLRunConfig):
     port: int = 5439
 
     # How tags should be assigned to datasets
     tag_matchers: List[TagMatcher] = field(default_factory=lambda: [])
-
-    # configs for fetching query logs
-    query_log: RedshiftQueryLogConfig = field(
-        default_factory=lambda: RedshiftQueryLogConfig()
-    )  # type: ignore

--- a/metaphor/redshift/config.py
+++ b/metaphor/redshift/config.py
@@ -27,4 +27,4 @@ class RedshiftRunConfig(PostgreSQLRunConfig):
     # configs for fetching query logs
     query_log: RedshiftQueryLogConfig = field(
         default_factory=lambda: RedshiftQueryLogConfig()
-    )
+    ) # type: ignore

--- a/metaphor/redshift/config.py
+++ b/metaphor/redshift/config.py
@@ -27,4 +27,4 @@ class RedshiftRunConfig(PostgreSQLRunConfig):
     # configs for fetching query logs
     query_log: RedshiftQueryLogConfig = field(
         default_factory=lambda: RedshiftQueryLogConfig()
-    ) # type: ignore
+    )  # type: ignore

--- a/metaphor/redshift/extractor.py
+++ b/metaphor/redshift/extractor.py
@@ -14,7 +14,7 @@ from metaphor.common.tag_matcher import tag_datasets
 from metaphor.common.utils import md5_digest, start_of_day
 from metaphor.models.crawler_run_metadata import Platform
 from metaphor.models.metadata_change_event import DataPlatform, QueriedDataset, QueryLog
-from metaphor.postgresql.extractor import PostgreSQLExtractor
+from metaphor.postgresql.extractor import BasePostgreSQLExtractor
 from metaphor.redshift.access_event import AccessEvent
 from metaphor.redshift.config import RedshiftRunConfig
 from metaphor.redshift.utils import exclude_system_databases
@@ -22,7 +22,7 @@ from metaphor.redshift.utils import exclude_system_databases
 logger = get_logger()
 
 
-class RedshiftExtractor(PostgreSQLExtractor):
+class RedshiftExtractor(BasePostgreSQLExtractor):
     """Redshift metadata extractor"""
 
     _description = "Redshift metadata crawler"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.93"
+version = "0.14.94"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.91"
+version = "0.14.92"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/postgresql/config.yml
+++ b/tests/postgresql/config.yml
@@ -14,4 +14,16 @@ filter:
   excludes:
     db3:
 port: 1234
+query_log:
+  aws:
+    access_key_id: access_id
+    secret_access_key: secret
+    region_name: us-west-2
+    assume_role_arn: arn:aws:iam::12312837197:role/MetaphorRole
+  logs_group: /aws/rds/instance/postgres/postgresql
+  lookback_days: 1
+  excluded_usernames:
+    - foo
+    - bar
+
 output: {}

--- a/tests/postgresql/test_config.py
+++ b/tests/postgresql/test_config.py
@@ -1,5 +1,7 @@
+from metaphor.common.aws import AwsCredentials
 from metaphor.common.base_config import OutputConfig
 from metaphor.common.filter import DatasetFilter
+from metaphor.postgresql.config import PostgreSQLQueryLogConfig
 from metaphor.postgresql.extractor import PostgreSQLRunConfig
 
 
@@ -31,4 +33,15 @@ def test_yaml_config(test_root_dir):
         ),
         port=1234,
         output=OutputConfig(),
+        query_log=PostgreSQLQueryLogConfig(
+            lookback_days=1,
+            excluded_usernames={"foo", "bar"},
+            aws=AwsCredentials(
+                access_key_id="access_id",
+                secret_access_key="secret",
+                assume_role_arn="arn:aws:iam::12312837197:role/MetaphorRole",
+                region_name="us-west-2",
+            ),
+            logs_group="/aws/rds/instance/postgres/postgresql",
+        ),
     )

--- a/tests/postgresql/test_extractor.py
+++ b/tests/postgresql/test_extractor.py
@@ -1,4 +1,8 @@
-from metaphor.postgresql.extractor import PostgreSQLExtractor
+from datetime import datetime, timezone
+
+from metaphor.common.base_config import OutputConfig
+from metaphor.models.metadata_change_event import DataPlatform, QueriedDataset, QueryLog
+from metaphor.postgresql.extractor import PostgreSQLExtractor, PostgreSQLRunConfig
 
 
 def test_parse_max_length():
@@ -40,3 +44,69 @@ def test_parse_format_type():
     assert PostgreSQLExtractor._parse_format_type(
         "character varying", "character varying(10)"
     ) == (None, 10)
+
+
+def test_extract_duration():
+    assert PostgreSQLExtractor._extract_duration("1 ms") == 1.0
+    assert PostgreSQLExtractor._extract_duration("1 second") is None
+
+
+def dummy_config(**args):
+    return PostgreSQLRunConfig(
+        host="", database="", user="", password="", output=OutputConfig(), **args
+    )
+
+
+def test_process_cloud_watch_log():
+    extractor = PostgreSQLExtractor(dummy_config())
+
+    cache = {}
+    assert (
+        extractor._process_cloud_watch_log(
+            "2024-08-29 09:25:50 UTC:10.1.1.134(48507):metaphor@metaphor:[615]:LOG: duration: 0.858 ms",
+            cache,
+        )
+        is None
+    )
+    assert (
+        extractor._process_cloud_watch_log(
+            "2024-08-29 09:25:50 UTC:10.1.1.134(48507):metaphor@metaphor:[615]:LOG: statement: SELECT x, y from schema.table;",
+            cache,
+        )
+        is None
+    )
+    assert extractor._process_cloud_watch_log(
+        "2024-08-29 09:25:51 UTC:10.1.1.134(48507):metaphor@metaphor:[615]:LOG: duration: 55.66 ms",
+        cache,
+    ) == QueryLog(
+        id="POSTGRESQL:330833d44bea62c26a5d6dd206eecdf4",
+        account=None,
+        bytes_read=None,
+        bytes_written=None,
+        cost=None,
+        default_database="metaphor",
+        default_schema=None,
+        duration=55.66,
+        email=None,
+        metadata=None,
+        parsing=None,
+        platform=DataPlatform.POSTGRESQL,
+        query_id="330833d44bea62c26a5d6dd206eecdf4",
+        rows_read=None,
+        rows_written=None,
+        sources=[
+            QueriedDataset(
+                columns=None,
+                database="metaphor",
+                id="DATASET~F68D8D6F1F49DA4605F13F20FD3CA883",
+                schema="schema",
+                table="table",
+            )
+        ],
+        sql="SELECT x, y from schema.table;",
+        sql_hash="330833d44bea62c26a5d6dd206eecdf4",
+        start_time=datetime(2024, 8, 29, 9, 25, 50, tzinfo=timezone.utc),
+        targets=[],
+        type=None,
+        user_id="metaphor",
+    )

--- a/tests/postgresql/test_extractor.py
+++ b/tests/postgresql/test_extractor.py
@@ -1,5 +1,8 @@
 from datetime import datetime, timezone
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
+
+import pytest
+from freezegun import freeze_time
 
 from metaphor.common.base_config import OutputConfig
 from metaphor.models.metadata_change_event import DataPlatform, QueriedDataset, QueryLog
@@ -65,6 +68,40 @@ def dummy_config(**args):
     )
 
 
+gold = QueryLog(
+    id="POSTGRESQL:330833d44bea62c26a5d6dd206eecdf4",
+    account=None,
+    bytes_read=None,
+    bytes_written=None,
+    cost=None,
+    default_database="metaphor",
+    default_schema=None,
+    duration=55.66,
+    email=None,
+    metadata=None,
+    parsing=None,
+    platform=DataPlatform.POSTGRESQL,
+    query_id="330833d44bea62c26a5d6dd206eecdf4",
+    rows_read=None,
+    rows_written=None,
+    sources=[
+        QueriedDataset(
+            columns=None,
+            database="metaphor",
+            id="DATASET~F68D8D6F1F49DA4605F13F20FD3CA883",
+            schema="schema",
+            table="table",
+        )
+    ],
+    sql="SELECT x, y from schema.table;",
+    sql_hash="330833d44bea62c26a5d6dd206eecdf4",
+    start_time=datetime(2024, 8, 29, 9, 25, 50, tzinfo=timezone.utc),
+    targets=[],
+    type=None,
+    user_id="metaphor",
+)
+
+
 def test_process_cloud_watch_log():
     extractor = PostgreSQLExtractor(dummy_config())
 
@@ -87,40 +124,12 @@ def test_process_cloud_watch_log():
         )
         is None
     )
-    assert extractor._process_cloud_watch_log(
-        "2024-08-29 09:25:51 UTC:10.1.1.134(48507):metaphor@metaphor:[615]:LOG: duration: 55.66 ms",
-        cache,
-    ) == QueryLog(
-        id="POSTGRESQL:330833d44bea62c26a5d6dd206eecdf4",
-        account=None,
-        bytes_read=None,
-        bytes_written=None,
-        cost=None,
-        default_database="metaphor",
-        default_schema=None,
-        duration=55.66,
-        email=None,
-        metadata=None,
-        parsing=None,
-        platform=DataPlatform.POSTGRESQL,
-        query_id="330833d44bea62c26a5d6dd206eecdf4",
-        rows_read=None,
-        rows_written=None,
-        sources=[
-            QueriedDataset(
-                columns=None,
-                database="metaphor",
-                id="DATASET~F68D8D6F1F49DA4605F13F20FD3CA883",
-                schema="schema",
-                table="table",
-            )
-        ],
-        sql="SELECT x, y from schema.table;",
-        sql_hash="330833d44bea62c26a5d6dd206eecdf4",
-        start_time=datetime(2024, 8, 29, 9, 25, 50, tzinfo=timezone.utc),
-        targets=[],
-        type=None,
-        user_id="metaphor",
+    assert (
+        extractor._process_cloud_watch_log(
+            "2024-08-29 09:25:51 UTC:10.1.1.134(48507):metaphor@metaphor:[615]:LOG: duration: 55.66 ms",
+            cache,
+        )
+        == gold
     )
 
     # SQL don't have source and targets
@@ -172,12 +181,44 @@ def test_process_cloud_watch_log():
     )
 
 
+@freeze_time("2000-01-01")
 def test_collect_query_logs_from_cloud_watch():
     extractor = PostgreSQLExtractor(dummy_config())
 
     mocked_client = MagicMock()
-    mocked_client.filter_log_events.return_value = []
+    mocked_client.filter_log_events.side_effect = [
+        {"nextToken": "token", "events": [{"message": ""}]},
+        {
+            "events": [
+                {
+                    "message": "2024-08-29 09:25:50 UTC:10.1.1.134(48507):metaphor@metaphor:[615]:LOG: statement: SELECT x, y from schema.table;",
+                },
+                {
+                    "message": "2024-08-29 09:25:51 UTC:10.1.1.134(48507):metaphor@metaphor:[615]:LOG: duration: 55.66 ms",
+                },
+            ]
+        },
+    ]
 
-    extractor._collect_query_logs_from_cloud_watch(
+    iterator = extractor._collect_query_logs_from_cloud_watch(
         mocked_client, lookback_days=1, logs_group="123"
+    )
+    assert next(iterator) == gold
+
+    with pytest.raises(StopIteration):
+        next(iterator)
+    mocked_client.filter_log_events.assert_has_calls(
+        [
+            call(
+                logGroupName="123",
+                startTime=946598400000,
+                endTime=946684800000,
+            ),
+            call(
+                logGroupName="123",
+                startTime=946598400000,
+                endTime=946684800000,
+                nextToken="token",
+            ),
+        ]
     )

--- a/tests/postgresql/test_extractor.py
+++ b/tests/postgresql/test_extractor.py
@@ -68,6 +68,8 @@ def test_process_cloud_watch_log():
     extractor = PostgreSQLExtractor(dummy_config())
 
     cache = {}
+
+    # No previous log
     assert (
         extractor._process_cloud_watch_log(
             "2024-08-29 09:25:50 UTC:10.1.1.134(48507):metaphor@metaphor:[615]:LOG: duration: 0.858 ms",
@@ -76,6 +78,7 @@ def test_process_cloud_watch_log():
         is None
     )
 
+    # Valid Statement
     assert (
         extractor._process_cloud_watch_log(
             "2024-08-29 09:25:50 UTC:10.1.1.134(48507):metaphor@metaphor:[615]:LOG: statement: SELECT x, y from schema.table;",
@@ -119,6 +122,7 @@ def test_process_cloud_watch_log():
         user_id="metaphor",
     )
 
+    # SQL don't have source and targets
     assert (
         extractor._process_cloud_watch_log(
             "2024-08-29 09:25:50 UTC:10.1.1.134(48507):metaphor@metaphor:[615]:LOG: statement: CREATE USER abc PASSWORD 'asjdkasjd';",
@@ -134,6 +138,7 @@ def test_process_cloud_watch_log():
         is None
     )
 
+    # Skip queries in excluded_user
     assert (
         extractor._process_cloud_watch_log(
             "2024-08-29 09:25:50 UTC:10.1.1.134(48507):foo@metaphor:[615]:LOG: statement: SELECT x, y from schema.table;",
@@ -149,6 +154,7 @@ def test_process_cloud_watch_log():
         is None
     )
 
+    # Skip log that is not `statement` or `execute`
     assert (
         extractor._process_cloud_watch_log(
             "2024-08-29 09:25:50 UTC:10.1.1.134(48507):foo@metaphor:[615]:LOG: bind: SELECT x, y from schema.table;",

--- a/tests/postgresql/test_extractor.py
+++ b/tests/postgresql/test_extractor.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from unittest.mock import MagicMock
 
 from metaphor.common.base_config import OutputConfig
 from metaphor.models.metadata_change_event import DataPlatform, QueriedDataset, QueryLog
@@ -168,4 +169,15 @@ def test_process_cloud_watch_log():
             cache,
         )
         is None
+    )
+
+
+def test_collect_query_logs_from_cloud_watch():
+    extractor = PostgreSQLExtractor(dummy_config())
+
+    mocked_client = MagicMock()
+    mocked_client.filter_log_events.return_value = []
+
+    extractor._collect_query_logs_from_cloud_watch(
+        mocked_client, lookback_days=1, logs_group="123"
     )

--- a/tests/postgresql/test_log_parser.py
+++ b/tests/postgresql/test_log_parser.py
@@ -1,0 +1,5 @@
+from metaphor.postgresql.log_parser import parse_postgres_log
+
+
+def test_parse_postgres_log():
+    assert parse_postgres_log("2024-08-29 09:25:50 UTC:foo@metaphor:[615]:LOG") is None

--- a/tests/postgresql/usage/config.yml
+++ b/tests/postgresql/usage/config.yml
@@ -1,0 +1,17 @@
+---
+host: host
+database: database
+user: user
+password: password
+filter:
+  includes:
+    db1:
+      schema1:
+    db2:
+      schema2:
+        - table1
+        - table2
+  excludes:
+    db3:
+port: 1234
+output: {}

--- a/tests/postgresql/usage/test_config.py
+++ b/tests/postgresql/usage/test_config.py
@@ -1,0 +1,34 @@
+from metaphor.common.base_config import OutputConfig
+from metaphor.common.filter import DatasetFilter
+from metaphor.postgresql.usage.config import PostgreSQLUsageRunConfig
+
+
+def test_yaml_config(test_root_dir):
+    config = PostgreSQLUsageRunConfig.from_yaml_file(
+        f"{test_root_dir}/postgresql/usage/config.yml"
+    )
+
+    assert config == PostgreSQLUsageRunConfig(
+        host="host",
+        database="database",
+        user="user",
+        password="password",
+        filter=DatasetFilter(
+            includes={
+                "db1": {
+                    "schema1": None,
+                },
+                "db2": {
+                    "schema2": set(
+                        [
+                            "table1",
+                            "table2",
+                        ]
+                    )
+                },
+            },
+            excludes={"db3": None},
+        ),
+        port=1234,
+        output=OutputConfig(),
+    )

--- a/tests/redshift/config.yml
+++ b/tests/redshift/config.yml
@@ -14,4 +14,7 @@ filter:
   excludes:
     db3:
 port: 1234
+query_log:
+  lookback_days: 1
+  excluded_usernames: [metaphor]
 output: {}

--- a/tests/redshift/test_config.py
+++ b/tests/redshift/test_config.py
@@ -1,6 +1,6 @@
 from metaphor.common.base_config import OutputConfig
 from metaphor.common.filter import DatasetFilter
-from metaphor.redshift.config import RedshiftRunConfig
+from metaphor.redshift.config import QueryLogConfig, RedshiftRunConfig
 
 
 def test_yaml_config(test_root_dir):
@@ -28,5 +28,9 @@ def test_yaml_config(test_root_dir):
             excludes={"db3": None},
         ),
         port=1234,
+        query_log=QueryLogConfig(
+            lookback_days=1,
+            excluded_usernames={"metaphor"},
+        ),
         output=OutputConfig(),
     )

--- a/tests/redshift/test_config.py
+++ b/tests/redshift/test_config.py
@@ -1,6 +1,7 @@
 from metaphor.common.base_config import OutputConfig
 from metaphor.common.filter import DatasetFilter
-from metaphor.redshift.config import QueryLogConfig, RedshiftRunConfig
+from metaphor.postgresql.config import QueryLogConfig
+from metaphor.redshift.config import RedshiftRunConfig
 
 
 def test_yaml_config(test_root_dir):

--- a/tests/redshift/test_extractor.py
+++ b/tests/redshift/test_extractor.py
@@ -24,7 +24,7 @@ def dummy_config(**args):
 
 
 @patch(
-    "metaphor.postgresql.extractor.PostgreSQLExtractor._fetch_databases",
+    "metaphor.postgresql.extractor.BasePostgreSQLExtractor._fetch_databases",
     new_callable=AsyncMock,
 )
 @pytest.mark.asyncio
@@ -86,7 +86,7 @@ def test_collect_query_logs(test_root_dir: str) -> None:
     included_dbs = {ae.database for ae in access_events}
 
     with patch(
-        "metaphor.postgresql.extractor.PostgreSQLExtractor._connect_database"
+        "metaphor.postgresql.extractor.BasePostgreSQLExtractor._connect_database"
     ) as mock_connect_database, patch(
         "metaphor.redshift.access_event.AccessEvent.fetch_access_event"
     ) as mock_fetch_access_event:


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

PostgreSQL does not store the query history, or user action in the database but can be configured as logging to its log file. Therefore, we can parse the Postgres log for query log extraction

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

- Extract query history from CloudWatch

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

Test against an RDS instance.

<!--
  Describe how the change was tested end-to-end.
-->

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
