### PR TITLE
Fix rate limiting issues with Power BI admin APIs

### DIFF
--- a/metaphor/power_bi/power_bi_client.py
+++ b/metaphor/power_bi/power_bi_client.py
@@ -105,24 +105,9 @@ class PowerBIClient:
             url, List[PowerBIApp], transform_response=lambda r: r.json()["value"]
         )
 
-    def get_tiles(self, dashboard_id: str) -> List[PowerBITile]:
-        # https://docs.microsoft.com/en-us/rest/api/power-bi/admin/dashboards-get-tiles-as-admin
-        url = f"{self.API_ENDPOINT}/admin/dashboards/{dashboard_id}/tiles"
-
-        try:
-            return self._call_get(
-                url, List[PowerBITile], transform_response=lambda r: r.json()["value"]
-            )
-        except EntityNotFoundError:
-            logger.error(
-                f"Unable to find dashboard {dashboard_id}."
-                f"Please add the service principal as a viewer to the workspace"
-            )
-            return []
-
-    def get_datasets(self, group_id: str) -> List[PowerBIDataset]:
-        # https://docs.microsoft.com/en-us/rest/api/power-bi/admin/datasets-get-datasets-in-group-as-admin
-        url = f"{self.API_ENDPOINT}/admin/groups/{group_id}/datasets"
+    def get_datasets(self) -> List[PowerBIDataset]:
+        # https://learn.microsoft.com/en-us/rest/api/power-bi/admin/datasets-get-datasets-as-admin
+        url = f"{self.API_ENDPOINT}/admin/datasets"
         return self._call_get(
             url, List[PowerBIDataset], transform_response=lambda r: r.json()["value"]
         )
@@ -163,16 +148,32 @@ class PowerBIClient:
             )
             return []
 
-    def get_dashboards(self, group_id: str) -> List[PowerBIDashboard]:
-        # https://docs.microsoft.com/en-us/rest/api/power-bi/admin/dashboards-get-dashboards-in-group-as-admin
-        url = f"{self.API_ENDPOINT}/admin/groups/{group_id}/dashboards"
+    def get_dashboards(self) -> List[PowerBIDashboard]:
+        # https://learn.microsoft.com/en-us/rest/api/power-bi/admin/dashboards-get-dashboards-as-admin
+        url = f"{self.API_ENDPOINT}/admin/dashboards"
         return self._call_get(
             url, List[PowerBIDashboard], transform_response=lambda r: r.json()["value"]
         )
 
-    def get_reports(self, group_id: str) -> List[PowerBIReport]:
-        # https://docs.microsoft.com/en-us/rest/api/power-bi/admin/reports-get-reports-in-group-as-admin
-        url = f"{self.API_ENDPOINT}/admin/groups/{group_id}/reports"
+    def get_dashboard_tiles(
+        self, group_id: str, dashboard_id: str
+    ) -> List[PowerBITile]:
+        # https://learn.microsoft.com/en-us/rest/api/power-bi/dashboards/get-tiles-in-group
+        url = f"{self.API_ENDPOINT}/groups/{group_id}/dashboards/{dashboard_id}/tiles"
+
+        try:
+            return self._call_get(
+                url, List[PowerBITile], transform_response=lambda r: r.json()["value"]
+            )
+        except Exception as e:
+            logger.error(
+                f"Failed to get tiles from dashboard {dashboard_id} in workspace {group_id}: {e}"
+            )
+            return []
+
+    def get_reports(self) -> List[PowerBIReport]:
+        # https://learn.microsoft.com/en-us/rest/api/power-bi/admin/reports-get-reports-as-admin
+        url = f"{self.API_ENDPOINT}/admin/reports"
         return self._call_get(
             url, List[PowerBIReport], transform_response=lambda r: r.json()["value"]
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.157"
+version = "0.14.158"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/power_bi/test_extractor.py
+++ b/tests/power_bi/test_extractor.py
@@ -177,7 +177,7 @@ dataflow_id = "00000000-0000-0000-0001-00000000000A"
 dataflow_id2 = "00000000-0000-0000-0002-00000000000A"
 
 
-def fake_get_datasets(workspace_id: str) -> List[PowerBIDataset]:
+def fake_get_datasets() -> List[PowerBIDataset]:
     return [dataset1, dataset2, dataset3]
 
 
@@ -194,15 +194,15 @@ def fake_get_dataset_parameters(
     ]
 
 
-def fake_get_reports(workspace_id: str) -> List[PowerBIReport]:
+def fake_get_reports() -> List[PowerBIReport]:
     return [report1, report2, report1_app]
 
 
-def fake_get_dashboards(workspace_id: str) -> List[PowerBIDashboard]:
+def fake_get_dashboards() -> List[PowerBIDashboard]:
     return [dashboard1, dashboard2, dashboard1_app]
 
 
-def fake_get_tiles(dashboard_id: str) -> List[PowerBITile]:
+def fake_get_dashboard_tiles(workspace_id: str, dashboard_id: str) -> List[PowerBITile]:
     return tiles[dashboard_id]
 
 
@@ -555,7 +555,9 @@ async def test_extractor(
     )
     mocked_pbi_client_instance.get_reports.side_effect = fake_get_reports
     mocked_pbi_client_instance.get_dashboards.side_effect = fake_get_dashboards
-    mocked_pbi_client_instance.get_tiles.side_effect = fake_get_tiles
+    mocked_pbi_client_instance.get_dashboard_tiles.side_effect = (
+        fake_get_dashboard_tiles
+    )
     mocked_pbi_client_instance.get_pages.side_effect = fake_get_pages
     mocked_pbi_client_instance.get_refreshes.side_effect = fake_get_refreshes
     mocked_pbi_client_instance.get_apps.side_effect = fake_get_apps


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Most of the Power BI [Admin APIs](https://learn.microsoft.com/en-us/rest/api/power-bi/admin) have a rate limit of 200 requests/hour. We reach the limit quickly when crawling a large number of workspaces.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

Replace the following per-workspace API calls with global API calls. These global APIs appear to be equivalent and are able to scale to thousands of items without any issues.
- [GetDatasetsInGroupAsAdmin](https://learn.microsoft.com/en-us/rest/api/power-bi/admin/datasets-get-datasets-in-group-as-admin) => [GetDatasetsAsAdmin](https://learn.microsoft.com/en-us/rest/api/power-bi/admin/datasets-get-datasets-as-admin)
- [GetReportsInGroupAsAdmin](https://learn.microsoft.com/en-us/rest/api/power-bi/admin/reports-get-reports-in-group-as-admin) => [GetReportsAsAdmin](https://learn.microsoft.com/en-us/rest/api/power-bi/admin/reports-get-reports-as-admin)
- [GetDashboardsInGroupAsAdmin](https://learn.microsoft.com/en-us/rest/api/power-bi/admin/dashboards-get-dashboards-in-group-as-admin) => [GetDashboardsAsAdmin](https://learn.microsoft.com/en-us/rest/api/power-bi/admin/dashboards-get-dashboards-as-admin)

Unfortunately, there is no global version of [GetTilesAsAdmin](https://learn.microsoft.com/en-us/rest/api/power-bi/admin/dashboards-get-dashboards-as-admin), so we need to fallback to the non-admin version [Get Tiles In Group](https://learn.microsoft.com/en-us/rest/api/power-bi/dashboards/get-tiles-in-group). This would require the service principal to be added to each workspace, which is already a requirement for getting refresh schedule, data sources, etc.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified the before/after MCE against production instances.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
