### PR TITLE
Support Postgres log extraction with log_duration disabled

### DIFF
--- a/metaphor/common/aws.py
+++ b/metaphor/common/aws.py
@@ -58,7 +58,10 @@ class AwsCredentials:
 
 
 def iterate_logs_from_cloud_watch(
-    client: client, lookback_days: int, logs_group: str
+    client: client,
+    lookback_days: int,
+    logs_group: str,
+    filter_pattern: Optional[str] = None,
 ) -> Iterator[str]:
 
     logger.info(f"Collecting query log from cloud watch for {lookback_days} days")
@@ -79,6 +82,8 @@ def iterate_logs_from_cloud_watch(
         }
         if next_token:
             params["nextToken"] = next_token
+        if filter_pattern:
+            params["filterPattern"] = filter_pattern
         response = client.filter_log_events(**params)
 
         next_token = response["nextToken"] if "nextToken" in response else None

--- a/metaphor/common/sql/process_query/process_query.py
+++ b/metaphor/common/sql/process_query/process_query.py
@@ -22,6 +22,15 @@ def _is_insert_values_into(expression: Expression) -> bool:
     )
 
 
+ALLOW_EXPRESSION_TYPES = (
+    exp.Alter,
+    exp.DDL,
+    exp.DML,
+    exp.Merge,
+    exp.Query,
+)
+
+
 def process_query(
     sql: str,
     data_platform: DataPlatform,
@@ -78,12 +87,7 @@ def process_query(
     if config.ignore_command_statement and isinstance(expression, exp.Command):
         return None
 
-    if (
-        isinstance(expression, exp.Show)
-        or isinstance(expression, exp.Set)
-        or isinstance(expression, exp.Rollback)
-        or isinstance(expression, exp.Commit)
-    ):
+    if not isinstance(expression, ALLOW_EXPRESSION_TYPES):
         return None
 
     if not config.redact_literals.enabled:

--- a/metaphor/common/sql/process_query/process_query.py
+++ b/metaphor/common/sql/process_query/process_query.py
@@ -82,6 +82,7 @@ def process_query(
         isinstance(expression, exp.Show)
         or isinstance(expression, exp.Set)
         or isinstance(expression, exp.Rollback)
+        or isinstance(expression, exp.Commit)
     ):
         return None
 

--- a/metaphor/postgresql/README.md
+++ b/metaphor/postgresql/README.md
@@ -56,6 +56,12 @@ query_log:
 
   # (Optional) Number of days of query logs to fetch. Default to 1. If 0, the no query logs will be fetched.
   lookback_days: <days>
+
+  # (Optional) Extract query log duration if postgres parameter `log_duration` is true
+  log_duration_enabled: <bool>
+
+  # (Optional) CloudWatch log filter pattern, https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html
+  filter_pattern: <pattern>  # For example: -root LOG
     
   # (Optional) A list of users whose queries will be excluded from the log fetching.
   excluded_usernames:

--- a/metaphor/postgresql/config.py
+++ b/metaphor/postgresql/config.py
@@ -45,6 +45,7 @@ class BasePostgreSQLRunConfig(BaseConfig):
 @dataclass(config=ConnectorConfig)
 class PostgreSQLQueryLogConfig(QueryLogConfig):
     aws: Optional[AwsCredentials] = None
+    log_duration_enabled: bool = False
     logs_group: Optional[str] = None
 
 

--- a/metaphor/postgresql/config.py
+++ b/metaphor/postgresql/config.py
@@ -47,6 +47,7 @@ class PostgreSQLQueryLogConfig(QueryLogConfig):
     aws: Optional[AwsCredentials] = None
     log_duration_enabled: bool = False
     logs_group: Optional[str] = None
+    filter_pattern: Optional[str] = None
 
 
 @dataclass(config=ConnectorConfig)

--- a/metaphor/postgresql/config.py
+++ b/metaphor/postgresql/config.py
@@ -45,9 +45,9 @@ class BasePostgreSQLRunConfig(BaseConfig):
 @dataclass(config=ConnectorConfig)
 class PostgreSQLQueryLogConfig(QueryLogConfig):
     aws: Optional[AwsCredentials] = None
+    filter_pattern: Optional[str] = None
     log_duration_enabled: bool = False
     logs_group: Optional[str] = None
-    filter_pattern: Optional[str] = None
 
 
 @dataclass(config=ConnectorConfig)

--- a/metaphor/postgresql/extractor.py
+++ b/metaphor/postgresql/extractor.py
@@ -412,11 +412,12 @@ class PostgreSQLExtractor(BasePostgreSQLExtractor):
             and self._query_log_config.logs_group is not None
         ):
             client = self._query_log_config.aws.get_session().client("logs")
-            lookback_days = self._query_log_config.lookback_days
-            logs_group = self._query_log_config.logs_group
 
             for message in iterate_logs_from_cloud_watch(
-                client, lookback_days, logs_group
+                client=client,
+                lookback_days=self._query_log_config.lookback_days,
+                logs_group=self._query_log_config.logs_group,
+                filter_pattern=self._query_log_config.filter_pattern,
             ):
                 query_log = self._process_cloud_watch_log(
                     message,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.121"
+version = "0.14.122"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/postgresql/expected_logs_execute.json
+++ b/tests/postgresql/expected_logs_execute.json
@@ -1,0 +1,40 @@
+[
+  {
+    "_id": "POSTGRESQL:9f07fea1cd4a1223a3695b4865f40d82",
+    "defaultDatabase": "metaphor",
+    "platform": "POSTGRESQL",
+    "queryId": "9f07fea1cd4a1223a3695b4865f40d82",
+    "sources": [
+      {
+        "database": "metaphor",
+        "id": "DATASET~F68D8D6F1F49DA4605F13F20FD3CA883",
+        "schema": "schema",
+        "table": "table"
+      }
+    ],
+    "sql": "SELECT * FROM schema.table",
+    "sqlHash": "9f07fea1cd4a1223a3695b4865f40d82",
+    "startTime": "2024-08-29T09:25:50+00:00",
+    "targets": [],
+    "userId": "metaphor"
+  },
+  {
+    "_id": "POSTGRESQL:06903bf0b96b1021e32edad5cf2b15f1",
+    "defaultDatabase": "metaphor",
+    "platform": "POSTGRESQL",
+    "queryId": "06903bf0b96b1021e32edad5cf2b15f1",
+    "sources": [
+      {
+        "database": "metaphor",
+        "id": "DATASET~1149097F32B03CEE64BB356B77701736",
+        "schema": "schema2",
+        "table": "table"
+      }
+    ],
+    "sql": "SELECT * FROM schema2.table",
+    "sqlHash": "06903bf0b96b1021e32edad5cf2b15f1",
+    "startTime": "2024-08-29T09:25:50+00:00",
+    "targets": [],
+    "userId": "metaphor"
+  }
+]

--- a/tests/postgresql/test_extractor.py
+++ b/tests/postgresql/test_extractor.py
@@ -226,7 +226,7 @@ async def test_extractor(
         "2024-08-29 09:25:51 UTC:10.1.1.134(48507):metaphor@metaphor:[615]:LOG: duration: 55.66 ms",
     ]
 
-    def mock_iterate_logs(_1, _2, _3):
+    def mock_iterate_logs(**_):
         yield from logs
 
     mocked_iterate_logs.side_effect = mock_iterate_logs
@@ -305,7 +305,7 @@ def test_collect_query_logs(
         f"{date}:{host}:{user_db}:[616]:LOG: execute S_1: COMMIT",
     ]
 
-    def mock_iterate_logs(_1, _2, _3):
+    def mock_iterate_logs(**_):
         yield from logs
 
     mocked_iterate_logs.side_effect = mock_iterate_logs

--- a/tests/postgresql/test_extractor.py
+++ b/tests/postgresql/test_extractor.py
@@ -69,6 +69,7 @@ def dummy_config(**args):
             lookback_days=1,
             logs_group="group",
             excluded_usernames={"foo"},
+            log_duration_enabled=True,
             aws=AwsCredentials(
                 access_key_id="",
                 secret_access_key="",
@@ -220,9 +221,13 @@ async def test_extractor(
     mock_session.client.return_value = 1
     mocked_get_session.return_value = mock_session
 
-    def mock_iterate_logs(a, b, c):
-        yield "2024-08-29 09:25:50 UTC:10.1.1.134(48507):metaphor@metaphor:[615]:LOG: statement: SELECT x, y from schema.table;"
-        yield "2024-08-29 09:25:51 UTC:10.1.1.134(48507):metaphor@metaphor:[615]:LOG: duration: 55.66 ms"
+    logs = [
+        "2024-08-29 09:25:50 UTC:10.1.1.134(48507):metaphor@metaphor:[615]:LOG: statement: SELECT x, y from schema.table;",
+        "2024-08-29 09:25:51 UTC:10.1.1.134(48507):metaphor@metaphor:[615]:LOG: duration: 55.66 ms",
+    ]
+
+    def mock_iterate_logs(_1, _2, _3):
+        yield from logs
 
     mocked_iterate_logs.side_effect = mock_iterate_logs
 
@@ -273,4 +278,44 @@ def test_alter_rename():
         targets=[],
         type=None,
         user_id="metaphor",
+    )
+
+
+@patch("metaphor.common.aws.AwsCredentials.get_session")
+@patch("metaphor.postgresql.extractor.iterate_logs_from_cloud_watch")
+def test_collect_query_logs(
+    mocked_iterate_logs: MagicMock,
+    mocked_get_session: MagicMock,
+    test_root_dir: str,
+):
+    mock_session = MagicMock()
+    mock_session.client.return_value = 1
+    mocked_get_session.return_value = mock_session
+
+    date = "2024-08-29 09:25:50 UTC"
+    host = "10.1.1.134(48507)"
+    user_db = "metaphor@metaphor"
+
+    logs = [
+        f"{date}:{host}:{user_db}:[615]:LOG: execute <unnamed>: BEGIN",
+        f"{date}:{host}:{user_db}:[615]:LOG: execute <unnamed>: SELECT * FROM schema.table",
+        f"{date}:{host}:{user_db}:[615]:LOG: execute S_1: COMMIT",
+        f"{date}:{host}:{user_db}:[616]:LOG: execute <unnamed>: BEGIN",
+        f"{date}:{host}:{user_db}:[616]:LOG: execute <unnamed>: SELECT * FROM schema2.table",
+        f"{date}:{host}:{user_db}:[616]:LOG: execute S_1: COMMIT",
+    ]
+
+    def mock_iterate_logs(_1, _2, _3):
+        yield from logs
+
+    mocked_iterate_logs.side_effect = mock_iterate_logs
+
+    config = dummy_config()
+    assert config.query_log
+    config.query_log.log_duration_enabled = False
+
+    extractor = PostgreSQLExtractor(config)
+    log_events = [EventUtil.trim_event(e) for e in extractor.collect_query_logs()]
+    assert log_events == load_json(
+        f"{test_root_dir}/postgresql/expected_logs_execute.json"
     )


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

Since `log_duration` does not always default to `true`, we should be able to extract query history without duration.

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

- Add `log_duration_enabled` flag to default to `false` to extract log without duration
- Add `filter_pattern` to speed up query log extraction
- fix skipping `execute` statement and add testcase

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

Update unit tests, verified against dev postgres instance.

<!--
  Describe how the change was tested end-to-end.
-->

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
