### PR TITLE
[sc-29648] Use `init_virtual_view` to get or create the source in `depends_on`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.140"
+version = "0.14.141"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

If a source model isn't referenced in the run, when we parse the `depends_on` of the node that depends on the source model it will break.

Using `init_virtual_view` to get the model or create it when it does not exist yet solves the issue.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

`virtual_views[n]` -> `init_virtual_views(virtual_views, n, name_getter)`.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Testing in progress.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
