### PR TITLE
Treat unhandled Monte Carlo anomalies as data quality errors

### DIFF
--- a/metaphor/monte_carlo/README.md
+++ b/metaphor/monte_carlo/README.md
@@ -34,7 +34,7 @@ snowflake_account: <account_name>
 
 #### Treat Unhandled Anomalies as Errors
 
-If set to true, the connector will treat unhandled [anomalies](https://docs.getmontecarlo.com/docs/detectors-overview) as data quality errors.
+If set to true, the connector will treat unhandled [anomalies](https://docs.getmontecarlo.com/docs/detectors-overview) as data quality errors. Default is false.
 
 ```yaml
 treat_unhandled_anomalies_as_errors: true

--- a/metaphor/monte_carlo/README.md
+++ b/metaphor/monte_carlo/README.md
@@ -32,6 +32,22 @@ If some of the monitored data assets are Snowflake datasets, please provide the 
 snowflake_account: <account_name>
 ```
 
+#### Treat Unhandled Anomalies as Errors
+
+If set to true, the connector will treat unhandled [anomalies](https://docs.getmontecarlo.com/docs/detectors-overview) as data quality errors.
+
+```yaml
+treat_unhandled_anomalies_as_errors: true
+```
+
+#### Anomalies Lookback Days
+
+By default the connector only retrieves anomalies from the last 30 days. You can change this by setting the `anomalies_lookback_days` field.
+
+```yaml
+anomalies_lookback_days: 30
+```
+
 ## Testing
 
 Follow the [Installation](../../README.md) instructions to install `metaphor-connectors` in your environment (or virtualenv). Make sure to include either `all` or `monte_carlo` extra.

--- a/metaphor/monte_carlo/config.py
+++ b/metaphor/monte_carlo/config.py
@@ -15,6 +15,12 @@ class MonteCarloRunConfig(BaseConfig):
     # Snowflake data source account
     snowflake_account: Optional[str] = None
 
+    # Treat unhandled anomalies as errors
+    treat_unhandled_anomalies_as_errors: bool = False
+
+    # Number of days to look back for anomalies
+    anomalies_lookback_days = 30
+
     # Errors to be ignored, e.g. timeouts
     ignored_errors: List[str] = field(
         default_factory=lambda: [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.162"
+version = "0.14.163"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/monte_carlo/config.yml
+++ b/tests/monte_carlo/config.yml
@@ -1,4 +1,5 @@
 ---
 api_key_id: key_id
 api_key_secret: key_secret
+treat_unhandled_anomalies_as_errors: true
 output: {}

--- a/tests/monte_carlo/expected.json
+++ b/tests/monte_carlo/expected.json
@@ -11,6 +11,16 @@
           "targets": [],
           "title": "auto_monitor_name_cd5b69bd-e465-4545-b3f9-a5d507ea766c",
           "url": "https://getmontecarlo.com/monitors/e0dc143e-dd8a-4cb9-b4cc-dedec715d955"
+        },
+        {
+          "description": "Anomaly 1",
+          "lastRun": "2023-06-23T03:54:35.817000+00:00",
+          "owner": "yi@metaphor.io",
+          "severity": "HIGH",
+          "status": "ERROR",
+          "targets": [],
+          "title": "Anomaly 1",
+          "url": "https://getmontecarlo.com/alerts/1"
         }
       ],
       "provider": "MONTE_CARLO",

--- a/tests/monte_carlo/test_config.py
+++ b/tests/monte_carlo/test_config.py
@@ -10,5 +10,6 @@ def test_yaml_config(test_root_dir):
     assert config == MonteCarloRunConfig(
         api_key_id="key_id",
         api_key_secret="key_secret",
+        treat_unhandled_anomalies_as_errors=True,
         output=OutputConfig(),
     )

--- a/tests/monte_carlo/test_extractor.py
+++ b/tests/monte_carlo/test_extractor.py
@@ -14,6 +14,7 @@ def dummy_config():
         api_key_id="key_id",
         api_key_secret="key_secret",
         snowflake_account="snow",
+        treat_unhandled_anomalies_as_errors=True,
         output=OutputConfig(),
     )
 
@@ -62,7 +63,6 @@ async def test_extractor(mock_pycarlo_client: MagicMock, test_root_dir: str):
                     "uuid": "e0dc143e-dd8a-4cb9-b4cc-dedec715d955",
                     "name": "auto_monitor_name_cd5b69bd-e465-4545-b3f9-a5d507ea766c",
                     "description": "Field Health for all fields in db:metaphor.test1",
-                    "entities": ["db:metaphor.test1"],
                     "entityMcons": [
                         "MCON++6418a1e2-9718-4413-9d2b-6a354e01ddf8++a19e22b4-7659-4064-8fd4-8d6122fabe1c++table++db:metaphor.test1"
                     ],
@@ -77,7 +77,6 @@ async def test_extractor(mock_pycarlo_client: MagicMock, test_root_dir: str):
                     "uuid": "ce4c4568-35f4-4365-a6fe-95f233fcf6c3",
                     "name": "auto_monitor_name_53c985e6-8f49-4af7-8ef1-7b402a27538b",
                     "description": "Field Health for all fields in db:metaphor.test2",
-                    "entities": ["db:metaphor.test2"],
                     "entityMcons": [
                         "MCON++6418a1e2-9718-4413-9d2b-6a354e01ddf8++a19e22b4-7659-4064-8fd4-8d6122fabe1c++table++db:metaphor.test2"
                     ],
@@ -92,7 +91,6 @@ async def test_extractor(mock_pycarlo_client: MagicMock, test_root_dir: str):
                     "uuid": "2c156c8d-ab4a-432f-b8bb-f9ea9f31ed3d",
                     "name": "auto_monitor_name_18637195-a3c4-416e-a3e2-a89cc10adbc8",
                     "description": "Field Health for all fields in db:metaphor.test3",
-                    "entities": ["db:metaphor.test3"],
                     "entityMcons": [
                         "MCON++6418a1e2-9718-4413-9d2b-6a354e01ddf8++a19e22b4-7659-4064-8fd4-8d6122fabe1c++table++db:metaphor.test3"
                     ],
@@ -107,7 +105,6 @@ async def test_extractor(mock_pycarlo_client: MagicMock, test_root_dir: str):
                     "uuid": "d14af7d8-6342-420a-bb09-5805fad677f1",
                     "name": "auto_monitor_name_693b98e3-950d-472b-83fe-8c8e5b5979f9",
                     "description": "Field Health for all fields in db:metaphor.test4",
-                    "entities": ["db:metaphor.test4"],
                     "entityMcons": [
                         "MCON++6418a1e2-9718-4413-9d2b-6a354e01ddf8++a19e22b4-7659-4064-8fd4-8d6122fabe1c++table++db:metaphor.test4"
                     ],
@@ -132,6 +129,52 @@ async def test_extractor(mock_pycarlo_client: MagicMock, test_root_dir: str):
                     "prevExecutionTime": "2023-06-23T03:54:35.817000+00:00",
                 },
             ]
+        },
+        {
+            "get_alerts": {
+                "edges": [
+                    {
+                        "node": {
+                            "id": "1",
+                            "title": "Anomaly 1",
+                            "type": "ANOMALIES",
+                            "status": None,
+                            "severity": "SEV_1",
+                            "priority": None,
+                            "owner": {
+                                "email": "yi@metaphor.io",
+                            },
+                            "createdTime": "2023-06-23T03:54:35.817000+00:00",
+                            "tables": [
+                                {
+                                    "mcon": "MCON++6418a1e2-9718-4413-9d2b-6a354e01ddf8++a19e22b4-7659-4064-8fd4-8d6122fabe1c++table++db:metaphor.test1",
+                                }
+                            ],
+                        }
+                    },
+                    {
+                        "node": {
+                            "id": "1",
+                            "title": "Handled anomaly",
+                            "type": "ANOMALIES",
+                            "status": "EXPECTED",
+                            "severity": "SEV_2",
+                            "priority": None,
+                            "owner": None,
+                            "createdTime": "2023-06-23T03:54:35.817000+00:00",
+                            "tables": [
+                                {
+                                    "mcon": "MCON++6418a1e2-9718-4413-9d2b-6a354e01ddf8++a19e22b4-7659-4064-8fd4-8d6122fabe1c++table++db:metaphor.test1",
+                                }
+                            ],
+                        }
+                    },
+                ],
+                "page_info": {
+                    "end_corsor": "cursor",
+                    "has_next_page": False,
+                },
+            }
         },
     ]
 


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

In addition to [user-defined monitors](https://docs.getmontecarlo.com/docs/monitors-overview), Monte Carlo also supports [automatic anomaly detection](https://docs.getmontecarlo.com/docs/detectors-overview). We'd like to surface these anomalies as data quality issues, only if they're triggered and not marked as handled (acknowledged/expected/fixed) by the user 


### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Use [getAlerts](https://apidocs.getmontecarlo.com/#query-getAlerts) GraphQL query to retrieve all `ANOMALIES` alerts and map unhandled ones to failed data monitors.
- Generalize `_convert_dataset_name` into `_extract_dataset_name` for MCON to dataset name parsing.
- Add configs to opt into the new behavior and to control the lookback length.

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified before & after against a production instance.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
