### PR TITLE
[sc-27944] Do not populate dataset in Tableau crawler

### DIFF
--- a/metaphor/snowflake/extractor.py
+++ b/metaphor/snowflake/extractor.py
@@ -902,6 +902,8 @@ class SnowflakeExtractor(BaseExtractor):
             database=database, schema=schema, table=table
         )
 
+        dataset.system_tags = SystemTags(tags=[])
+
         return dataset
 
     @staticmethod

--- a/metaphor/snowflake/utils.py
+++ b/metaphor/snowflake/utils.py
@@ -16,7 +16,6 @@ from metaphor.models.metadata_change_event import (
     SnowflakeStreamSourceType,
     SnowflakeStreamType,
     SystemTag,
-    SystemTags,
 )
 
 logger = logging.getLogger(__name__)
@@ -240,13 +239,11 @@ def _update_field_system_tag(field: SchemaField, system_tag: SystemTag) -> None:
 
 
 def append_dataset_system_tag(dataset: Dataset, system_tag: SystemTag) -> None:
-    assert dataset.schema is not None
-
-    if dataset.system_tags is None:
-        dataset.system_tags = SystemTags()
-    if dataset.system_tags.tags is None:
-        dataset.system_tags.tags = []
-
+    assert (
+        dataset.schema is not None
+        and dataset.system_tags
+        and dataset.system_tags.tags is not None
+    )
     # Always override exisiting tag, since we process database tags first, then schema tags and
     # then finally table tags
     other_tags = [t for t in dataset.system_tags.tags if t.key != system_tag.key]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.100"
+version = "0.14.101"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/snowflake/test_extractor.py
+++ b/tests/snowflake/test_extractor.py
@@ -434,7 +434,7 @@ def test_fetch_hierarchy_system_tags(mock_connect: MagicMock):
 
     extractor._fetch_tags(mock_cursor)
 
-    assert dataset.system_tags is None
+    assert dataset.system_tags and dataset.system_tags.tags is not None
     assert extractor._hierarchies.get(dataset_normalized_name(table_name)) is not None
     db_hierarchy = extractor._hierarchies[dataset_normalized_name(table_name)]
     assert db_hierarchy.logical_id == HierarchyLogicalID(

--- a/tests/tableau/expected.json
+++ b/tests/tableau/expected.json
@@ -170,48 +170,5 @@
       ],
       "url": "https://10ax.online.tableau.com/#/site/abc/workbooks/123"
     }
-  },
-  {
-    "logicalId": {
-      "name": "db.schema.table",
-      "platform": "BIGQUERY"
-    }
-  },
-  {
-    "logicalId": {
-      "account": "snow",
-      "name": "dev_db.london.cycle",
-      "platform": "SNOWFLAKE"
-    },
-    "systemTags": {
-      "tags": [
-        {
-          "systemTagSource": "TABLEAU",
-          "value": "bar"
-        },
-        {
-          "systemTagSource": "TABLEAU",
-          "value": "foo"
-        }
-      ]
-    }
-  },
-  {
-    "logicalId": {
-      "name": "acme.berlin_bicycles.cycle_hire",
-      "platform": "REDSHIFT"
-    },
-    "systemTags": {
-      "tags": [
-        {
-          "systemTagSource": "TABLEAU",
-          "value": "bar"
-        },
-        {
-          "systemTagSource": "TABLEAU",
-          "value": "foo"
-        }
-      ]
-    }
   }
 ]

--- a/tests/tableau/test_extractor.py
+++ b/tests/tableau/test_extractor.py
@@ -157,7 +157,6 @@ def test_parse_database_table():
                 database=None,
                 schema=None,
             ),
-            system_tags=None,
         )
         is None
     )
@@ -171,7 +170,6 @@ def test_parse_database_table():
                 database=Database(name="db", connectionType="invalid_type"),
                 schema=None,
             ),
-            system_tags=None,
         )
         is None
     )
@@ -185,7 +183,6 @@ def test_parse_database_table():
             database=Database(name="db", connectionType="redshift"),
             schema="foo",
         ),
-        system_tags=None,
     ) == to_dataset_entity_id("db.schema.table", DataPlatform.REDSHIFT)
 
     # Full back to two-segment "name"
@@ -197,7 +194,6 @@ def test_parse_database_table():
             database=Database(name="db", connectionType="redshift"),
             schema="foo",
         ),
-        system_tags=None,
     ) == to_dataset_entity_id("db.schema.table", DataPlatform.REDSHIFT)
 
     # Test BigQuery project name => ID mapping
@@ -218,7 +214,6 @@ def test_parse_database_table():
             database=Database(name="bq_name", connectionType="bigquery"),
             schema="foo",
         ),
-        system_tags=None,
     ) == to_dataset_entity_id("bq_id.schema.table", DataPlatform.BIGQUERY)
 
 


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Tableau crawler populated the datasets only to set their system tags, but these system tags will conflict with existing dataset tags, and we don't want that.

This also reverts #968 , since we want the empty array to be there if no system tag is found for an entity.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Reverted #968 
- Removed `_init_dataset` logic in Tableau crawler.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

- Crawler run locally.
- Modified unit test.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
