### PR TITLE
[sc-28750] Set `ignore_command_statement` default to `False`

### DIFF
--- a/metaphor/common/docs/process_query.md
+++ b/metaphor/common/docs/process_query.md
@@ -11,6 +11,8 @@ process_query:
 
   ignore_insert_values_into: <true | false>  # Ignore `INSERT INTO ... VALUES` expressions. These expressions don't have any lineage information, and are often very large in size. Default is `false`.
 
+  ignore_command_statement: <true | false>  # Ignore SQL statements that are parsed as COMMANDs. This is for platform specific SQL commands such as `CREATE USER`. Default is `false`.
+
   skip_unparsable_queries: <true | false>  # If this is set to `true`, when Sqlglot fails to parse a query we skip it from the collected MCE. Default is `false`, meaning we pass through any query we are unable to parse.
 ```
 
@@ -18,3 +20,4 @@ If any of the following boolean values is set to true, crawler will process the 
 
 - `redact_literals.enabled`
 - `ignore_insert_values_into`
+- `ignore_command_statement`

--- a/metaphor/common/sql/process_query/config.py
+++ b/metaphor/common/sql/process_query/config.py
@@ -65,7 +65,7 @@ class ProcessQueryConfig:
     If this is set to `True`, when Sqlglot fails to parse a query we skip it from the collected MCE.
     """
 
-    ignore_command_statement: bool = True
+    ignore_command_statement: bool = False
     """
     Skip commands that interact with databases, such as: create user
     """

--- a/metaphor/postgresql/config.py
+++ b/metaphor/postgresql/config.py
@@ -20,7 +20,9 @@ class QueryLogConfig:
 
     # Config to control query processing
     process_query: ProcessQueryConfig = field(
-        default_factory=lambda: ProcessQueryConfig()
+        default_factory=lambda: ProcessQueryConfig(
+            ignore_command_statement=True
+        )  # Ignore COMMAND statements by default
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.105"
+version = "0.14.106"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/common/sql/process_query/test_config.py
+++ b/tests/common/sql/process_query/test_config.py
@@ -10,10 +10,10 @@ def test_config():
     assert config.should_process
 
     config = ProcessQueryConfig()
-    assert config.should_process
-
-    config = ProcessQueryConfig(ignore_command_statement=False)
     assert not config.should_process
+
+    config = ProcessQueryConfig(ignore_command_statement=True)
+    assert config.should_process
 
     config = ProcessQueryConfig(
         redact_literals=RedactPIILiteralsConfig(where_clauses=True),

--- a/tests/common/sql/process_query/test_process_query.py
+++ b/tests/common/sql/process_query/test_process_query.py
@@ -16,9 +16,10 @@ config = ProcessQueryConfig(
         enabled=True,
     ),
     ignore_insert_values_into=True,
+    ignore_command_statement=True,
 )
 
-pre_preprocess_only = ProcessQueryConfig()
+pre_preprocess_only = ProcessQueryConfig(ignore_command_statement=True)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

`ignore_command_statement` was defaulted to True, which made all crawlers that parses SQL queries in all environments started processing queries.

Instead of doing it by default, our users should explicitly opt-in to query processing.

The actual SQL query that could not be parsed by sqlglot is tracked in a [separate ticket](https://app.shortcut.com/metaphor-data/story/28750/metaphor-crawler-big-query-integrations-error)

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Set `ignore_command_statement` default to `False`
- Modified unit test
- Updated readme

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Modified unit test.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
