### PR TITLE
[sc-28469] Enable `process_query` for BQ, Postgres, Redshift and UC

### DIFF
--- a/metaphor/bigquery/README.md
+++ b/metaphor/bigquery/README.md
@@ -157,6 +157,10 @@ query_log:
   fetch_job_query_if_truncated: <boolean>
 ```
 
+##### Process Query Config
+
+See [Process Query](../common/docs/process_query.md) for more information on the optional `process_query_config` config.
+
 ### Notes
 
 Make sure to use BigQuery project ID when setting the `database` field in the filter configuration. For example:

--- a/metaphor/bigquery/config.py
+++ b/metaphor/bigquery/config.py
@@ -7,6 +7,7 @@ from pydantic.dataclasses import dataclass
 from metaphor.common.base_config import BaseConfig
 from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.filter import DatasetFilter
+from metaphor.common.sql.process_query.config import ProcessQueryConfig
 from metaphor.common.tag_matcher import TagMatcher
 from metaphor.common.utils import must_set_exactly_one
 
@@ -55,6 +56,11 @@ class BigQueryQueryLogConfig:
 
     # Fetch the full query SQL from job API if it's truncated in the audit metadata log
     fetch_job_query_if_truncated: bool = True
+
+    # Config to control query processing
+    process_query: ProcessQueryConfig = field(
+        default_factory=lambda: ProcessQueryConfig()
+    )
 
 
 @dataclass(config=ConnectorConfig)

--- a/metaphor/postgresql/README.md
+++ b/metaphor/postgresql/README.md
@@ -65,6 +65,10 @@ query_log:
 
 See [Filter Configurations](../common/docs/filter.md) for more information on the optional `filter` config.
 
+#### Process Query Config
+
+See [Process Query](../common/docs/process_query.md) for more information on the optional `process_query_config` config.
+
 #### Output Destination
 
 See [Output Config](../common/docs/output.md) for more information on the optional `output` config.

--- a/metaphor/postgresql/config.py
+++ b/metaphor/postgresql/config.py
@@ -7,6 +7,7 @@ from metaphor.common.aws import AwsCredentials
 from metaphor.common.base_config import BaseConfig
 from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.filter import DatasetFilter
+from metaphor.common.sql.process_query.config import ProcessQueryConfig
 
 
 @dataclass(config=ConnectorConfig)
@@ -16,6 +17,11 @@ class QueryLogConfig:
 
     # Query log filter to exclude certain usernames
     excluded_usernames: Set[str] = field(default_factory=lambda: set())
+
+    # Config to control query processing
+    process_query: ProcessQueryConfig = field(
+        default_factory=lambda: ProcessQueryConfig()
+    )
 
 
 @dataclass(config=ConnectorConfig)

--- a/metaphor/redshift/README.md
+++ b/metaphor/redshift/README.md
@@ -85,6 +85,10 @@ query_log:
     - <user_name2>
 ```
 
+##### Process Query Config
+
+See [Process Query](../common/docs/process_query.md) for more information on the optional `process_query_config` config.
+
 ## Testing
 
 Follow the [Installation](../../README.md) instructions to install `metaphor-connectors` in your environment (or virtualenv). Make sure to include either `all` or `redshift` extra.

--- a/metaphor/redshift/extractor.py
+++ b/metaphor/redshift/extractor.py
@@ -1,12 +1,13 @@
 import asyncio
 import datetime
-from typing import Collection, Iterator, List, Set
+from typing import Collection, Iterator, List, Optional, Set
 
 from metaphor.common.constants import BYTES_PER_MEGABYTES
 from metaphor.common.entity_id import dataset_normalized_name
 from metaphor.common.event_util import ENTITY_TYPES
 from metaphor.common.logger import get_logger
 from metaphor.common.models import to_dataset_statistics
+from metaphor.common.sql.process_query.process_query import process_query
 from metaphor.common.sql.table_level_lineage.table_level_lineage import (
     extract_table_level_lineage,
 )
@@ -173,21 +174,31 @@ class RedshiftExtractor(BasePostgreSQLExtractor):
         ):
             return
 
-        query_log = QueryLog(
-            id=f"{DataPlatform.REDSHIFT.name}:{access_event.query_id}",
-            query_id=str(access_event.query_id),
-            platform=DataPlatform.REDSHIFT,
-            start_time=access_event.start_time,
-            duration=float(
-                (access_event.end_time - access_event.start_time).total_seconds()
-            ),
-            user_id=access_event.usename,
-            rows_read=float(access_event.rows),
-            bytes_read=float(access_event.bytes),
-            sources=tll.sources,
-            targets=tll.targets,
-            sql=access_event.querytxt,
-            sql_hash=md5_digest(access_event.querytxt.encode("utf-8")),
-        )
+        sql: Optional[str] = access_event.querytxt
+        if self._query_log_config.process_query.should_process:
+            sql = process_query(
+                access_event.querytxt,
+                DataPlatform.REDSHIFT,
+                self._query_log_config.process_query,
+                str(access_event.query_id),
+            )
 
-        return query_log
+        if sql:
+            query_log = QueryLog(
+                id=f"{DataPlatform.REDSHIFT.name}:{access_event.query_id}",
+                query_id=str(access_event.query_id),
+                platform=DataPlatform.REDSHIFT,
+                start_time=access_event.start_time,
+                duration=float(
+                    (access_event.end_time - access_event.start_time).total_seconds()
+                ),
+                user_id=access_event.usename,
+                rows_read=float(access_event.rows),
+                bytes_read=float(access_event.bytes),
+                sources=tll.sources,
+                targets=tll.targets,
+                sql=access_event.querytxt,
+                sql_hash=md5_digest(sql.encode("utf-8")),
+            )
+
+            return query_log

--- a/metaphor/unity_catalog/README.md
+++ b/metaphor/unity_catalog/README.md
@@ -63,6 +63,10 @@ query_log:
   max_results: <count>
 ```
 
+##### Process Query Config
+
+See [Process Query](../common/docs/process_query.md) for more information on the optional `process_query_config` config.
+
 #### Warehouse ID
 
 Note: we encourage using cluster, this connector will deprecate the SQL warehouse support.

--- a/metaphor/unity_catalog/config.py
+++ b/metaphor/unity_catalog/config.py
@@ -6,6 +6,7 @@ from pydantic.dataclasses import dataclass
 from metaphor.common.base_config import BaseConfig
 from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.filter import DatasetFilter
+from metaphor.common.sql.process_query.config import ProcessQueryConfig
 
 
 @dataclass(config=ConnectorConfig)
@@ -18,6 +19,11 @@ class UnityCatalogQueryLogConfig:
 
     # Deprecated: Not used. Will be dropped in 0.15
     max_results: Optional[int] = 1000
+
+    # Config to control query processing
+    process_query: ProcessQueryConfig = field(
+        default_factory=lambda: ProcessQueryConfig()
+    )
 
 
 @dataclass(config=ConnectorConfig)

--- a/metaphor/unity_catalog/extractor.py
+++ b/metaphor/unity_catalog/extractor.py
@@ -491,6 +491,7 @@ class UnityCatalogExtractor(BaseExtractor):
             self._query_log_config.excluded_usernames,
             self._service_principals,
             self._datasets,
+            self._query_log_config.process_query,
         ):
             yield query_log
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.96"
+version = "0.14.97"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/unity_catalog/test_utils.py
+++ b/tests/unity_catalog/test_utils.py
@@ -8,6 +8,7 @@ from pytest_snapshot.plugin import Snapshot
 
 from metaphor.common.entity_id import dataset_normalized_name, to_dataset_entity_id
 from metaphor.common.event_util import EventUtil
+from metaphor.common.sql.process_query.config import ProcessQueryConfig
 from metaphor.models.metadata_change_event import (
     DataPlatform,
     Dataset,
@@ -113,6 +114,7 @@ GROUP BY
                     ),
                 ),
             },
+            ProcessQueryConfig(),
         )
     )
     for log in logs:


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

We added SQL preprocessor, but currently only Snowflake crawler makes use of it. The other data platform that we get query history from should also have the ability to preprocess their queries.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Add `process_query` function call in the following crawler's `collect_query_logs` method:
- BigQuery
- Redshift
- Postgresql
- Unity Catalog

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

- Modified UC unit test
- Run all four crawlers with stage configuration with `redact_literals.enabled` set to True, all run without error and the literals are all redacted.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
