### PR TITLE
[sc-29305] Merge dbt cloud metadata before writing to file

### DIFF
--- a/metaphor/common/utils.py
+++ b/metaphor/common/utils.py
@@ -1,7 +1,7 @@
 import math
 from datetime import datetime, time, timedelta, timezone
 from hashlib import md5
-from typing import Any, Callable, Dict, Iterable, List, Optional, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, TypeVar, Union
 
 from dateutil.parser import isoparse
 from pydantic import validate_email
@@ -18,9 +18,19 @@ def start_of_day(daysAgo=0) -> datetime:
     ) - timedelta(days=daysAgo)
 
 
-def unique_list(non_unique_list: Iterable) -> list:
+T = TypeVar("T")
+
+
+def unique_list(non_unique_list: Iterable[T]) -> list[T]:
     """Returns an order-preserving list with no duplicate elements"""
     return list(dict.fromkeys(non_unique_list))
+
+
+def dedup_lists(left: Optional[List[T]], right: Optional[List[T]]) -> List[T]:
+    """
+    Dedups two lists into a single list. Order is preserved.
+    """
+    return unique_list((left or []) + (right or []))
 
 
 def filter_empty_strings(original_list: list) -> list:

--- a/metaphor/dbt/cloud/extractor.py
+++ b/metaphor/dbt/cloud/extractor.py
@@ -3,7 +3,7 @@ from typing import Collection, Dict, Set
 import httpx
 
 from metaphor.common.base_extractor import BaseExtractor
-from metaphor.common.event_util import ENTITY_TYPES, EventUtil
+from metaphor.common.event_util import ENTITY_TYPES
 from metaphor.common.logger import get_logger
 from metaphor.dbt.cloud.client import DbtAdminAPIClient
 from metaphor.dbt.cloud.config import DbtCloudConfig
@@ -11,10 +11,9 @@ from metaphor.dbt.cloud.discovery_api import DiscoveryAPIClient
 from metaphor.dbt.cloud.http import LogTransport
 from metaphor.dbt.cloud.parser.parser import Parser
 from metaphor.dbt.cloud.utils import parse_environment
+from metaphor.dbt.util import should_be_included
 from metaphor.models.crawler_run_metadata import Platform
 from metaphor.models.metadata_change_event import Dataset, Metric, VirtualView
-
-from metaphor.dbt.util import should_be_included
 
 logger = get_logger()
 
@@ -80,7 +79,7 @@ class DbtCloudExtractor(BaseExtractor):
         datasets = [d for d in self.datasets.values() if should_be_included(d)]
         views = [v for v in self.virtual_views.values() if should_be_included(v)]
         metrics = [m for m in self.metrics.values() if should_be_included(m)]
-        
+
         return datasets + views + metrics
 
     async def _extract_job(self, job_id: int):

--- a/metaphor/dbt/cloud/extractor.py
+++ b/metaphor/dbt/cloud/extractor.py
@@ -41,9 +41,9 @@ class DbtCloudExtractor(BaseExtractor):
 
         self._project_accounts: Dict[int, str] = {}
 
-        self.datasets: Dict[str, Dataset] = {}
-        self.virtual_views: Dict[str, VirtualView] = {}
-        self.metrics: Dict[str, Metric] = {}
+        self._datasets: Dict[str, Dataset] = {}
+        self._virtual_views: Dict[str, VirtualView] = {}
+        self._metrics: Dict[str, Metric] = {}
 
         self._parsed_runs: Set[int] = set()
 
@@ -76,9 +76,9 @@ class DbtCloudExtractor(BaseExtractor):
         for job_id in self._job_ids:
             await self._extract_job(job_id)
 
-        datasets = [d for d in self.datasets.values() if should_be_included(d)]
-        views = [v for v in self.virtual_views.values() if should_be_included(v)]
-        metrics = [m for m in self.metrics.values() if should_be_included(m)]
+        datasets = [d for d in self._datasets.values() if should_be_included(d)]
+        views = [v for v in self._virtual_views.values() if should_be_included(v)]
+        metrics = [m for m in self._metrics.values() if should_be_included(m)]
 
         return datasets + views + metrics
 
@@ -122,9 +122,9 @@ class DbtCloudExtractor(BaseExtractor):
             project_name,
             docs_base_url,
             project_explore_url=project_explore_url,
-            datasets=self.datasets,
-            virtual_views=self.virtual_views,
-            metrics=self.metrics,
+            datasets=self._datasets,
+            virtual_views=self._virtual_views,
+            metrics=self._metrics,
         )
         job_run_parser.parse_run(run)
         self._parsed_runs.add(run.run_id)

--- a/metaphor/dbt/cloud/parser/common.py
+++ b/metaphor/dbt/cloud/parser/common.py
@@ -1,13 +1,18 @@
+import json
 from typing import Dict, List, Union
 
 from metaphor.common.entity_id import EntityId
-from metaphor.common.utils import unique_list
-from metaphor.dbt.util import get_virtual_view_id
+from metaphor.common.utils import dedup_lists, unique_list
+from metaphor.dbt.util import build_system_tags, get_virtual_view_id
 from metaphor.models.metadata_change_event import (
     Dataset,
     DbtMacro,
     DbtMetric,
     DbtModel,
+    Metric,
+    Ownership,
+    OwnershipAssignment,
+    TagAssignment,
     VirtualView,
 )
 
@@ -22,28 +27,43 @@ def parse_depends_on(
     if not depends_on:
         return
 
-    datasets, models, macros = None, None, None
-
-    datasets = unique_list(
-        [str(source_map[n]) for n in depends_on if n.startswith("source.")]
+    target.source_datasets = (
+        unique_list(
+            [str(source_map[n]) for n in depends_on if n.startswith("source.")]
+            + (target.source_datasets or [])
+        )
+        or None
     )
 
-    models = unique_list(
-        [
-            get_virtual_view_id(virtual_views[n].logical_id)  # type: ignore
-            for n in depends_on
-            if n.startswith("model.") or n.startswith("snapshot.")
-        ]
+    target.source_models = (
+        unique_list(
+            [
+                get_virtual_view_id(virtual_views[n].logical_id)  # type: ignore
+                for n in depends_on
+                if n.startswith("model.") or n.startswith("snapshot.")
+            ]
+            + (target.source_models or [])
+        )
+        or None
     )
 
-    macros = [
-        macro_map[n] for n in depends_on if n.startswith("macro.") and n in macro_map
-    ]
-
-    target.source_datasets = datasets if datasets else None
-    target.source_models = models if models else None
     if isinstance(target, DbtModel):
-        target.macros = macros if macros else None
+        DbtMacro.__hash__ = lambda macro: hash(json.dumps(macro.to_dict()))  # type: ignore
+        target.macros = (
+            unique_list(
+                [
+                    macro_map[n]
+                    for n in depends_on
+                    if n.startswith("macro.") and n in macro_map
+                ]
+                + (
+                    target.macros
+                    if isinstance(target, DbtModel) and target.macros
+                    else []
+                )
+            )
+            or None
+        )
 
 
 def dataset_has_parsed_fields(
@@ -57,4 +77,53 @@ def dataset_has_parsed_fields(
         or dataset.tag_assignment is not None
         or dataset.documentation is not None
         or dataset.data_quality is not None
+    )
+
+
+def update_entity_system_tags(
+    entity: Union[Metric, VirtualView],
+    tags: List[str],
+) -> None:
+    """
+    Updates the entity's system tags. The duplicated tag values are removed.
+    """
+    if not tags:
+        return
+    existing_tags = (
+        []
+        if not entity.system_tags
+        else [tag.value for tag in entity.system_tags.tags or [] if tag.value]
+    )
+    entity.system_tags = build_system_tags(dedup_lists(existing_tags, tags))
+
+
+def update_entity_ownership_assignments(
+    entity: Union[Dataset, VirtualView], ownerships: List[Ownership]
+) -> None:
+    if not ownerships:
+        return
+    existing_ownerships = (
+        []
+        if not entity.ownership_assignment
+        else entity.ownership_assignment.ownerships or []
+    )
+    Ownership.__hash__ = lambda ownership: hash(json.dumps(ownership.to_dict()))  # type: ignore
+    entity.ownership_assignment = OwnershipAssignment(
+        ownerships=dedup_lists(existing_ownerships, ownerships)
+    )
+
+
+def update_entity_tag_assignments(
+    entity: Dataset,
+    tag_names: List[str],
+) -> None:
+    if not tag_names:
+        return
+
+    if not entity.tag_assignment:
+        entity.tag_assignment = TagAssignment()
+    if entity.tag_assignment.tag_names is None:
+        entity.tag_assignment.tag_names = []
+    entity.tag_assignment.tag_names = dedup_lists(
+        entity.tag_assignment.tag_names, tag_names
     )

--- a/metaphor/dbt/cloud/parser/common.py
+++ b/metaphor/dbt/cloud/parser/common.py
@@ -66,20 +66,6 @@ def parse_depends_on(
         )
 
 
-def dataset_has_parsed_fields(
-    dataset: Dataset,
-) -> bool:
-    """
-    init_dataset may generate irrelevant datasets, need to filter these out
-    """
-    return (
-        dataset.ownership_assignment is not None
-        or dataset.tag_assignment is not None
-        or dataset.documentation is not None
-        or dataset.data_quality is not None
-    )
-
-
 def update_entity_system_tags(
     entity: Union[Metric, VirtualView],
     tags: List[str],

--- a/metaphor/dbt/cloud/parser/dbt_metric_parser.py
+++ b/metaphor/dbt/cloud/parser/dbt_metric_parser.py
@@ -1,11 +1,13 @@
+import json
 from typing import Dict, Optional
 
 from metaphor.common.entity_id import EntityId
+from metaphor.common.utils import dedup_lists
 from metaphor.dbt.cloud.discovery_api.generated.get_job_run_metrics import (
     GetJobRunMetricsJobMetrics as JobMetric,
 )
-from metaphor.dbt.cloud.parser.common import parse_depends_on
-from metaphor.dbt.util import build_metric_docs_url, build_system_tags, init_metric
+from metaphor.dbt.cloud.parser.common import parse_depends_on, update_entity_system_tags
+from metaphor.dbt.util import build_metric_docs_url, init_metric
 from metaphor.models.metadata_change_event import (
     DbtMacro,
     DbtMetric,
@@ -29,38 +31,48 @@ class MetricParser:
 
     def parse(
         self,
-        metric: JobMetric,
+        job_metric: JobMetric,
         source_map: Dict[str, EntityId],
         macro_map: Dict[str, DbtMacro],
     ) -> None:
 
-        metric_entity = init_metric(self._metrics, metric.unique_id)
-        metric_entity.dbt_metric = DbtMetric(
-            package_name=metric.package_name,
-            description=metric.description or None,
-            label=metric.label,
-            timestamp=metric.timestamp,
-            time_grains=metric.time_grains,
-            dimensions=metric.dimensions,
-            filters=[
-                MetricFilter(field=f.field, operator=f.operator, value=f.value)
-                for f in metric.filters
-            ],
-            url=build_metric_docs_url(self._docs_base_url, metric.unique_id),
-            sql=metric.expression or metric.sql,
-            type=metric.calculation_method or metric.type,
+        metric = init_metric(self._metrics, job_metric.unique_id)
+        MetricFilter.__hash__ = lambda filter: hash(json.dumps(filter.to_dict()))  # type: ignore
+        metric.dbt_metric = DbtMetric(
+            package_name=job_metric.package_name or None,
+            description=job_metric.description or None,
+            label=job_metric.label,
+            timestamp=job_metric.timestamp,
+            time_grains=job_metric.time_grains,
+            dimensions=job_metric.dimensions,
+            filters=dedup_lists(
+                metric.dbt_metric.filters if metric.dbt_metric else [],
+                [
+                    MetricFilter(field=f.field, operator=f.operator, value=f.value)
+                    for f in job_metric.filters
+                ],
+            ),
+            url=build_metric_docs_url(self._docs_base_url, job_metric.unique_id),
+            sql=job_metric.expression or job_metric.sql,
+            type=job_metric.calculation_method or job_metric.type,
         )
-        if metric.tags:
-            metric_entity.system_tags = build_system_tags(metric.tags)
+        update_entity_system_tags(metric, job_metric.tags or [])
 
         parse_depends_on(
             self._virtual_views,
-            metric.depends_on,
+            job_metric.depends_on,
             source_map,
             macro_map,
-            metric_entity.dbt_metric,
+            metric.dbt_metric,
         )
 
-        metric_entity.entity_upstream = EntityUpstream(
-            source_entities=metric_entity.dbt_metric.source_models,
+        metric.entity_upstream = EntityUpstream(
+            source_entities=dedup_lists(
+                (
+                    metric.entity_upstream.source_entities
+                    if metric.entity_upstream
+                    else []
+                ),
+                metric.dbt_metric.source_models,
+            )
         )

--- a/metaphor/dbt/cloud/parser/dbt_node_parser.py
+++ b/metaphor/dbt/cloud/parser/dbt_node_parser.py
@@ -98,23 +98,25 @@ class NodeParser:
         if not model.database or not model.schema_ or not table:
             return
 
-        dataset = init_dataset(
-            self._datasets,
-            model.database,
-            model.schema_,
-            table,
-            self._platform,
-            self._account,
-            model.unique_id,
-        )
-
         # Assign ownership & tags to materialized table/view
         ownerships = get_ownerships_from_meta(model.meta, self._meta_ownerships)
-        update_entity_ownership_assignments(dataset, ownerships.materialized_table)
+        tag_names = get_metaphor_tags_from_meta(model.meta, self._meta_tags)
         update_entity_ownership_assignments(virtual_view, ownerships.dbt_model)
 
-        tag_names = get_metaphor_tags_from_meta(model.meta, self._meta_tags)
-        update_entity_tag_assignments(dataset, tag_names)
+        # Only init the dataset if there's ownership or tag names
+        if ownerships.materialized_table or tag_names:
+            dataset = init_dataset(
+                self._datasets,
+                model.database,
+                model.schema_,
+                table,
+                self._platform,
+                self._account,
+                model.unique_id,
+            )
+
+            update_entity_ownership_assignments(dataset, ownerships.materialized_table)
+            update_entity_tag_assignments(dataset, tag_names)
 
         # Capture the whole "meta" field as key-value pairs
         if len(model.meta) > 0:

--- a/metaphor/dbt/cloud/parser/parser.py
+++ b/metaphor/dbt/cloud/parser/parser.py
@@ -1,7 +1,6 @@
 import time
-from typing import Dict, List, Optional, Set
+from typing import Dict, Optional, Set
 
-from metaphor.common.event_util import ENTITY_TYPES
 from metaphor.common.logger import get_logger
 from metaphor.common.snowflake import normalize_snowflake_account
 from metaphor.dbt.cloud.client import DbtRun
@@ -10,7 +9,6 @@ from metaphor.dbt.cloud.discovery_api import DiscoveryAPIClient
 from metaphor.dbt.cloud.discovery_api.generated.get_job_run_models import (
     GetJobRunModelsJobModels as Model,
 )
-from metaphor.dbt.cloud.parser.common import dataset_has_parsed_fields
 from metaphor.dbt.cloud.parser.dbt_macro_parser import MacroParser
 from metaphor.dbt.cloud.parser.dbt_metric_parser import MetricParser
 from metaphor.dbt.cloud.parser.dbt_node_parser import NodeParser
@@ -148,18 +146,6 @@ class Parser:
         for metric in self._get_metrics(run):
             self._metric_parser.parse(metric, source_map, macro_map)
 
-        entities: List[ENTITY_TYPES] = []
-        entities.extend(
-            dataset
-            for dataset in self._datasets.values()
-            if dataset_has_parsed_fields(dataset)
-        )
-        entities.extend(
-            v
-            for k, v in self._virtual_views.items()
-            if k not in self._referenced_virtual_views
-        )
-        entities.extend(self._metrics.values())
         logger.info(
             f"Fetched job ID: {run.job_id}. Elapsed time: {time.time() - start} secs."
         )

--- a/metaphor/fivetran/extractor.py
+++ b/metaphor/fivetran/extractor.py
@@ -14,7 +14,7 @@ from metaphor.common.entity_id import (
 from metaphor.common.event_util import ENTITY_TYPES
 from metaphor.common.logger import get_logger
 from metaphor.common.snowflake import normalize_snowflake_account
-from metaphor.common.utils import safe_float
+from metaphor.common.utils import dedup_lists, safe_float
 from metaphor.fivetran.config import FivetranRunConfig
 from metaphor.fivetran.models import (
     ConnectorPayload,
@@ -291,7 +291,8 @@ class FivetranExtractor(BaseExtractor):
         dataset_id = str(to_dataset_entity_id_from_logical_id(dataset.logical_id))
 
         pipeline = self._pipelines[connector.id]
-        pipeline.fivetran.targets = list(set(pipeline.fivetran.targets + [dataset_id]))
+        assert pipeline.fivetran is not None
+        pipeline.fivetran.targets = dedup_lists(pipeline.fivetran.targets, [dataset_id])
 
         if connector.service in SOURCE_PLATFORM_MAPPING:
             source_db = self.get_database_name_from_connector(connector)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.126"
+version = "0.14.127"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.131"
+version = "0.14.132"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/dbt/cloud/expected.json
+++ b/tests/dbt/cloud/expected.json
@@ -400,34 +400,6 @@
     }
   },
   {
-    "logicalId": {
-      "account": "john.doe@metaphor.io",
-      "name": "demo_db.metaphor.churn_region_agg",
-      "platform": "SNOWFLAKE"
-    }
-  },
-  {
-    "logicalId": {
-      "account": "john.doe@metaphor.io",
-      "name": "demo_db.metaphor.modular_campaigns",
-      "platform": "SNOWFLAKE"
-    }
-  },
-  {
-    "logicalId": {
-      "account": "john.doe@metaphor.io",
-      "name": "demo_db.metaphor.subscriptions_growth",
-      "platform": "SNOWFLAKE"
-    }
-  },
-  {
-    "logicalId": {
-      "account": "john.doe@metaphor.io",
-      "name": "demo_db.metaphor.subscriptions_v2",
-      "platform": "SNOWFLAKE"
-    }
-  },
-  {
     "documentation": {
       "datasetDocumentations": [],
       "fieldDocumentations": [
@@ -451,13 +423,6 @@
     "logicalId": {
       "account": "john.doe@metaphor.io",
       "name": "acme.berlin_bicycles.cycle_stations",
-      "platform": "SNOWFLAKE"
-    }
-  },
-  {
-    "logicalId": {
-      "account": "john.doe@metaphor.io",
-      "name": "acme.ride_share.cleaned_bike_rides",
       "platform": "SNOWFLAKE"
     }
   },

--- a/tests/dbt/cloud/expected.json
+++ b/tests/dbt/cloud/expected.json
@@ -294,6 +294,174 @@
     }
   },
   {
+    "documentation": {
+      "datasetDocumentations": [
+        "This dataset contains profile info of each customer. E.g first name, last name, email, company name etc."
+      ],
+      "fieldDocumentations": [
+        {
+          "documentation": "Auto-generated ID",
+          "fieldPath": "id"
+        },
+        {
+          "documentation": "Customer's first name",
+          "fieldPath": "first_name"
+        },
+        {
+          "documentation": "Customer's last name",
+          "fieldPath": "last_name"
+        },
+        {
+          "documentation": "Customer's email address",
+          "fieldPath": "email"
+        },
+        {
+          "documentation": "Customer's company",
+          "fieldPath": "company"
+        },
+        {
+          "documentation": "Creation timestamp",
+          "fieldPath": "date"
+        }
+      ]
+    },
+    "logicalId": {
+      "account": "john.doe@metaphor.io",
+      "name": "demo_db.metaphor.customer_profile",
+      "platform": "SNOWFLAKE"
+    }
+  },
+  {
+    "documentation": {
+      "datasetDocumentations": [
+        "This dataset contains all subscriptions info."
+      ],
+      "fieldDocumentations": [
+        {
+          "documentation": "Creation timestamp",
+          "fieldPath": "created_at"
+        },
+        {
+          "documentation": "Subscription full display name",
+          "fieldPath": "long_name"
+        },
+        {
+          "documentation": "Subscription price in cents",
+          "fieldPath": "price"
+        },
+        {
+          "documentation": "Type of subscription renewal",
+          "fieldPath": "renew_type"
+        },
+        {
+          "documentation": "Subscription short name",
+          "fieldPath": "short_name"
+        },
+        {
+          "documentation": "Primary Key",
+          "fieldPath": "sub_id"
+        }
+      ]
+    },
+    "logicalId": {
+      "account": "john.doe@metaphor.io",
+      "name": "demo_db.metaphor.subscriptions_base",
+      "platform": "SNOWFLAKE"
+    }
+  },
+  {
+    "documentation": {
+      "datasetDocumentations": [
+        "This dataset represents all the raw subscription changes info of our product. Each subscription is represented by unique subs_id and each change has a unique chng_id."
+      ],
+      "fieldDocumentations": [
+        {
+          "documentation": "Change type",
+          "fieldPath": "change_type"
+        },
+        {
+          "documentation": "Primary Key",
+          "fieldPath": "chg_id"
+        },
+        {
+          "documentation": "Creation timestamp",
+          "fieldPath": "created_at"
+        },
+        {
+          "documentation": "Subscription ID",
+          "fieldPath": "sub_id"
+        }
+      ]
+    },
+    "logicalId": {
+      "account": "john.doe@metaphor.io",
+      "name": "demo_db.metaphor.subscriptions_change_raw",
+      "platform": "SNOWFLAKE"
+    }
+  },
+  {
+    "logicalId": {
+      "account": "john.doe@metaphor.io",
+      "name": "demo_db.metaphor.churn_region_agg",
+      "platform": "SNOWFLAKE"
+    }
+  },
+  {
+    "logicalId": {
+      "account": "john.doe@metaphor.io",
+      "name": "demo_db.metaphor.modular_campaigns",
+      "platform": "SNOWFLAKE"
+    }
+  },
+  {
+    "logicalId": {
+      "account": "john.doe@metaphor.io",
+      "name": "demo_db.metaphor.subscriptions_growth",
+      "platform": "SNOWFLAKE"
+    }
+  },
+  {
+    "logicalId": {
+      "account": "john.doe@metaphor.io",
+      "name": "demo_db.metaphor.subscriptions_v2",
+      "platform": "SNOWFLAKE"
+    }
+  },
+  {
+    "documentation": {
+      "datasetDocumentations": [],
+      "fieldDocumentations": [
+        {
+          "documentation": "Duration of the bike trip in seconds.",
+          "fieldPath": "duration"
+        }
+      ]
+    },
+    "logicalId": {
+      "account": "john.doe@metaphor.io",
+      "name": "acme.berlin_bicycles.cycle_hire",
+      "platform": "SNOWFLAKE"
+    }
+  },
+  {
+    "documentation": {
+      "datasetDocumentations": [],
+      "fieldDocumentations": []
+    },
+    "logicalId": {
+      "account": "john.doe@metaphor.io",
+      "name": "acme.berlin_bicycles.cycle_stations",
+      "platform": "SNOWFLAKE"
+    }
+  },
+  {
+    "logicalId": {
+      "account": "john.doe@metaphor.io",
+      "name": "acme.ride_share.cleaned_bike_rides",
+      "platform": "SNOWFLAKE"
+    }
+  },
+  {
     "dbtModel": {
       "compiledSql": "\\n\\nwith\\n\\ncustomers as (\\n\\n    select * from acme.jaffle_shop.stg_customers\\n\\n),\\n\\norders_mart as (\\n\\n    select * from acme.jaffle_shop.orders\\n\\n),\\n\\norder_items_mart as (\\n\\n    select * from acme.jaffle_shop.order_items\\n),\\n\\norder_summary as (\\n\\n    select\\n        customer_id,\\n\\n        count(distinct om.order_id) as count_lifetime_orders,\\n        count(distinct om.order_id) > 1 as is_repeat_buyer,\\n        min(om.ordered_at) as first_ordered_at,\\n        max(om.ordered_at) as last_ordered_at,\\n        sum(oi.subtotal) as lifetime_spend_pretax,\\n        sum(om.order_total) as lifetime_spend\\n\\n    from orders_mart om\\n    \\n    left join order_items_mart oi on om.order_id = oi.order_id\\n    \\n    group by 1\\n\\n),\\n\\njoined as (\\n\\n    select\\n        customers.*,\\n        order_summary.count_lifetime_orders,\\n        order_summary.first_ordered_at,\\n        order_summary.last_ordered_at,\\n        order_summary.lifetime_spend_pretax,\\n        order_summary.lifetime_spend,\\n\\n        case\\n            when order_summary.is_repeat_buyer then 'returning'\\n            else 'new'\\n        end as customer_type\\n\\n    from customers\\n\\n    left join order_summary\\n        on customers.customer_id = order_summary.customer_id\\n\\n)\\n\\nselect * from joined",
       "description": "Customer overview data mart, offering key details for each unique customer. One row per customer.",
@@ -1175,367 +1343,6 @@
     }
   },
   {
-    "dbtMetric": {
-      "description": "The cumulative revenue for all orders.",
-      "dimensions": [],
-      "filters": [],
-      "label": "Cumulative Revenue (All Time)",
-      "packageName": "jaffle_shop",
-      "timeGrains": [],
-      "type": "cumulative",
-      "url": "https://cloud.getdbt.com/accounts/1/jobs/21/docs/#!/metric/metric.jaffle_shop.cumulative_revenue"
-    },
-    "entityUpstream": {},
-    "logicalId": {
-      "name": "jaffle_shop.cumulative_revenue",
-      "type": "DBT_METRIC"
-    }
-  },
-  {
-    "dbtMetric": {
-      "description": "Distict count of customers placing orders",
-      "dimensions": [],
-      "filters": [],
-      "label": "Customers w/ Orders",
-      "packageName": "jaffle_shop",
-      "timeGrains": [],
-      "type": "simple",
-      "url": "https://cloud.getdbt.com/accounts/1/jobs/21/docs/#!/metric/metric.jaffle_shop.customers_with_orders"
-    },
-    "entityUpstream": {},
-    "logicalId": {
-      "name": "jaffle_shop.customers_with_orders",
-      "type": "DBT_METRIC"
-    }
-  },
-  {
-    "dbtMetric": {
-      "description": "Count of orders that contain food order items",
-      "dimensions": [],
-      "filters": [],
-      "label": "Food Orders",
-      "packageName": "jaffle_shop",
-      "timeGrains": [],
-      "type": "simple",
-      "url": "https://cloud.getdbt.com/accounts/1/jobs/21/docs/#!/metric/metric.jaffle_shop.food_orders"
-    },
-    "entityUpstream": {},
-    "logicalId": {
-      "name": "jaffle_shop.food_orders",
-      "type": "DBT_METRIC"
-    }
-  },
-  {
-    "dbtMetric": {
-      "description": "The revenue from food in each order",
-      "dimensions": [],
-      "filters": [],
-      "label": "Food Revenue",
-      "packageName": "jaffle_shop",
-      "timeGrains": [],
-      "type": "simple",
-      "url": "https://cloud.getdbt.com/accounts/1/jobs/21/docs/#!/metric/metric.jaffle_shop.food_revenue"
-    },
-    "entityUpstream": {},
-    "logicalId": {
-      "name": "jaffle_shop.food_revenue",
-      "type": "DBT_METRIC"
-    }
-  },
-  {
-    "dbtMetric": {
-      "description": "The % of order revenue from food.",
-      "dimensions": [],
-      "filters": [],
-      "label": "Food Revenue %",
-      "packageName": "jaffle_shop",
-      "timeGrains": [],
-      "type": "ratio",
-      "url": "https://cloud.getdbt.com/accounts/1/jobs/21/docs/#!/metric/metric.jaffle_shop.food_revenue_pct"
-    },
-    "entityUpstream": {},
-    "logicalId": {
-      "name": "jaffle_shop.food_revenue_pct",
-      "type": "DBT_METRIC"
-    }
-  },
-  {
-    "dbtMetric": {
-      "description": "Count of orders with order total over 20.",
-      "dimensions": [],
-      "filters": [],
-      "label": "Large Orders",
-      "packageName": "jaffle_shop",
-      "timeGrains": [],
-      "type": "simple",
-      "url": "https://cloud.getdbt.com/accounts/1/jobs/21/docs/#!/metric/metric.jaffle_shop.large_order"
-    },
-    "entityUpstream": {},
-    "logicalId": {
-      "name": "jaffle_shop.large_order",
-      "type": "DBT_METRIC"
-    }
-  },
-  {
-    "dbtMetric": {
-      "description": "Count of locations that placed in order.",
-      "dimensions": [],
-      "filters": [],
-      "label": "Locations",
-      "packageName": "jaffle_shop",
-      "timeGrains": [],
-      "type": "simple",
-      "url": "https://cloud.getdbt.com/accounts/1/jobs/21/docs/#!/metric/metric.jaffle_shop.locations"
-    },
-    "entityUpstream": {},
-    "logicalId": {
-      "name": "jaffle_shop.locations",
-      "type": "DBT_METRIC"
-    }
-  },
-  {
-    "dbtMetric": {
-      "description": "The median revenue for each order item. Excludes tax.",
-      "dimensions": [],
-      "filters": [],
-      "label": "Median Revenue",
-      "packageName": "jaffle_shop",
-      "timeGrains": [],
-      "type": "simple",
-      "url": "https://cloud.getdbt.com/accounts/1/jobs/21/docs/#!/metric/metric.jaffle_shop.median_revenue"
-    },
-    "entityUpstream": {},
-    "logicalId": {
-      "name": "jaffle_shop.median_revenue",
-      "type": "DBT_METRIC"
-    }
-  },
-  {
-    "dbtMetric": {
-      "description": "Unique count of new customers.",
-      "dimensions": [],
-      "filters": [],
-      "label": "New Customers",
-      "packageName": "jaffle_shop",
-      "timeGrains": [],
-      "type": "simple",
-      "url": "https://cloud.getdbt.com/accounts/1/jobs/21/docs/#!/metric/metric.jaffle_shop.new_customer"
-    },
-    "entityUpstream": {},
-    "logicalId": {
-      "name": "jaffle_shop.new_customer",
-      "type": "DBT_METRIC"
-    }
-  },
-  {
-    "dbtMetric": {
-      "description": "Sum of cost for each order item.",
-      "dimensions": [],
-      "filters": [],
-      "label": "Order Cost",
-      "packageName": "jaffle_shop",
-      "timeGrains": [],
-      "type": "simple",
-      "url": "https://cloud.getdbt.com/accounts/1/jobs/21/docs/#!/metric/metric.jaffle_shop.order_cost"
-    },
-    "entityUpstream": {},
-    "logicalId": {
-      "name": "jaffle_shop.order_cost",
-      "type": "DBT_METRIC"
-    }
-  },
-  {
-    "dbtMetric": {
-      "description": "Gross profit from each order.",
-      "dimensions": [],
-      "filters": [],
-      "label": "Order Gross Profit",
-      "packageName": "jaffle_shop",
-      "timeGrains": [],
-      "type": "derived",
-      "url": "https://cloud.getdbt.com/accounts/1/jobs/21/docs/#!/metric/metric.jaffle_shop.order_gross_profit"
-    },
-    "entityUpstream": {},
-    "logicalId": {
-      "name": "jaffle_shop.order_gross_profit",
-      "type": "DBT_METRIC"
-    }
-  },
-  {
-    "dbtMetric": {
-      "description": "Count of orders.",
-      "dimensions": [],
-      "filters": [],
-      "label": "Orders",
-      "packageName": "jaffle_shop",
-      "timeGrains": [],
-      "type": "simple",
-      "url": "https://cloud.getdbt.com/accounts/1/jobs/21/docs/#!/metric/metric.jaffle_shop.orders"
-    },
-    "entityUpstream": {},
-    "logicalId": {
-      "name": "jaffle_shop.orders",
-      "type": "DBT_METRIC"
-    }
-  },
-  {
-    "dbtMetric": {
-      "description": "Sum of total order amonunt. Includes tax + revenue.",
-      "dimensions": [],
-      "filters": [],
-      "label": "Order Total",
-      "packageName": "jaffle_shop",
-      "timeGrains": [],
-      "type": "simple",
-      "url": "https://cloud.getdbt.com/accounts/1/jobs/21/docs/#!/metric/metric.jaffle_shop.order_total"
-    },
-    "entityUpstream": {},
-    "logicalId": {
-      "name": "jaffle_shop.order_total",
-      "type": "DBT_METRIC"
-    }
-  },
-  {
-    "dbtMetric": {
-      "description": "Sum of the product revenue for each order item. Excludes tax.",
-      "dimensions": [],
-      "filters": [],
-      "label": "Revenue",
-      "packageName": "jaffle_shop",
-      "timeGrains": [],
-      "type": "simple",
-      "url": "https://cloud.getdbt.com/accounts/1/jobs/21/docs/#!/metric/metric.jaffle_shop.revenue"
-    },
-    "entityUpstream": {},
-    "logicalId": {
-      "name": "jaffle_shop.revenue",
-      "type": "DBT_METRIC"
-    }
-  },
-  {
-    "dbtMetric": {
-      "description": "Percentage growth of revenue compared to 1 month ago. Excluded tax",
-      "dimensions": [],
-      "filters": [],
-      "label": "Revenue Growth % M/M",
-      "packageName": "jaffle_shop",
-      "timeGrains": [],
-      "type": "derived",
-      "url": "https://cloud.getdbt.com/accounts/1/jobs/21/docs/#!/metric/metric.jaffle_shop.revenue_growth_mom"
-    },
-    "entityUpstream": {},
-    "logicalId": {
-      "name": "jaffle_shop.revenue_growth_mom",
-      "type": "DBT_METRIC"
-    }
-  },
-  {
-    "documentation": {
-      "datasetDocumentations": [
-        "This dataset contains profile info of each customer. E.g first name, last name, email, company name etc."
-      ],
-      "fieldDocumentations": [
-        {
-          "documentation": "Auto-generated ID",
-          "fieldPath": "id"
-        },
-        {
-          "documentation": "Customer's first name",
-          "fieldPath": "first_name"
-        },
-        {
-          "documentation": "Customer's last name",
-          "fieldPath": "last_name"
-        },
-        {
-          "documentation": "Customer's email address",
-          "fieldPath": "email"
-        },
-        {
-          "documentation": "Customer's company",
-          "fieldPath": "company"
-        },
-        {
-          "documentation": "Creation timestamp",
-          "fieldPath": "date"
-        }
-      ]
-    },
-    "logicalId": {
-      "account": "john.doe@metaphor.io",
-      "name": "demo_db.metaphor.customer_profile",
-      "platform": "SNOWFLAKE"
-    }
-  },
-  {
-    "documentation": {
-      "datasetDocumentations": [
-        "This dataset contains all subscriptions info."
-      ],
-      "fieldDocumentations": [
-        {
-          "documentation": "Creation timestamp",
-          "fieldPath": "created_at"
-        },
-        {
-          "documentation": "Subscription full display name",
-          "fieldPath": "long_name"
-        },
-        {
-          "documentation": "Subscription price in cents",
-          "fieldPath": "price"
-        },
-        {
-          "documentation": "Type of subscription renewal",
-          "fieldPath": "renew_type"
-        },
-        {
-          "documentation": "Subscription short name",
-          "fieldPath": "short_name"
-        },
-        {
-          "documentation": "Primary Key",
-          "fieldPath": "sub_id"
-        }
-      ]
-    },
-    "logicalId": {
-      "account": "john.doe@metaphor.io",
-      "name": "demo_db.metaphor.subscriptions_base",
-      "platform": "SNOWFLAKE"
-    }
-  },
-  {
-    "documentation": {
-      "datasetDocumentations": [
-        "This dataset represents all the raw subscription changes info of our product. Each subscription is represented by unique subs_id and each change has a unique chng_id."
-      ],
-      "fieldDocumentations": [
-        {
-          "documentation": "Change type",
-          "fieldPath": "change_type"
-        },
-        {
-          "documentation": "Primary Key",
-          "fieldPath": "chg_id"
-        },
-        {
-          "documentation": "Creation timestamp",
-          "fieldPath": "created_at"
-        },
-        {
-          "documentation": "Subscription ID",
-          "fieldPath": "sub_id"
-        }
-      ]
-    },
-    "logicalId": {
-      "account": "john.doe@metaphor.io",
-      "name": "demo_db.metaphor.subscriptions_change_raw",
-      "platform": "SNOWFLAKE"
-    }
-  },
-  {
     "dbtModel": {
       "compiledSql": "select \n  1 as id,\n  subscriptions_growth.customer_id as cus_id,\n  'no' as reason,\n  subscriptions_growth.created_at as sub_date,\n  '2014-01-01 16:00:00' as cancel_date\nfrom DEMO_DB.METAPHOR.subscriptions_growth as subscriptions_growth",
       "description": "This dataset contains info about churn, all the accounts that have cancelled the subscriptions in the past.",
@@ -2008,33 +1815,6 @@
           "value": "subscription"
         }
       ]
-    }
-  },
-  {
-    "documentation": {
-      "datasetDocumentations": [],
-      "fieldDocumentations": [
-        {
-          "documentation": "Duration of the bike trip in seconds.",
-          "fieldPath": "duration"
-        }
-      ]
-    },
-    "logicalId": {
-      "account": "john.doe@metaphor.io",
-      "name": "acme.berlin_bicycles.cycle_hire",
-      "platform": "SNOWFLAKE"
-    }
-  },
-  {
-    "documentation": {
-      "datasetDocumentations": [],
-      "fieldDocumentations": []
-    },
-    "logicalId": {
-      "account": "john.doe@metaphor.io",
-      "name": "acme.berlin_bicycles.cycle_stations",
-      "platform": "SNOWFLAKE"
     }
   },
   {
@@ -2784,6 +2564,291 @@
         "london_bike_analysis"
       ],
       "name": "cycle_hire_snapshot"
+    }
+  },
+  {
+    "dbtMetric": {
+      "description": "The cumulative revenue for all orders.",
+      "dimensions": [],
+      "filters": [],
+      "label": "Cumulative Revenue (All Time)",
+      "packageName": "jaffle_shop",
+      "timeGrains": [],
+      "type": "cumulative",
+      "url": "https://cloud.getdbt.com/accounts/1/jobs/21/docs/#!/metric/metric.jaffle_shop.cumulative_revenue"
+    },
+    "entityUpstream": {
+      "sourceEntities": []
+    },
+    "logicalId": {
+      "name": "jaffle_shop.cumulative_revenue",
+      "type": "DBT_METRIC"
+    }
+  },
+  {
+    "dbtMetric": {
+      "description": "Distict count of customers placing orders",
+      "dimensions": [],
+      "filters": [],
+      "label": "Customers w/ Orders",
+      "packageName": "jaffle_shop",
+      "timeGrains": [],
+      "type": "simple",
+      "url": "https://cloud.getdbt.com/accounts/1/jobs/21/docs/#!/metric/metric.jaffle_shop.customers_with_orders"
+    },
+    "entityUpstream": {
+      "sourceEntities": []
+    },
+    "logicalId": {
+      "name": "jaffle_shop.customers_with_orders",
+      "type": "DBT_METRIC"
+    }
+  },
+  {
+    "dbtMetric": {
+      "description": "Count of orders that contain food order items",
+      "dimensions": [],
+      "filters": [],
+      "label": "Food Orders",
+      "packageName": "jaffle_shop",
+      "timeGrains": [],
+      "type": "simple",
+      "url": "https://cloud.getdbt.com/accounts/1/jobs/21/docs/#!/metric/metric.jaffle_shop.food_orders"
+    },
+    "entityUpstream": {
+      "sourceEntities": []
+    },
+    "logicalId": {
+      "name": "jaffle_shop.food_orders",
+      "type": "DBT_METRIC"
+    }
+  },
+  {
+    "dbtMetric": {
+      "description": "The revenue from food in each order",
+      "dimensions": [],
+      "filters": [],
+      "label": "Food Revenue",
+      "packageName": "jaffle_shop",
+      "timeGrains": [],
+      "type": "simple",
+      "url": "https://cloud.getdbt.com/accounts/1/jobs/21/docs/#!/metric/metric.jaffle_shop.food_revenue"
+    },
+    "entityUpstream": {
+      "sourceEntities": []
+    },
+    "logicalId": {
+      "name": "jaffle_shop.food_revenue",
+      "type": "DBT_METRIC"
+    }
+  },
+  {
+    "dbtMetric": {
+      "description": "The % of order revenue from food.",
+      "dimensions": [],
+      "filters": [],
+      "label": "Food Revenue %",
+      "packageName": "jaffle_shop",
+      "timeGrains": [],
+      "type": "ratio",
+      "url": "https://cloud.getdbt.com/accounts/1/jobs/21/docs/#!/metric/metric.jaffle_shop.food_revenue_pct"
+    },
+    "entityUpstream": {
+      "sourceEntities": []
+    },
+    "logicalId": {
+      "name": "jaffle_shop.food_revenue_pct",
+      "type": "DBT_METRIC"
+    }
+  },
+  {
+    "dbtMetric": {
+      "description": "Count of orders with order total over 20.",
+      "dimensions": [],
+      "filters": [],
+      "label": "Large Orders",
+      "packageName": "jaffle_shop",
+      "timeGrains": [],
+      "type": "simple",
+      "url": "https://cloud.getdbt.com/accounts/1/jobs/21/docs/#!/metric/metric.jaffle_shop.large_order"
+    },
+    "entityUpstream": {
+      "sourceEntities": []
+    },
+    "logicalId": {
+      "name": "jaffle_shop.large_order",
+      "type": "DBT_METRIC"
+    }
+  },
+  {
+    "dbtMetric": {
+      "description": "Count of locations that placed in order.",
+      "dimensions": [],
+      "filters": [],
+      "label": "Locations",
+      "packageName": "jaffle_shop",
+      "timeGrains": [],
+      "type": "simple",
+      "url": "https://cloud.getdbt.com/accounts/1/jobs/21/docs/#!/metric/metric.jaffle_shop.locations"
+    },
+    "entityUpstream": {
+      "sourceEntities": []
+    },
+    "logicalId": {
+      "name": "jaffle_shop.locations",
+      "type": "DBT_METRIC"
+    }
+  },
+  {
+    "dbtMetric": {
+      "description": "The median revenue for each order item. Excludes tax.",
+      "dimensions": [],
+      "filters": [],
+      "label": "Median Revenue",
+      "packageName": "jaffle_shop",
+      "timeGrains": [],
+      "type": "simple",
+      "url": "https://cloud.getdbt.com/accounts/1/jobs/21/docs/#!/metric/metric.jaffle_shop.median_revenue"
+    },
+    "entityUpstream": {
+      "sourceEntities": []
+    },
+    "logicalId": {
+      "name": "jaffle_shop.median_revenue",
+      "type": "DBT_METRIC"
+    }
+  },
+  {
+    "dbtMetric": {
+      "description": "Unique count of new customers.",
+      "dimensions": [],
+      "filters": [],
+      "label": "New Customers",
+      "packageName": "jaffle_shop",
+      "timeGrains": [],
+      "type": "simple",
+      "url": "https://cloud.getdbt.com/accounts/1/jobs/21/docs/#!/metric/metric.jaffle_shop.new_customer"
+    },
+    "entityUpstream": {
+      "sourceEntities": []
+    },
+    "logicalId": {
+      "name": "jaffle_shop.new_customer",
+      "type": "DBT_METRIC"
+    }
+  },
+  {
+    "dbtMetric": {
+      "description": "Sum of cost for each order item.",
+      "dimensions": [],
+      "filters": [],
+      "label": "Order Cost",
+      "packageName": "jaffle_shop",
+      "timeGrains": [],
+      "type": "simple",
+      "url": "https://cloud.getdbt.com/accounts/1/jobs/21/docs/#!/metric/metric.jaffle_shop.order_cost"
+    },
+    "entityUpstream": {
+      "sourceEntities": []
+    },
+    "logicalId": {
+      "name": "jaffle_shop.order_cost",
+      "type": "DBT_METRIC"
+    }
+  },
+  {
+    "dbtMetric": {
+      "description": "Gross profit from each order.",
+      "dimensions": [],
+      "filters": [],
+      "label": "Order Gross Profit",
+      "packageName": "jaffle_shop",
+      "timeGrains": [],
+      "type": "derived",
+      "url": "https://cloud.getdbt.com/accounts/1/jobs/21/docs/#!/metric/metric.jaffle_shop.order_gross_profit"
+    },
+    "entityUpstream": {
+      "sourceEntities": []
+    },
+    "logicalId": {
+      "name": "jaffle_shop.order_gross_profit",
+      "type": "DBT_METRIC"
+    }
+  },
+  {
+    "dbtMetric": {
+      "description": "Count of orders.",
+      "dimensions": [],
+      "filters": [],
+      "label": "Orders",
+      "packageName": "jaffle_shop",
+      "timeGrains": [],
+      "type": "simple",
+      "url": "https://cloud.getdbt.com/accounts/1/jobs/21/docs/#!/metric/metric.jaffle_shop.orders"
+    },
+    "entityUpstream": {
+      "sourceEntities": []
+    },
+    "logicalId": {
+      "name": "jaffle_shop.orders",
+      "type": "DBT_METRIC"
+    }
+  },
+  {
+    "dbtMetric": {
+      "description": "Sum of total order amonunt. Includes tax + revenue.",
+      "dimensions": [],
+      "filters": [],
+      "label": "Order Total",
+      "packageName": "jaffle_shop",
+      "timeGrains": [],
+      "type": "simple",
+      "url": "https://cloud.getdbt.com/accounts/1/jobs/21/docs/#!/metric/metric.jaffle_shop.order_total"
+    },
+    "entityUpstream": {
+      "sourceEntities": []
+    },
+    "logicalId": {
+      "name": "jaffle_shop.order_total",
+      "type": "DBT_METRIC"
+    }
+  },
+  {
+    "dbtMetric": {
+      "description": "Sum of the product revenue for each order item. Excludes tax.",
+      "dimensions": [],
+      "filters": [],
+      "label": "Revenue",
+      "packageName": "jaffle_shop",
+      "timeGrains": [],
+      "type": "simple",
+      "url": "https://cloud.getdbt.com/accounts/1/jobs/21/docs/#!/metric/metric.jaffle_shop.revenue"
+    },
+    "entityUpstream": {
+      "sourceEntities": []
+    },
+    "logicalId": {
+      "name": "jaffle_shop.revenue",
+      "type": "DBT_METRIC"
+    }
+  },
+  {
+    "dbtMetric": {
+      "description": "Percentage growth of revenue compared to 1 month ago. Excluded tax",
+      "dimensions": [],
+      "filters": [],
+      "label": "Revenue Growth % M/M",
+      "packageName": "jaffle_shop",
+      "timeGrains": [],
+      "type": "derived",
+      "url": "https://cloud.getdbt.com/accounts/1/jobs/21/docs/#!/metric/metric.jaffle_shop.revenue_growth_mom"
+    },
+    "entityUpstream": {
+      "sourceEntities": []
+    },
+    "logicalId": {
+      "name": "jaffle_shop.revenue_growth_mom",
+      "type": "DBT_METRIC"
     }
   }
 ]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

It is possible for a single dbt model to be referenced by tests in jobs in different projects. To avoid writing to different virtual view MCEs, we want to write to the same virtual view and only update the necessary bits.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Pass crawler-wide entities to dbt cloud sub-parsers.
- Added dedup method.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

- Updated unit test.
- Ran the crawler locally.

The model `jaffle_shop.stg_supplies` has two tests:
<img width="1710" alt="截圖 2024-10-16 晚上7 45 02" src="https://github.com/user-attachments/assets/82abd0d8-1105-4440-b6c8-f2be97e8b9dd">

This model is referenced in 2 projects: `jaffle_shop` and `jaffle_shop_postgres` (basically a clone of the first one, just run on top of postgres.) Both projects are included in my crawler config.

When we run the extractor, in the model there's only 1 `not_null_stg_supplies_supply_uuid` test.

But when we look at data quality for the referenced dataset, we see there are two monitors. This is because the test is being run in two different projects:

<img width="1710" alt="截圖 2024-10-16 晚上7 45 13" src="https://github.com/user-attachments/assets/ed3e2b58-78b0-45a2-998c-96bc916affe7">

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
