### PR TITLE
[sc-28944] Provide config to link user name to email

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           poetry run isort --check .
           poetry run mypy . --explicit-package-bases
           poetry run bandit -r . -c pyproject.toml
-2
+
       - name: Test
         run: |
           poetry run coverage run -m pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           poetry run isort --check .
           poetry run mypy . --explicit-package-bases
           poetry run bandit -r . -c pyproject.toml
-
+2
       - name: Test
         run: |
           poetry run coverage run -m pytest

--- a/metaphor/kafka/config.py
+++ b/metaphor/kafka/config.py
@@ -141,7 +141,7 @@ class KafkaConfig(BaseConfig):
     """
 
     bootstrap_servers: List[KafkaBootstrapServer] = dataclass_field(
-        default_factory=lambda: []
+        default_factory=list
     )
     """
     The Kafka bootstrap servers / brokers. Cannot be empty.

--- a/metaphor/postgresql/README.md
+++ b/metaphor/postgresql/README.md
@@ -61,6 +61,11 @@ query_log:
   excluded_usernames:
     - <user_name1>
     - <user_name2>
+
+  # (Optional) A dict from user name to email. This is for Metaphor to recognize each query's issuer.
+  username_to_email:
+    <user1>: <user1 email>
+    <user2>: <user2 email>
 ```
 
 See [Filter Configurations](../common/docs/filter.md) for more information on the optional `filter` config.

--- a/metaphor/postgresql/config.py
+++ b/metaphor/postgresql/config.py
@@ -1,6 +1,7 @@
 from dataclasses import field
 from typing import Dict, Optional, Set
 
+from pydantic import field_validator
 from pydantic.dataclasses import dataclass
 
 from metaphor.common.aws import AwsCredentials
@@ -28,6 +29,13 @@ class QueryLogConfig:
     # Config to link user name to email so that Metaphor can display each query's issuer.
     username_to_email: Dict[str, str] = field(default_factory=dict)
 
+    @field_validator("username_to_email")
+    def _normalize_emails(cls, username_to_email: Dict[str, str]):
+        return {
+            k: v.lower()
+            for k, v
+            in username_to_email.items()
+        }
 
 @dataclass(config=ConnectorConfig)
 class BasePostgreSQLRunConfig(BaseConfig):

--- a/metaphor/postgresql/config.py
+++ b/metaphor/postgresql/config.py
@@ -1,5 +1,5 @@
 from dataclasses import field
-from typing import Optional, Set
+from typing import Dict, Optional, Set
 
 from pydantic.dataclasses import dataclass
 
@@ -16,7 +16,7 @@ class QueryLogConfig:
     lookback_days: int = 1
 
     # Query log filter to exclude certain usernames
-    excluded_usernames: Set[str] = field(default_factory=lambda: set())
+    excluded_usernames: Set[str] = field(default_factory=set)
 
     # Config to control query processing
     process_query: ProcessQueryConfig = field(
@@ -24,6 +24,9 @@ class QueryLogConfig:
             ignore_command_statement=True
         )  # Ignore COMMAND statements by default
     )
+
+    # Config to link user name to email so that Metaphor can display each query's issuer.
+    username_to_email: Dict[str, str] = field(default_factory=dict)
 
 
 @dataclass(config=ConnectorConfig)

--- a/metaphor/postgresql/config.py
+++ b/metaphor/postgresql/config.py
@@ -37,6 +37,7 @@ class QueryLogConfig:
             in username_to_email.items()
         }
 
+
 @dataclass(config=ConnectorConfig)
 class BasePostgreSQLRunConfig(BaseConfig):
     host: str

--- a/metaphor/postgresql/config.py
+++ b/metaphor/postgresql/config.py
@@ -31,11 +31,7 @@ class QueryLogConfig:
 
     @field_validator("username_to_email")
     def _normalize_emails(cls, username_to_email: Dict[str, str]):
-        return {
-            k: v.lower()
-            for k, v
-            in username_to_email.items()
-        }
+        return {k: v.lower() for k, v in username_to_email.items()}
 
 
 @dataclass(config=ConnectorConfig)

--- a/metaphor/postgresql/extractor.py
+++ b/metaphor/postgresql/extractor.py
@@ -498,12 +498,15 @@ class PostgreSQLExtractor(BasePostgreSQLExtractor):
 
         if sql:
             sql_hash = md5_digest(sql.encode("utf-8"))
+            user_id = parsed.user
+            email = self._query_log_config.username_to_email.get(user_id)
             return QueryLog(
                 id=f"{DataPlatform.POSTGRESQL.name}:{sql_hash}",
                 query_id=sql_hash,
                 platform=DataPlatform.POSTGRESQL,
                 default_database=parsed.database,
-                user_id=parsed.user,
+                user_id=user_id,
+                email=email,
                 sql=sql,
                 sql_hash=sql_hash,
                 duration=duration,

--- a/metaphor/redshift/README.md
+++ b/metaphor/redshift/README.md
@@ -83,6 +83,11 @@ query_log:
   excluded_usernames:
     - <user_name1>
     - <user_name2>
+
+  # (Optional) A dict from user name to email. This is for Metaphor to recognize each query's issuer.
+  username_to_email:
+    <user1>: <user1 email>
+    <user2>: <user2 email>
 ```
 
 ##### Process Query Config

--- a/metaphor/redshift/extractor.py
+++ b/metaphor/redshift/extractor.py
@@ -184,6 +184,8 @@ class RedshiftExtractor(BasePostgreSQLExtractor):
             )
 
         if sql:
+            user_id = access_event.usename
+            email = self._query_log_config.username_to_email.get(user_id)
             query_log = QueryLog(
                 id=f"{DataPlatform.REDSHIFT.name}:{access_event.query_id}",
                 query_id=str(access_event.query_id),
@@ -192,7 +194,8 @@ class RedshiftExtractor(BasePostgreSQLExtractor):
                 duration=float(
                     (access_event.end_time - access_event.start_time).total_seconds()
                 ),
-                user_id=access_event.usename,
+                user_id=user_id,
+                email=email,
                 rows_read=float(access_event.rows),
                 bytes_read=float(access_event.bytes),
                 sources=tll.sources,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.107"
+version = "0.14.108"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.108"
+version = "0.14.109"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/postgresql/test_extractor.py
+++ b/tests/postgresql/test_extractor.py
@@ -64,7 +64,10 @@ def dummy_config(**args):
         password="",
         output=OutputConfig(),
         **args,
-        query_log=PostgreSQLQueryLogConfig(excluded_usernames={"foo"}),
+        query_log=PostgreSQLQueryLogConfig(
+            excluded_usernames={"foo"},
+            username_to_email={"metaphor": "admin@metaphor.io"},
+        ),
     )
 
 
@@ -77,7 +80,7 @@ gold = QueryLog(
     default_database="metaphor",
     default_schema=None,
     duration=55.66,
-    email=None,
+    email="admin@metaphor.io",
     metadata=None,
     parsing=None,
     platform=DataPlatform.POSTGRESQL,
@@ -270,7 +273,7 @@ def test_alter_rename():
         default_database="metaphor",
         default_schema=None,
         duration=55.66,
-        email=None,
+        email="admin@metaphor.io",
         metadata=None,
         parsing=None,
         platform=DataPlatform.POSTGRESQL,

--- a/tests/redshift/query_logs.json
+++ b/tests/redshift/query_logs.json
@@ -6,6 +6,7 @@
           "_id": "REDSHIFT:7086",
           "bytesRead": 6500.0,
           "duration": -338161298.308308,
+          "email": "user1@metaphor.io",
           "platform": "REDSHIFT",
           "queryId": "7086",
           "rowsRead": 7155.0,
@@ -17,16 +18,17 @@
               "table": "table1"
             }
           ],
-          "targets": [],
           "sql": "select * from schema1.table1",
           "sqlHash": "fbbd533367fe766d71a48425c5c48654",
           "startTime": "2010-06-26T10:07:18.014673",
-          "userId": "aZUytYDMFTryuKyWtbEM"
+          "targets": [],
+          "userId": "user1"
         },
         {
           "_id": "REDSHIFT:9910",
           "bytesRead": 176.0,
           "duration": -217012182.227927,
+          "email": "user2@metaphor.io",
           "platform": "REDSHIFT",
           "queryId": "9910",
           "rowsRead": 4617.0,
@@ -38,11 +40,11 @@
               "table": "table2"
             }
           ],
-          "targets": [],
           "sql": "select * from schema2.table2",
           "sqlHash": "9f98db863e022a1b0c8b0895c1d4dec1",
           "startTime": "2003-10-01T10:15:51.904151",
-          "userId": "IevfvBUzEVUDrTbaIWKY"
+          "targets": [],
+          "userId": "user2"
         }
       ]
     }

--- a/tests/redshift/test_extractor.py
+++ b/tests/redshift/test_extractor.py
@@ -97,7 +97,7 @@ def test_collect_query_logs(test_root_dir: str) -> None:
         config.query_log = QueryLogConfig(
             username_to_email={
                 "user1": "user1@metaphor.io",
-                "user2": "user2@metaphor.io",
+                "user2": "USER2@METAPHOR.IO",
             }
         )
         extractor = RedshiftExtractor(config)


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

It's not possible to get the correspondence between user names and emails from Redshift or Postgres, we need user to provide this as a config value.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Add config field `username_to_email` in query log conifgs.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

- Modified unit tests.
- Ran crawler locally.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
