### PR TITLE
[sc-29929] invalid multi oas config

### DIFF
--- a/metaphor/openapi/config.py
+++ b/metaphor/openapi/config.py
@@ -44,11 +44,11 @@ class OpenAPIRunConfig(BaseConfig):
     def must_have_at_least_one_spec_config(self) -> "OpenAPIRunConfig":
         must_set_at_least_one(self.__dict__, ["specs", "base_url"])
 
-        if "base_url" not in self.__dict__ and "specs" in self.__dict__:
+        if self.__dict__.get("base_url") is None and self.__dict__.get("specs"):
             if not self.specs:
                 raise ValueError("Must have at least one spec")
 
-        if "base_url" in self.__dict__:
+        if self.__dict__.get("base_url"):
             must_set_exactly_one(
                 self.__dict__, ["openapi_json_path", "openapi_json_url"]
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.158"
+version = "0.14.159"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

```yaml
specs:
  - base_url: <url>
    openapi_json_url: <url>
  - base_url: <url>
    openapi_json_url: <url>

output:
  file:
    directory: <path>
```

didn't not pass the config validation

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

### 🤓 What?

Fix `OpenAPIRunConfig` validation function

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

### 🧪 Tested?

Verified locally

<!--
  Describe how the change was tested end-to-end.
-->

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
