### PR TITLE
Redshift profiler missing tables [sc-29514]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.134"
+version = "0.14.135"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
### 🤔 Why?

The `include_view` config was used incorrectly, doing the exact opposite.

### 🤓 What?

- fix the dataset filtering based on `include_view`, also excluding `external`, `stream`, `snapshot` types
- also remove the dataset entities with empty field statistics from the MCE

### 🧪 Tested?

tested with `include_view` set to True and False, verified the results.

### ☑️ Checks

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
