### PR TITLE
QuickSight data source validation error [sc-30088]

### DIFF
--- a/metaphor/quick_sight/data_source_utils.py
+++ b/metaphor/quick_sight/data_source_utils.py
@@ -2,24 +2,27 @@ from typing import Optional
 
 from metaphor.common.snowflake import normalize_snowflake_account
 from metaphor.models.metadata_change_event import DataPlatform
-from metaphor.quick_sight.models import (
-    DataSource,
-    DataSourceType,
-    TypeDataSourceParameters,
-)
+from metaphor.quick_sight.models import DataSource, TypeDataSourceParameters
 
+"""
+See https://docs.aws.amazon.com/quicksight/latest/APIReference/API_DataSource.html
+"""
 DATA_SOURCE_PLATFORM_MAP = {
-    DataSourceType.AURORA: DataPlatform.MYSQL,
-    DataSourceType.AURORA_POSTGRESQL: DataPlatform.POSTGRESQL,
-    DataSourceType.BIGQUERY: DataPlatform.BIGQUERY,
-    DataSourceType.DATABRICKS: DataPlatform.UNITY_CATALOG,
-    DataSourceType.MARIADB: DataPlatform.MYSQL,
-    DataSourceType.MYSQL: DataPlatform.MYSQL,
-    DataSourceType.POSTGRESQL: DataPlatform.POSTGRESQL,
-    DataSourceType.REDSHIFT: DataPlatform.REDSHIFT,
-    DataSourceType.ORACLE: DataPlatform.ORACLE,
-    DataSourceType.SNOWFLAKE: DataPlatform.SNOWFLAKE,
-    DataSourceType.SQLSERVER: DataPlatform.MSSQL,
+    "ATHENA": DataPlatform.ATHENA,
+    "AURORA": DataPlatform.MYSQL,
+    "AURORA_POSTGRESQL": DataPlatform.POSTGRESQL,
+    "BIGQUERY": DataPlatform.BIGQUERY,
+    "DATABRICKS": DataPlatform.UNITY_CATALOG,
+    "MARIADB": DataPlatform.MYSQL,
+    "MYSQL": DataPlatform.MYSQL,
+    "PRESTO": DataPlatform.TRINO,
+    "POSTGRESQL": DataPlatform.POSTGRESQL,
+    "REDSHIFT": DataPlatform.REDSHIFT,
+    "ORACLE": DataPlatform.ORACLE,
+    "S3": DataPlatform.S3,
+    "SNOWFLAKE": DataPlatform.SNOWFLAKE,
+    "SQLSERVER": DataPlatform.MSSQL,
+    "TRINO": DataPlatform.TRINO,
 }
 
 

--- a/metaphor/quick_sight/lineage.py
+++ b/metaphor/quick_sight/lineage.py
@@ -68,7 +68,7 @@ def _get_source_from_custom_sql(
     ):
         return None, None
 
-    data_platform = DATA_SOURCE_PLATFORM_MAP.get(data_source.Type)
+    data_platform = DATA_SOURCE_PLATFORM_MAP.get(data_source.Type, None)
     if not data_platform:
         return None, None
 
@@ -157,7 +157,7 @@ class LineageProcessor:
         ):
             return None
 
-        data_platform = DATA_SOURCE_PLATFORM_MAP.get(data_source.Type)
+        data_platform = DATA_SOURCE_PLATFORM_MAP.get(data_source.Type, None)
         if not data_platform:
             return None
 

--- a/metaphor/quick_sight/lineage.py
+++ b/metaphor/quick_sight/lineage.py
@@ -68,7 +68,7 @@ def _get_source_from_custom_sql(
     ):
         return None, None
 
-    data_platform = DATA_SOURCE_PLATFORM_MAP.get(data_source.Type, None)
+    data_platform = DATA_SOURCE_PLATFORM_MAP.get(data_source.Type.upper(), None)
     if not data_platform:
         return None, None
 
@@ -157,7 +157,7 @@ class LineageProcessor:
         ):
             return None
 
-        data_platform = DATA_SOURCE_PLATFORM_MAP.get(data_source.Type, None)
+        data_platform = DATA_SOURCE_PLATFORM_MAP.get(data_source.Type.upper(), None)
         if not data_platform:
             return None
 

--- a/metaphor/quick_sight/models.py
+++ b/metaphor/quick_sight/models.py
@@ -208,42 +208,6 @@ class Analysis:
     Definition: AnalysisDefinition
 
 
-class DataSourceType(Enum):
-    """
-    @see: https://docs.aws.amazon.com/quicksight/latest/APIReference/API_DataSource.html
-    """
-
-    ADOBE_ANALYTICS = "ADOBE_ANALYTICS"
-    AMAZON_ELASTICSEARCH = "AMAZON_ELASTICSEARCH"
-    ATHENA = "ATHENA"
-    AURORA = "AURORA"
-    AURORA_POSTGRESQL = "AURORA_POSTGRESQL"
-    AWS_IOT_ANALYTICS = "AWS_IOT_ANALYTICS"
-    GITHUB = "GITHUB"
-    JIRA = "JIRA"
-    MARIADB = "MARIADB"
-    MYSQL = "MYSQL"
-    ORACLE = "ORACLE"
-    POSTGRESQL = "POSTGRESQL"
-    PRESTO = "PRESTO"
-    REDSHIFT = "REDSHIFT"
-    S3 = "S3"
-    SALESFORCE = "SALESFORCE"
-    SERVICENOW = "SERVICENOW"
-    SNOWFLAKE = "SNOWFLAKE"
-    SPARK = "SPARK"
-    SQLSERVER = "SQLSERVER"
-    TERADATA = "TERADATA"
-    TWITTER = "TWITTER"
-    TIMESTREAM = "TIMESTREAM"
-    AMAZON_OPENSEARCH = "AMAZON_OPENSEARCH"
-    EXASOL = "EXASOL"
-    DATABRICKS = "DATABRICKS"
-    STARBURST = "STARBURST"
-    TRINO = "TRINO"
-    BIGQUERY = "BIGQUERY"
-
-
 @dataclass
 class DatabaseParameters:
     Database: str
@@ -336,11 +300,15 @@ class TypeDataSourceParameters:
 
 @dataclass
 class DataSource:
+    """
+    @see: https://docs.aws.amazon.com/quicksight/latest/APIReference/API_DataSource.html
+    """
+
     Arn: Optional[str] = None
     CreatedTime: Optional[datetime] = None
     DataSourceId: Optional[str] = None
     Name: Optional[str] = None
-    Type: Optional[DataSourceType] = None
+    Type: Optional[str] = None
     DataSourceParameters: Optional[TypeDataSourceParameters] = None
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.170"
+version = "0.14.171"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/quick_sight/test_extractor.py
+++ b/tests/quick_sight/test_extractor.py
@@ -14,7 +14,7 @@ def dummy_config():
         aws=AwsCredentials(
             access_key_id="key", secret_access_key="secret", region_name="region"
         ),
-        aws_account_id=123,
+        aws_account_id="123",
         output=OutputConfig(),
     )
 
@@ -31,7 +31,10 @@ async def test_extractor(mock_create_client: MagicMock, test_root_dir: str):
     list_data_sets_response = [
         {
             "DataSetSummaries": [
-                {"DataSetId": item["DataSet"]["DataSetId"]}
+                {
+                    "DataSetId": item["DataSet"]["DataSetId"],
+                    "Name": item["DataSet"]["Name"],
+                }
                 for item in datasets_response
             ]
         }
@@ -40,7 +43,10 @@ async def test_extractor(mock_create_client: MagicMock, test_root_dir: str):
     list_dashboards_response = [
         {
             "DashboardSummaryList": [
-                {"DashboardId": item["Dashboard"]["DashboardId"]}
+                {
+                    "DashboardId": item["Dashboard"]["DashboardId"],
+                    "Name": item["Dashboard"]["Name"],
+                }
                 for item in dashboards_response
             ]
         }
@@ -49,7 +55,10 @@ async def test_extractor(mock_create_client: MagicMock, test_root_dir: str):
     list_data_sources_response = [
         {
             "DataSources": [
-                {"DataSourceId": item["DataSource"]["DataSourceId"]}
+                {
+                    "DataSourceId": item["DataSource"]["DataSourceId"],
+                    "Name": item["DataSource"]["Name"],
+                }
                 for item in data_sources_response
             ]
         }


### PR DESCRIPTION
### 🤔 Why?

The dataSource.type returns value that is not defined in https://docs.aws.amazon.com/quicksight/latest/APIReference/API_DataSource.html, causing the pydantic enum validation to throw error.

### 🤓 What?

- Relex model field dataSource.type to string instead of enum
- update source type mapping and handle unsupported type
- move each asset process to be within try-catch
- minor update to logging info

### 🧪 Tested?

tested against Metaphor instance, needs to run against customer env. 

### ☑️ Checks


- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
