### PR TITLE
Snowflake profiler is not normalizing the [sc-29479]

### DIFF
--- a/metaphor/bigquery/profile/extractor.py
+++ b/metaphor/bigquery/profile/extractor.py
@@ -10,7 +10,6 @@ except ImportError:
     print("Please install metaphor[bigquery] extra\n")
     raise
 
-
 from metaphor.bigquery.extractor import BigQueryExtractor
 from metaphor.bigquery.profile.config import BigQueryProfileRunConfig, SamplingConfig
 from metaphor.bigquery.utils import build_client, get_credentials
@@ -18,6 +17,7 @@ from metaphor.common.base_extractor import BaseExtractor
 from metaphor.common.column_statistics import ColumnStatistics
 from metaphor.common.entity_id import dataset_normalized_name
 from metaphor.common.event_util import ENTITY_TYPES
+from metaphor.common.fieldpath import build_field_statistics
 from metaphor.common.filter import DatasetFilter
 from metaphor.common.logger import get_logger
 from metaphor.common.utils import safe_float
@@ -28,7 +28,6 @@ from metaphor.models.metadata_change_event import (
     DatasetFieldStatistics,
     DatasetLogicalID,
     DatasetSchema,
-    FieldStatistics,
 )
 
 logger = get_logger()
@@ -264,15 +263,15 @@ class BigQueryProfileExtractor(BaseExtractor):
                     index += 1
 
             fields.append(
-                FieldStatistics(
-                    field_path=field.field_path,
-                    distinct_value_count=unique_count,
-                    null_value_count=nulls,
-                    nonnull_value_count=non_nulls,
-                    min_value=min_value,
-                    max_value=max_value,
-                    average=avg,
-                    std_dev=std_dev,
+                build_field_statistics(
+                    field.field_path,
+                    unique_count,
+                    nulls,
+                    non_nulls,
+                    min_value,
+                    max_value,
+                    avg,
+                    std_dev,
                 )
             )
 

--- a/metaphor/common/fieldpath.py
+++ b/metaphor/common/fieldpath.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Optional
 
-from metaphor.models.metadata_change_event import SchemaField
+from metaphor.models.metadata_change_event import FieldStatistics, SchemaField
 
 
 class FieldDataType(Enum):
@@ -58,4 +58,29 @@ def build_schema_field(
         description=description or None,
         nullable=nullable,
         precision=precision,
+    )
+
+
+def build_field_statistics(
+    column: str,
+    unique_count: Optional[float] = None,
+    nulls: Optional[float] = None,
+    non_nulls: Optional[float] = None,
+    min_value: Optional[float] = None,
+    max_value: Optional[float] = None,
+    avg: Optional[float] = None,
+    std_dev: Optional[float] = None,
+) -> FieldStatistics:
+    """
+    Build field statistics for a column based on extracted column statistics.
+    """
+    return FieldStatistics(
+        field_path=column.lower(),
+        distinct_value_count=unique_count,
+        null_value_count=nulls,
+        nonnull_value_count=non_nulls,
+        min_value=min_value,
+        max_value=max_value,
+        average=avg,
+        std_dev=std_dev,
     )

--- a/metaphor/postgresql/profile/extractor.py
+++ b/metaphor/postgresql/profile/extractor.py
@@ -11,13 +11,13 @@ except ImportError:
 from metaphor.common.column_statistics import ColumnStatistics
 from metaphor.common.entity_id import dataset_normalized_name
 from metaphor.common.event_util import ENTITY_TYPES
+from metaphor.common.fieldpath import build_field_statistics
 from metaphor.common.logger import get_logger
 from metaphor.common.sampling import SamplingConfig
 from metaphor.common.utils import safe_float
 from metaphor.models.metadata_change_event import (
     Dataset,
     DatasetFieldStatistics,
-    FieldStatistics,
     MaterializationType,
 )
 from metaphor.postgresql.extractor import PostgreSQLExtractor
@@ -179,14 +179,14 @@ class PostgreSQLProfileExtractor(PostgreSQLExtractor):
                     index += 1
 
             dataset.field_statistics.field_statistics.append(
-                FieldStatistics(
-                    field_path=field.field_path,
-                    distinct_value_count=unique_values,
-                    null_value_count=nulls,
-                    nonnull_value_count=(row_count - nulls),
-                    min_value=min_value,
-                    max_value=max_value,
-                    average=avg,
+                build_field_statistics(
+                    field.field_path,
+                    unique_values,
+                    nulls,
+                    row_count - nulls,
+                    min_value,
+                    max_value,
+                    avg,
                 )
             )
 

--- a/metaphor/snowflake/profile/extractor.py
+++ b/metaphor/snowflake/profile/extractor.py
@@ -8,13 +8,13 @@ except ImportError:
     print("Please install metaphor[snowflake] extra\n")
     raise
 
-
 from metaphor.common.base_extractor import BaseExtractor
 from metaphor.common.entity_id import (
     dataset_normalized_name,
     normalize_full_dataset_name,
 )
 from metaphor.common.event_util import ENTITY_TYPES
+from metaphor.common.fieldpath import build_field_statistics
 from metaphor.common.logger import get_logger
 from metaphor.common.sampling import SamplingConfig
 from metaphor.common.snowflake import normalize_snowflake_account
@@ -25,7 +25,6 @@ from metaphor.models.metadata_change_event import (
     Dataset,
     DatasetFieldStatistics,
     DatasetLogicalID,
-    FieldStatistics,
 )
 from metaphor.snowflake import auth
 from metaphor.snowflake.extractor import DEFAULT_FILTER, SnowflakeExtractor
@@ -307,15 +306,15 @@ class SnowflakeProfileExtractor(BaseExtractor):
                     index += 1
 
             fields.append(
-                FieldStatistics(
-                    field_path=column,
-                    distinct_value_count=unique_count,
-                    null_value_count=nulls,
-                    nonnull_value_count=non_nulls,
-                    min_value=min_value,
-                    max_value=max_value,
-                    average=avg,
-                    std_dev=std_dev,
+                build_field_statistics(
+                    column,
+                    unique_count,
+                    nulls,
+                    non_nulls,
+                    min_value,
+                    max_value,
+                    avg,
+                    std_dev,
                 )
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.130"
+version = "0.14.131"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/snowflake/profile/expected.json
+++ b/tests/snowflake/profile/expected.json
@@ -3,17 +3,17 @@
     "fieldStatistics": {
       "fieldStatistics": [
         {
-          "fieldPath": "ID",
+          "fieldPath": "id",
           "nonnullValueCount": 4.0,
           "nullValueCount": 0.0
         },
         {
-          "fieldPath": "COMMON",
+          "fieldPath": "common",
           "nonnullValueCount": 4.0,
           "nullValueCount": 0.0
         },
         {
-          "fieldPath": "CLASS",
+          "fieldPath": "class",
           "nonnullValueCount": 4.0,
           "nullValueCount": 0.0
         }
@@ -29,32 +29,32 @@
     "fieldStatistics": {
       "fieldStatistics": [
         {
-          "fieldPath": "ID",
+          "fieldPath": "id",
           "nonnullValueCount": 0.0,
           "nullValueCount": 0.0
         },
         {
-          "fieldPath": "FOO",
+          "fieldPath": "foo",
           "nonnullValueCount": 0.0,
           "nullValueCount": 0.0
         },
         {
-          "fieldPath": "BAR",
+          "fieldPath": "bar",
           "nonnullValueCount": 0.0,
           "nullValueCount": 0.0
         },
         {
-          "fieldPath": "ID",
+          "fieldPath": "id",
           "nonnullValueCount": 0.0,
           "nullValueCount": 0.0
         },
         {
-          "fieldPath": "FoO",
+          "fieldPath": "foo",
           "nonnullValueCount": 0.0,
           "nullValueCount": 0.0
         },
         {
-          "fieldPath": "Phone Number",
+          "fieldPath": "phone number",
           "nonnullValueCount": 0.0,
           "nullValueCount": 0.0
         }
@@ -70,22 +70,22 @@
     "fieldStatistics": {
       "fieldStatistics": [
         {
-          "fieldPath": "D",
+          "fieldPath": "d",
           "nonnullValueCount": 5.0,
           "nullValueCount": 0.0
         },
         {
-          "fieldPath": "LOC",
+          "fieldPath": "loc",
           "nonnullValueCount": 5.0,
           "nullValueCount": 0.0
         },
         {
-          "fieldPath": "B_ID",
+          "fieldPath": "b_id",
           "nonnullValueCount": 5.0,
           "nullValueCount": 0.0
         },
         {
-          "fieldPath": "C",
+          "fieldPath": "c",
           "nonnullValueCount": 5.0,
           "nullValueCount": 0.0
         }
@@ -101,12 +101,12 @@
     "fieldStatistics": {
       "fieldStatistics": [
         {
-          "fieldPath": "ID",
+          "fieldPath": "id",
           "nonnullValueCount": 2.0,
           "nullValueCount": 0.0
         },
         {
-          "fieldPath": "NAME",
+          "fieldPath": "name",
           "nonnullValueCount": 2.0,
           "nullValueCount": 0.0
         }


### PR DESCRIPTION

### 🤔 Why?

We have normalized the dataset column `field path` in table crawlers, but the profile crawlers missed this normalization and thus caused some mismatch. 

### 🤓 What?

- normalize the profiled column field path

### 🧪 Tested?

unit test
tested against snowflake instance

### ☑️ Checks

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
