### PR TITLE
[sc-28901] Validate query logs as they're parsed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.107"
+version = "0.14.108"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.106"
+version = "0.14.107"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

We should validate the query logs as they're parsed, otherwise bugs are harder to find when they get to the lineage parser.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Validate the parsed query logs before writing them to file.

Tested this against our own Snowflake instance (13,589 queries)
- No validation: ﻿36 secs
<img width="832" alt="截圖 2024-09-23 中午12 53 10" src="https://github.com/user-attachments/assets/d5bd126b-20da-494a-8ca2-70e389fbb83f">

- Validated: 1 min 37 secs
<img width="829" alt="截圖 2024-09-23 中午12 51 24" src="https://github.com/user-attachments/assets/ffd7ef9c-c78f-4b70-8087-cd085f26ab2b">


### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Tested against
- BigQuery
- Snowflake (see above)
- Unity Catalog

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
