### PR TITLE
[sc-29679] `RequestsConfig` for HTTP request configuration values

### DIFF
--- a/metaphor/common/docs/requests.md
+++ b/metaphor/common/docs/requests.md
@@ -1,0 +1,5 @@
+# Requests Config
+
+Controls configurable values for HTTP requests:
+
+- `timeout`: How many seconds before the HTTP client times out.

--- a/metaphor/common/requests_config.py
+++ b/metaphor/common/requests_config.py
@@ -1,0 +1,15 @@
+from pydantic.dataclasses import dataclass
+
+from metaphor.common.dataclass import ConnectorConfig
+
+
+@dataclass(config=ConnectorConfig)
+class RequestsConfig:
+    """
+    Contains configuration values regarding HTTP requests.
+    """
+
+    timeout: int = 10
+    """
+    How many seconds before the requests client fails on a timed out request.
+    """

--- a/metaphor/fivetran/README.md
+++ b/metaphor/fivetran/README.md
@@ -24,6 +24,10 @@ api_secret: <api_secret>
 
 See [Output Config](../common/docs/output.md) for more information.
 
+#### Requests configuration
+
+See [Requests Config](../common/docs/requests.md) for more information.
+
 ## Testing
 
 Follow the [Installation](../../README.md) instructions to install `metaphor-connectors` in your environment (or virtualenv).

--- a/metaphor/fivetran/config.py
+++ b/metaphor/fivetran/config.py
@@ -5,6 +5,7 @@ from pydantic.dataclasses import dataclass
 from metaphor.common.base_config import BaseConfig
 from metaphor.common.dataclass import ConnectorConfig
 from metaphor.common.filter import DatasetFilter
+from metaphor.common.requests_config import RequestsConfig
 
 
 @dataclass(config=ConnectorConfig)
@@ -14,3 +15,5 @@ class FivetranRunConfig(BaseConfig):
 
     # Include or exclude specific databases/schemas/tables
     filter: DatasetFilter = dataclass_field(default_factory=lambda: DatasetFilter())
+
+    requests: RequestsConfig = dataclass_field(default_factory=lambda: RequestsConfig())

--- a/metaphor/fivetran/extractor.py
+++ b/metaphor/fivetran/extractor.py
@@ -135,6 +135,7 @@ class FivetranExtractor(BaseExtractor):
         self._source_metadata: Dict[str, SourceMetadataPayload] = {}
         self._users: Dict[str, str] = {}
         self._base_url = "https://api.fivetran.com/v1"
+        self._requests_timeout = config.requests.timeout
 
     async def extract(self) -> Collection[ENTITY_TYPES]:
         logger.info("Fetching metadata from Fivetran")
@@ -549,4 +550,10 @@ class FivetranExtractor(BaseExtractor):
 
     def _call_get(self, url: str, **kwargs):
         headers = {"Accept": "application/json;version=2"}
-        return make_request(url=url, headers=headers, auth=self._auth, **kwargs)
+        return make_request(
+            url=url,
+            headers=headers,
+            timeout=self._requests_timeout,
+            auth=self._auth,
+            **kwargs,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.145"
+version = "0.14.146"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/common/test_api_request.py
+++ b/tests/common/test_api_request.py
@@ -1,6 +1,8 @@
 from typing import Dict
 from unittest.mock import MagicMock, patch
 
+import pytest
+import requests
 from pydantic import BaseModel
 
 from metaphor.common.api_request import ApiError, make_request
@@ -32,3 +34,19 @@ def test_get_request_not_200(mock_get: MagicMock):
         assert False, "ApiError not thrown"
     except ApiError:
         assert True
+
+
+def test_requests_timeout():
+    # Simple demo webserver to test delayed responses
+    # https://httpbin.org/#/Dynamic_data/get_delay__delay_
+    url = "https://httpbin.org/delay/2"
+
+    # This times out
+    with pytest.raises(requests.Timeout):
+        make_request(url, headers={"accept": "application/json"}, type_=Dict, timeout=1)
+
+    # This is OK
+    resp = make_request(
+        url, headers={"accept": "application/json"}, type_=Dict, timeout=3
+    )
+    assert resp


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Fivetran can be slow with responses, sometimes even exceeding 10 seconds. To address this, we are exposing timeout for requests as a configuration value.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Added `RequestsConfig` for requests configuration values, and added it to fivetran's config.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Added unit test.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
