### PR TITLE
[sc-29504] `PathSpec._path_is_excluded` to check if path is excluded

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.135"
+version = "0.14.136"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/s3/test_path_spec.py
+++ b/tests/s3/test_path_spec.py
@@ -28,8 +28,13 @@ def test_exclude_table_wildcard() -> None:
     assert not path_spec.allow_path("s3://bucket/v1/services/data/skipped_1")
 
 
-def test_strip_last_slash() -> None:
+def test_trim_url_end() -> None:
     assert (
-        PathSpec._strip_last_slash(yarl.URL("s3://bucket/foo/bar/")).human_repr()
+        PathSpec._trim_url_end(yarl.URL("s3://bucket/foo/bar/")).human_repr()
+        == "s3://bucket/foo/bar"
+    )
+
+    assert (
+        PathSpec._trim_url_end(yarl.URL("s3://bucket/foo/bar/*")).human_repr()
         == "s3://bucket/foo/bar"
     )

--- a/tests/s3/test_path_spec.py
+++ b/tests/s3/test_path_spec.py
@@ -1,4 +1,4 @@
-import pytest
+import yarl
 
 from metaphor.s3.path_spec import PathSpec
 
@@ -12,9 +12,10 @@ def test_exclude_all_files_in_directory() -> None:
         excludes=["s3://bucket/v1/app/global/*"],
     )
     assert not path_spec.allow_path("s3://bucket/v1/app/global/foo/v4")
+    assert not path_spec.allow_path("s3://bucket/v1/app/global/foo/")
+    assert path_spec.allow_path("s3://bucket/v1/app/foo/bar/")
 
 
-@pytest.mark.skip
 def test_exclude_table_wildcard() -> None:
     path_spec = PathSpec(
         uri="s3://bucket/v1/services/data/{table}/v1/*/{partition[0]}/{partition[1]}/{partition[2]}/*.*",
@@ -24,3 +25,11 @@ def test_exclude_table_wildcard() -> None:
         excludes=["s3://bucket/v1/services/data/skipped_*"],
     )
     assert not path_spec.allow_path("s3://bucket/v1/services/data/skipped_0/")
+    assert not path_spec.allow_path("s3://bucket/v1/services/data/skipped_1")
+
+
+def test_strip_last_slash() -> None:
+    assert (
+        PathSpec._strip_last_slash(yarl.URL("s3://bucket/foo/bar/")).human_repr()
+        == "s3://bucket/foo/bar"
+    )


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

If the exclude path has a wildcard in the template label component, the crawler would not be able to filter the path out.

The original logic to decide if a path should be excluded is hard to follow, and even harder to fix the bug. Rewrote the whole thing to make it easier to follow.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- PathSpec._path_is_excluded method to check if the path is excluded.
- Added unit test.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Added unit test. Previously skipped unit test is now passing.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
