### PR TITLE
QuickSight crawler unsupported dataset type [sc-30088]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.169"
+version = "0.14.170"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
### 🤔 Why?

The quickSight DescribeDataSet API may throw error for some dataset type such as file formats (csv, s3 file, etc)

### 🤓 What?

- add try catch to not fail the entire crawler when DescribeDataSet error is thrown
- dump the list API response for debugging

### 🧪 Tested?

tested against Metaphor instance, but need to test on customer env to log the issue

### ☑️ Checks

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
