### PR TITLE
[sc-27944] Do not populate system tags when there is no tag for entity

### DIFF
--- a/metaphor/looker/lookml_parser.py
+++ b/metaphor/looker/lookml_parser.py
@@ -351,7 +351,7 @@ def _build_looker_explore(
         looker_explore=explore,
         structure=_get_model_asset_structure(model, name, explore_view_folder_name),
         entity_upstream=EntityUpstream(source_entities=source_entities),
-        system_tags=SystemTags(tags=tags),
+        system_tags=SystemTags(tags=tags) if tags else None,
     )
 
 

--- a/metaphor/tableau/extractor.py
+++ b/metaphor/tableau/extractor.py
@@ -408,12 +408,14 @@ class TableauExtractor(BaseExtractor):
         source_virtual_views: List[str] = []
         published_datasources: List[str] = []
 
-        system_tags = SystemTags(tags=[])
+        system_tags: Optional[SystemTags] = None
         if workbook.tags:
-            system_tags.tags = [
-                SystemTag(value=tag, system_tag_source=SystemTagSource.TABLEAU)
-                for tag in sorted(tag.name for tag in workbook.tags)
-            ]
+            system_tags = SystemTags(
+                tags=[
+                    SystemTag(value=tag, system_tag_source=SystemTagSource.TABLEAU)
+                    for tag in sorted(tag.name for tag in workbook.tags)
+                ]
+            )
 
         for published_source in workbook.upstreamDatasources:
             virtual_view_id = str(

--- a/metaphor/unity_catalog/extractor.py
+++ b/metaphor/unity_catalog/extractor.py
@@ -397,9 +397,6 @@ class UnityCatalogExtractor(BaseExtractor):
                     )
                 ]
             )
-
-        dataset.system_tags = SystemTags(tags=[])
-
         self._datasets[normalized_name] = dataset
 
         return dataset
@@ -560,8 +557,13 @@ class UnityCatalogExtractor(BaseExtractor):
                     )
                     dataset = self._datasets.get(normalized_dataset_name)
                     if dataset is not None:
-                        assert dataset.system_tags
-                        dataset.system_tags.tags = (
+
+                        if dataset.system_tags is None:
+                            dataset.system_tags = SystemTags()
+                        if dataset.system_tags.tags is None:
+                            dataset.system_tags.tags = []
+
+                        dataset.system_tags.tags.extend(
                             catalog_system_tags[catalog][0]
                             + catalog_system_tags[catalog][1][schema.name]
                         )
@@ -589,7 +591,10 @@ class UnityCatalogExtractor(BaseExtractor):
                     logger.warning(f"Cannot find {normalized_dataset_name} dataset")
                     continue
 
-                assert dataset.system_tags and dataset.system_tags.tags is not None
+                if dataset.system_tags is None:
+                    dataset.system_tags = SystemTags()
+                if dataset.system_tags.tags is None:
+                    dataset.system_tags.tags = []
 
                 if tag_value:
                     tag = SystemTag(
@@ -790,8 +795,6 @@ class UnityCatalogExtractor(BaseExtractor):
             ),
         )
         dataset.entity_upstream = EntityUpstream(source_entities=[])
-
-        dataset.system_tags = SystemTags(tags=[])
 
         self._datasets[full_name] = dataset
 

--- a/metaphor/unity_catalog/extractor.py
+++ b/metaphor/unity_catalog/extractor.py
@@ -551,22 +551,24 @@ class UnityCatalogExtractor(BaseExtractor):
     ) -> None:
         for schema in self._api.schemas.list(catalog):
             if schema.name:
-                for table in self._api.tables.list(catalog, schema.name):
-                    normalized_dataset_name = dataset_normalized_name(
-                        catalog, schema.name, table.name
-                    )
-                    dataset = self._datasets.get(normalized_dataset_name)
-                    if dataset is not None:
-
-                        if dataset.system_tags is None:
-                            dataset.system_tags = SystemTags()
-                        if dataset.system_tags.tags is None:
-                            dataset.system_tags.tags = []
-
-                        dataset.system_tags.tags.extend(
-                            catalog_system_tags[catalog][0]
-                            + catalog_system_tags[catalog][1][schema.name]
+                schema_tags = (
+                    catalog_system_tags[catalog][0]
+                    + catalog_system_tags[catalog][1][schema.name]
+                )
+                if schema_tags:
+                    for table in self._api.tables.list(catalog, schema.name):
+                        normalized_dataset_name = dataset_normalized_name(
+                            catalog, schema.name, table.name
                         )
+                        dataset = self._datasets.get(normalized_dataset_name)
+                        if dataset is not None:
+
+                            if dataset.system_tags is None:
+                                dataset.system_tags = SystemTags()
+                            if dataset.system_tags.tags is None:
+                                dataset.system_tags.tags = []
+
+                            dataset.system_tags.tags.extend(schema_tags)
 
     def _extract_object_tags(
         self, catalog, columns: List[str], tag_schema_name: str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.100"
+version = "0.14.101"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/looker/test_lookml_parser.py
+++ b/tests/looker/test_lookml_parser.py
@@ -250,7 +250,6 @@ def test_join(test_root_dir):
                 entity_upstream=EntityUpstream(
                     source_entities=[str(virtual_view_id1), str(virtual_view_id2)]
                 ),
-                system_tags=SystemTags(tags=[]),
             ),
         ],
     )
@@ -323,7 +322,6 @@ def test_explore_in_view(test_root_dir):
                     name="explore1",
                 ),
                 entity_upstream=EntityUpstream(source_entities=[str(virtual_view_id)]),
-                system_tags=SystemTags(tags=[]),
             ),
         ],
     )
@@ -421,7 +419,6 @@ def test_derived_table(test_root_dir):
                 name="explore1",
             ),
             entity_upstream=EntityUpstream(source_entities=[str(virtual_view_id1)]),
-            system_tags=SystemTags(tags=[]),
         ),
         VirtualView(
             logical_id=VirtualViewLogicalID(
@@ -436,7 +433,6 @@ def test_derived_table(test_root_dir):
                 name="explore2",
             ),
             entity_upstream=EntityUpstream(source_entities=[str(virtual_view_id2)]),
-            system_tags=SystemTags(tags=[]),
         ),
         VirtualView(
             logical_id=VirtualViewLogicalID(
@@ -451,7 +447,6 @@ def test_derived_table(test_root_dir):
                 name="explore3",
             ),
             entity_upstream=EntityUpstream(source_entities=[str(virtual_view_id3)]),
-            system_tags=SystemTags(tags=[]),
         ),
     ]
 
@@ -511,7 +506,6 @@ def test_sql_table_name(test_root_dir):
                 name="explore1",
             ),
             entity_upstream=EntityUpstream(source_entities=[str(virtual_view_id1)]),
-            system_tags=SystemTags(tags=[]),
         ),
     ]
 
@@ -687,7 +681,6 @@ def test_complex_includes(test_root_dir):
                 name="explore1",
             ),
             entity_upstream=EntityUpstream(source_entities=[str(virtual_view_id1)]),
-            system_tags=SystemTags(tags=[]),
         ),
     ]
 
@@ -838,7 +831,6 @@ def test_view_extension(test_root_dir):
                 base_view=str(virtual_view_id1),
             ),
             entity_upstream=EntityUpstream(source_entities=[str(virtual_view_id1)]),
-            system_tags=SystemTags(tags=[]),
         ),
     ]
 
@@ -954,7 +946,6 @@ def test_explore_extension(test_root_dir):
                 name="explore1",
             ),
             entity_upstream=EntityUpstream(source_entities=[str(virtual_view1)]),
-            system_tags=SystemTags(tags=[]),
         ),
         VirtualView(
             logical_id=VirtualViewLogicalID(
@@ -969,7 +960,6 @@ def test_explore_extension(test_root_dir):
                 name="explore2",
             ),
             entity_upstream=EntityUpstream(source_entities=[str(virtual_view2)]),
-            system_tags=SystemTags(tags=[]),
         ),
         VirtualView(
             logical_id=VirtualViewLogicalID(
@@ -984,7 +974,6 @@ def test_explore_extension(test_root_dir):
                 name="explore3",
             ),
             entity_upstream=EntityUpstream(source_entities=[str(virtual_view1)]),
-            system_tags=SystemTags(tags=[]),
         ),
         VirtualView(
             logical_id=VirtualViewLogicalID(
@@ -999,7 +988,6 @@ def test_explore_extension(test_root_dir):
                 name="explore4",
             ),
             entity_upstream=EntityUpstream(source_entities=[str(virtual_view3)]),
-            system_tags=SystemTags(tags=[]),
         ),
         VirtualView(
             logical_id=VirtualViewLogicalID(
@@ -1014,7 +1002,6 @@ def test_explore_extension(test_root_dir):
                 name="base_explore2",
             ),
             entity_upstream=EntityUpstream(source_entities=[str(virtual_view2)]),
-            system_tags=SystemTags(tags=[]),
         ),
         VirtualView(
             logical_id=VirtualViewLogicalID(
@@ -1029,6 +1016,5 @@ def test_explore_extension(test_root_dir):
                 name="view3",
             ),
             entity_upstream=EntityUpstream(source_entities=[str(virtual_view3)]),
-            system_tags=SystemTags(tags=[]),
         ),
     ]

--- a/tests/unity_catalog/expected.json
+++ b/tests/unity_catalog/expected.json
@@ -379,9 +379,6 @@
         }
       ]
     },
-    "systemTags": {
-      "tags": []
-    },
     "unityCatalog": {
       "datasetType": "UNITY_CATALOG_TABLE",
       "tableInfo": {

--- a/tests/unity_catalog/snapshots/test_extractor/test_init_dataset/external_shallow_clone.json
+++ b/tests/unity_catalog/snapshots/test_extractor/test_init_dataset/external_shallow_clone.json
@@ -18,9 +18,6 @@
     "schema": "schema",
     "table": "table"
   },
-  "systemTags": {
-    "tags": []
-  },
   "unityCatalog": {
     "datasetType": "UNITY_CATALOG_TABLE",
     "tableInfo": {

--- a/tests/unity_catalog/snapshots/test_extractor/test_init_dataset/shallow_clone.json
+++ b/tests/unity_catalog/snapshots/test_extractor/test_init_dataset/shallow_clone.json
@@ -18,9 +18,6 @@
     "schema": "schema",
     "table": "table"
   },
-  "systemTags": {
-    "tags": []
-  },
   "unityCatalog": {
     "datasetType": "UNITY_CATALOG_TABLE",
     "tableInfo": {

--- a/tests/unity_catalog/snapshots/test_extractor/test_init_dataset/table.json
+++ b/tests/unity_catalog/snapshots/test_extractor/test_init_dataset/table.json
@@ -36,9 +36,6 @@
       }
     ]
   },
-  "systemTags": {
-    "tags": []
-  },
   "unityCatalog": {
     "datasetType": "UNITY_CATALOG_TABLE",
     "tableInfo": {


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Having `systemTags.tags` as empty array in a crawler will make Metaphor ingestion overwrite the existing system tags found by other crawlers.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

If no system tags exist for an entity, do not populate its `systemTags` field.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Modified unit test.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
