### PR TITLE
Confluence ingestion error [sc-29555]

### DIFF
--- a/metaphor/common/embeddings.py
+++ b/metaphor/common/embeddings.py
@@ -118,7 +118,6 @@ def map_metadata(
 
         embedding_dict[nodeid] = {
             "entityId": nodeid_format,
-            "documentId": nodeid_format,
             "embedding_1": embedding_dict[nodeid],
             "pageId": metadata_dict[nodeid]["pageId"],
             "lastRefreshed": metadata_dict[nodeid]["lastRefreshed"],

--- a/tests/confluence/expected.json
+++ b/tests/confluence/expected.json
@@ -1,7 +1,6 @@
 [
   {
     "entityId": "EXTERNAL_DOCUMENT~5678",
-    "documentId": "EXTERNAL_DOCUMENT~5678",
     "embedding_1": [
       0.1,
       0.2,

--- a/tests/monday/expected.json
+++ b/tests/monday/expected.json
@@ -1,7 +1,6 @@
 [
   {
     "entityId": "EXTERNAL_DOCUMENT~5678",
-    "documentId": "EXTERNAL_DOCUMENT~5678",
     "embedding_1": [
       0.1,
       0.2,

--- a/tests/notion/expected.json
+++ b/tests/notion/expected.json
@@ -1,7 +1,6 @@
 [
   {
     "entityId": "EXTERNAL_DOCUMENT~ABCD1234",
-    "documentId": "EXTERNAL_DOCUMENT~ABCD1234",
     "embedding_1": [
       0.1,
       0.2,

--- a/tests/sharepoint/expected.json
+++ b/tests/sharepoint/expected.json
@@ -1,7 +1,6 @@
 [
   {
     "entityId": "EXTERNAL_DOCUMENT~PAGE123",
-    "documentId": "EXTERNAL_DOCUMENT~PAGE123",
     "embedding_1": [
       0.1,
       0.2,

--- a/tests/sharepoint/expected_no_text.json
+++ b/tests/sharepoint/expected_no_text.json
@@ -1,7 +1,6 @@
 [
   {
     "entityId": "EXTERNAL_DOCUMENT~PAGE123",
-    "documentId": "EXTERNAL_DOCUMENT~PAGE123",
     "embedding_1": [
       0.1,
       0.2,

--- a/tests/static_web/expected.json
+++ b/tests/static_web/expected.json
@@ -1,7 +1,6 @@
 [
   {
     "entityId": "EXTERNAL_DOCUMENT~ABCD1234",
-    "documentId": "EXTERNAL_DOCUMENT~ABCD1234",
     "embedding_1": [
       0.1,
       0.2,


### PR DESCRIPTION
### 🤔 Why?

We have removed `documentId` in search documents, but the crawler-generated search documents still have it, causing ingestion validation errors.

### 🤓 What?

- remove `documentId` field

### 🧪 Tested?

tested confluence crawler, verified the generated MCE

### ☑️ Checks


- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
