### PR TITLE
Add config to disable queries that require SELECT permission

### DIFF
--- a/metaphor/common/utils.py
+++ b/metaphor/common/utils.py
@@ -87,6 +87,11 @@ def safe_str(value: Any) -> Optional[str]:
     return None if value is None else str(value)
 
 
+def non_empty_str(value: Any) -> Optional[str]:
+    """Converts a value to str, return None if the original value is None or empty string"""
+    return None if value is None or value == "" else str(value)
+
+
 def safe_float(value: Optional[Union[float, int, str]]) -> Optional[float]:
     """Converts a value to float, return None if the original value is None or NaN or INF"""
     return (

--- a/metaphor/unity_catalog/README.md
+++ b/metaphor/unity_catalog/README.md
@@ -34,6 +34,10 @@ See [Output Config](../common/docs/output.md) for more information.
 
 See [Filter Configurations](../common/docs/filter.md) for more information on the optional `filter` config.
 
+#### SELECT Permissions
+
+Certain metadata, such as table properties & last refreshed time, can only be extracted if the user has SELECT permissions on the table. By default, the connector will attempt to extract this metadata and print errors in the logs if it fails. To disable this behavior, set `has_select_permissions` to `false`.
+
 #### Source URL
 
 By default, each table is associated with a Unity Catalog URL derived from the `hostname` config.
@@ -66,18 +70,6 @@ query_log:
 ##### Process Query Config
 
 See [Process Query](../common/docs/process_query.md) for more information on the optional `process_query_config` config.
-
-#### Warehouse ID
-
-Note: we encourage using cluster, this connector will deprecate the SQL warehouse support.
-
-To run the queries using a specific warehouse, simply add its ID in the configuration file:
-
-```yaml
-warehouse_id: <warehouse_id>
-```
-
-If no warehouse id nor cluster path is provided, the connector automatically uses the first discovered warehouse.
 
 ## Testing
 

--- a/metaphor/unity_catalog/config.py
+++ b/metaphor/unity_catalog/config.py
@@ -41,6 +41,9 @@ class UnityCatalogRunConfig(BaseConfig):
     # Include or exclude specific databases/schemas/tables
     filter: DatasetFilter = field(default_factory=lambda: DatasetFilter())
 
+    # Whether the user has SELECT permissions on the tables
+    has_select_permissions: bool = True
+
     # configs for fetching query logs
     query_log: UnityCatalogQueryLogConfig = field(
         default_factory=lambda: UnityCatalogQueryLogConfig()

--- a/metaphor/unity_catalog/queries.py
+++ b/metaphor/unity_catalog/queries.py
@@ -677,7 +677,7 @@ def get_last_refreshed_time(
         try:
             cursor.execute(f"DESCRIBE HISTORY {table_full_name} LIMIT {limit}")
         except Exception as error:
-            logger.exception(f"Failed to get history for {table_full_name}: {error}")
+            logger.error(f"Failed to get history for {table_full_name}: {error}")
             return None
 
         for history in cursor.fetchall():
@@ -704,7 +704,7 @@ def get_table_properties(
         try:
             cursor.execute(f"SHOW TBLPROPERTIES {table_full_name}")
         except Exception as error:
-            logger.exception(
+            logger.error(
                 f"Failed to show table properties for {table_full_name}: {error}"
             )
             return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.144"
+version = "0.14.145"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -11,6 +11,7 @@ from metaphor.common.utils import (
     is_email,
     must_set_at_least_one,
     must_set_exactly_one,
+    non_empty_str,
     removesuffix,
     safe_float,
     safe_int,
@@ -143,6 +144,13 @@ def test_safe_str():
     assert safe_str(None) is None
     assert safe_str("string") == "string"
     assert safe_str(100) == "100"
+
+
+def test_non_empty_str():
+    assert non_empty_str(None) is None
+    assert non_empty_str("") is None
+    assert non_empty_str("string") == "string"
+    assert non_empty_str(100) == "100"
 
 
 def test_safe_float():

--- a/tests/great_expectations/basic_sql/gx/.gitignore
+++ b/tests/great_expectations/basic_sql/gx/.gitignore
@@ -1,0 +1,2 @@
+
+uncommitted/

--- a/tests/great_expectations/snowflake/gx/.gitignore
+++ b/tests/great_expectations/snowflake/gx/.gitignore
@@ -1,0 +1,2 @@
+
+uncommitted/

--- a/tests/unity_catalog/config.yml
+++ b/tests/unity_catalog/config.yml
@@ -3,5 +3,7 @@ hostname: hostname
 http_path: path
 token: token
 source_url: http://foo.bar/{catalog}/{schema}/{table}
+has_select_permissions: false
 describe_history_limit: 30
+max_concurrency: 20
 output: {}

--- a/tests/unity_catalog/expected.json
+++ b/tests/unity_catalog/expected.json
@@ -204,7 +204,7 @@
         "properties": [
           {
             "key": "delta.lastCommitTimestamp",
-            "value": "1664444422000"
+            "value": "\"1664444422000\""
           }
         ]
       }
@@ -286,59 +286,59 @@
         "properties": [
           {
             "key": "view.catalogAndNamespace.numParts",
-            "value": "2"
+            "value": "\"2\""
           },
           {
             "key": "view.sqlConfig.spark.sql.hive.convertCTAS",
-            "value": "true"
+            "value": "\"true\""
           },
           {
             "key": "view.query.out.col.0",
-            "value": "key"
+            "value": "\"key\""
           },
           {
             "key": "view.sqlConfig.spark.sql.parquet.compression.codec",
-            "value": "snappy"
+            "value": "\"snappy\""
           },
           {
             "key": "view.query.out.numCols",
-            "value": "3"
+            "value": "\"3\""
           },
           {
             "key": "view.referredTempViewNames",
-            "value": "[]"
+            "value": "\"[]\""
           },
           {
             "key": "view.query.out.col.1",
-            "value": "values"
+            "value": "\"values\""
           },
           {
             "key": "view.sqlConfig.spark.sql.streaming.stopTimeout",
-            "value": "15s"
+            "value": "\"15s\""
           },
           {
             "key": "view.catalogAndNamespace.part.0",
-            "value": "catalog"
+            "value": "\"catalog\""
           },
           {
             "key": "view.sqlConfig.spark.sql.sources.commitProtocolClass",
-            "value": "com.databricks.sql.transaction.directory.DirectoryAtomicCommitProtocol"
+            "value": "\"com.databricks.sql.transaction.directory.DirectoryAtomicCommitProtocol\""
           },
           {
             "key": "view.sqlConfig.spark.sql.sources.default",
-            "value": "delta"
+            "value": "\"delta\""
           },
           {
             "key": "view.sqlConfig.spark.sql.legacy.createHiveTableByDefault",
-            "value": "false"
+            "value": "\"false\""
           },
           {
             "key": "view.query.out.col.2",
-            "value": "nested_values"
+            "value": "\"nested_values\""
           },
           {
             "key": "view.catalogAndNamespace.part.1",
-            "value": "default"
+            "value": "\"default\""
           }
         ]
       }

--- a/tests/unity_catalog/test_config.py
+++ b/tests/unity_catalog/test_config.py
@@ -12,6 +12,8 @@ def test_yaml_config_password(test_root_dir):
         http_path="path",
         token="token",
         source_url="http://foo.bar/{catalog}/{schema}/{table}",
+        has_select_permissions=False,
         describe_history_limit=30,
+        max_concurrency=20,
         output=OutputConfig(),
     )


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

A few small fixed/improvements after https://github.com/MetaphorData/connectors/pull/1022.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Add `has_select_permissions` config to enable/disable all queries that require SELECT permission.
- Avoid printing the full stack when encountering permission issues.
- Properly handle empty descriptions.
- Properly JSON-encode table property values.
- Add files missed by https://github.com/MetaphorData/connectors/pull/1025

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified end-to-end against a production instance.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
