### PR TITLE
Allow to config workgroup to collection query log from

### DIFF
--- a/metaphor/athena/README.md
+++ b/metaphor/athena/README.md
@@ -63,6 +63,11 @@ query_log:
   # (Optional) Number of days of query logs to fetch. Default to 1. If 0, the no query logs will be fetched.
   lookback_days: <days>
 
+  # (Optional) WorkGroups to collect query history, default to []. If not specify, collect from the primary workgroup
+  work_groups:
+    - workgroup_1
+    - ...
+
   # (Optional)
   process_query: <process_query_config>
 ```

--- a/metaphor/athena/config.py
+++ b/metaphor/athena/config.py
@@ -1,4 +1,5 @@
 from dataclasses import field
+from typing import List
 
 from pydantic.dataclasses import dataclass
 
@@ -13,6 +14,9 @@ from metaphor.common.sql.process_query.config import ProcessQueryConfig
 class QueryLogConfig:
     # Number of days back of query logs to fetch, if 0, don't fetch query logs
     lookback_days: int = 1
+
+    # (Optional) WorkGroups to collect query history, default to []. If not specify, collect from the primary workgroup
+    work_groups: List[str] = field(default_factory=list)
 
     # Config to control query processing
     process_query: ProcessQueryConfig = field(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.129"
+version = "0.14.130"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

Currently, we only get the query log for the primary workgroup, and we should support specifying workgroup

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

As title, add a new config and update the README.

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

Test against dev.

<!--
  Describe how the change was tested end-to-end.
-->

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
