### PR TITLE
add timeout to SQL parsing

### DIFF
--- a/metaphor/quick_sight/lineage.py
+++ b/metaphor/quick_sight/lineage.py
@@ -57,6 +57,7 @@ TypeColumnMap = Dict[str, Column]
 
 def _get_source_from_custom_sql(
     resources: Dict[str, ResourceType],
+    table_id: str,
     custom_sql: TypeCustomSql,
 ) -> Tuple[Optional[List[str]], Optional[VirtualViewQuery]]:
     data_source = resources.get(custom_sql.DataSourceArn)
@@ -80,7 +81,7 @@ def _get_source_from_custom_sql(
         query,
         platform=data_platform,
         account=account,
-        query_id="",
+        query_id=table_id,
         default_database=database,
     )
 
@@ -198,7 +199,7 @@ class LineageProcessor:
 
             if physical_table.CustomSql:
                 source_entities, query = _get_source_from_custom_sql(
-                    self._resources, physical_table.CustomSql
+                    self._resources, table_id, physical_table.CustomSql
                 )
 
                 # CLL of custom sql is not supported

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.173"
+version = "0.14.174"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION

### 🤔 Why?

The SQL parser may stuck for some particular SQL queries.

### 🤓 What?

- Add timeout to SQL parsing

### 🧪 Tested?

tested on Metaphor instance, add sleep to trigger timeout

### ☑️ Checks

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
