### PR TITLE
snowflake source info last updated missing [sc-29859]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.159"
+version = "0.14.160"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/snowflake/test_extractor.py
+++ b/tests/snowflake/test_extractor.py
@@ -207,10 +207,14 @@ def test_fetch_table_info(mock_connect: MagicMock):
 
     mock_conn.cursor.return_value = mock_cursor
 
-    mock_cursor.fetchone.return_value = {
-        f"DDL_{normalized_name}": "ddl",
-        f"UPDATED_{normalized_name}": 1719327434000000000,
-    }
+    mock_cursor.fetchone.side_effect = [
+        {
+            f"UPDATED_{normalized_name}": 1719327434000000000,
+        },
+        {
+            f"DDL_{normalized_name}": "ddl",
+        },
+    ]
 
     extractor = SnowflakeExtractor(make_snowflake_config())
 


### PR DESCRIPTION

### 🤔 Why?

`get_ddl` function in snowflake may throw SQL compilation error in some rare cases. This will cause all the table info for all the tables in the same batch to be lost. 


### 🤓 What?

- split the get_ddl with get last update time, so at least they won't impact each other. 

### 🧪 Tested?

tested against Metaphor instance

### ☑️ Checks


- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
