### PR TITLE
[sc-29500] Exclude should work if it ends in `/*`

### DIFF
--- a/metaphor/s3/README.md
+++ b/metaphor/s3/README.md
@@ -146,6 +146,8 @@ All other file types are automatically ignored. If not specified, all of the abo
 
 You can optionally specify the URI patterns to exclude using the `excludes` config. It supports wildcards but not `{table}` & `{partition}` labels.
 
+To exclude an entire directory, use `s3://bucket/directory` instead of `s3://bucket/directory/*`.
+
 ## Optional Configurations
 
 ### TLS Verification

--- a/metaphor/s3/path_spec.py
+++ b/metaphor/s3/path_spec.py
@@ -293,6 +293,8 @@ class PathSpec(BaseModel):
             path.rsplit("/", slash_to_remove)[0]
             if exclude[-1] == "/":
                 exclude_pat = exclude[:-1]
+            elif exclude[-2:] == "/*":
+                exclude_pat = exclude[:-2]
             else:
                 exclude_pat = exclude
             if fnmatch(path.rsplit("/", slash_to_remove)[0], exclude_pat):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.132"
+version = "0.14.133"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/s3/test_path_spec.py
+++ b/tests/s3/test_path_spec.py
@@ -1,0 +1,26 @@
+import pytest
+
+from metaphor.s3.path_spec import PathSpec
+
+
+def test_exclude_all_files_in_directory() -> None:
+    path_spec = PathSpec(
+        uri="s3://bucket/v1/app/*/{table}/v4/*/{partition[0]}/{partition[1]}/{partition[2]}/*.*",
+        file_types={
+            "parquet",
+        },
+        excludes=["s3://bucket/v1/app/global/*"],
+    )
+    assert not path_spec.allow_path("s3://bucket/v1/app/global/foo/v4")
+
+
+@pytest.mark.skip
+def test_exclude_table_wildcard() -> None:
+    path_spec = PathSpec(
+        uri="s3://bucket/v1/services/data/{table}/v1/*/{partition[0]}/{partition[1]}/{partition[2]}/*.*",
+        file_types={
+            "parquet",
+        },
+        excludes=["s3://bucket/v1/services/data/skipped_*"],
+    )
+    assert not path_spec.allow_path("s3://bucket/v1/services/data/skipped_0/")


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

If the excluded path ends in `/*`, all files within the directory should be excluded.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- If the excluded path ends in `/*`, all files within the directory should be excluded.
- The other issue where the exclusion rule contains wildcard in template label part name will be addressed in a separate PR. It requires much more work to do properly.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Added unit test.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
