### PR TITLE
update quicksight lineage

### DIFF
--- a/metaphor/common/snowflake.py
+++ b/metaphor/common/snowflake.py
@@ -1,8 +1,9 @@
 PRIVATE_LINK_SUFFIX = ".privatelink"
 SNOWFLAKE_HOST_SUFFIX = ".snowflakecomputing.com"
+SNOWFLAKE_DEFAULT_REGION = ".us-west-2"
 
 
-def normalize_snowflake_account(host: str) -> str:
+def normalize_snowflake_account(host: str, remove_default_region: bool = False) -> str:
     """
     Normalize different variations of Snowflake account.
     See https://docs.snowflake.com/en/user-guide/admin-account-identifier
@@ -16,6 +17,9 @@ def normalize_snowflake_account(host: str) -> str:
 
     # Strip PrivateLink suffix
     if host.endswith(PRIVATE_LINK_SUFFIX):
-        return host[: -len(PRIVATE_LINK_SUFFIX)]
+        host = host[: -len(PRIVATE_LINK_SUFFIX)]
+
+    if remove_default_region and host.endswith(SNOWFLAKE_DEFAULT_REGION):
+        host = host[: -len(SNOWFLAKE_DEFAULT_REGION)]
 
     return host

--- a/metaphor/common/snowflake.py
+++ b/metaphor/common/snowflake.py
@@ -15,10 +15,12 @@ def normalize_snowflake_account(host: str, remove_default_region: bool = False) 
     if host.endswith(SNOWFLAKE_HOST_SUFFIX):
         host = host[: -len(SNOWFLAKE_HOST_SUFFIX)]
 
-    # Strip PrivateLink suffix
+    # Strip PrivateLink suffix, e.g. account.privatelink.snowflakecomputing.com
     if host.endswith(PRIVATE_LINK_SUFFIX):
         host = host[: -len(PRIVATE_LINK_SUFFIX)]
 
+    # Remove default region (us-west-2) if applicable, e.g. account.us-west-2.snowflakecomputing.com
+    # This is to keep the account name consistent with the results from the snowflake crawler
     if remove_default_region and host.endswith(SNOWFLAKE_DEFAULT_REGION):
         host = host[: -len(SNOWFLAKE_DEFAULT_REGION)]
 

--- a/metaphor/quick_sight/data_source_utils.py
+++ b/metaphor/quick_sight/data_source_utils.py
@@ -98,11 +98,19 @@ def get_account(data_source: DataSource) -> Optional[str]:
 
     if parameters.SnowflakeParameters:
         return (
-            normalize_snowflake_account(parameters.SnowflakeParameters.Host)
+            normalize_snowflake_account(parameters.SnowflakeParameters.Host, True)
             if parameters.SnowflakeParameters.Host
             else None
         )
 
     if parameters.SqlServerParameters:
         return parameters.SqlServerParameters.Host
+
     return None
+
+
+def get_id_from_arn(arn: str) -> str:
+    """
+    Extract id from arn (e.g. arn:aws:quicksight:us-west-2:1231048943:[dataset/dashboard/datasource]/xxx)
+    """
+    return arn.split("/")[-1]

--- a/metaphor/quick_sight/lineage.py
+++ b/metaphor/quick_sight/lineage.py
@@ -6,11 +6,13 @@ from metaphor.common.entity_id import (
     parts_to_dataset_entity_id,
     to_entity_id_from_virtual_view_logical_id,
 )
+from metaphor.common.logger import get_logger
 from metaphor.common.sql.table_level_lineage.table_level_lineage import (
     extract_table_level_lineage,
 )
 from metaphor.common.utils import unique_list
 from metaphor.models.metadata_change_event import (
+    DataPlatform,
     EntityUpstream,
     FieldMapping,
     SourceField,
@@ -38,6 +40,8 @@ from metaphor.quick_sight.models import (
     TypeRelationalTable,
 )
 
+logger = get_logger()
+
 
 @dataclass
 class ColumnReference:
@@ -53,68 +57,6 @@ class Column:
 
 
 TypeColumnMap = Dict[str, Column]
-
-
-def _get_source_from_custom_sql(
-    resources: Dict[str, ResourceType],
-    table_id: str,
-    custom_sql: TypeCustomSql,
-) -> Tuple[Optional[List[str]], Optional[VirtualViewQuery]]:
-    data_source = resources.get(custom_sql.DataSourceArn)
-
-    if (
-        data_source is None
-        or not isinstance(data_source, DataSource)
-        or data_source.Type is None
-    ):
-        return None, None
-
-    data_platform = DATA_SOURCE_PLATFORM_MAP.get(data_source.Type.upper(), None)
-    if not data_platform:
-        return None, None
-
-    database = get_database(data_source)
-    account = get_account(data_source)
-    query = custom_sql.SqlQuery
-
-    tll = extract_table_level_lineage(
-        query,
-        platform=data_platform,
-        account=account,
-        query_id=table_id,
-        default_database=database,
-    )
-
-    return unique_list([source.id for source in tll.sources]), VirtualViewQuery(
-        default_database=database,
-        query=custom_sql.SqlQuery,
-        source_dataset_account=account,
-        source_platform=data_platform,
-    )
-
-
-def _process_transformation(
-    columns: TypeColumnMap,
-    transformations: List[TransformOperation],
-) -> None:
-    for transformation in transformations:
-        if transformation.CreateColumnsOperation:
-            for column in transformation.CreateColumnsOperation.Columns:
-                columns[column.ColumnName] = Column(
-                    upstream=[],
-                    expression=column.Expression,
-                    output=DataSetColumn(Name=column.ColumnName),
-                )
-        elif transformation.ProjectOperation:
-            for key in list(columns.keys()):
-                if key not in transformation.ProjectOperation.ProjectedColumns:
-                    columns.pop(key)
-
-        elif transformation.RenameColumnOperation:
-            before = transformation.RenameColumnOperation.ColumnName
-            after = transformation.RenameColumnOperation.NewColumnName
-            columns[after] = columns[before]
-            columns.pop(before)
 
 
 class LineageProcessor:
@@ -145,25 +87,68 @@ class LineageProcessor:
 
         return output_table_id
 
-    def _get_source_from_relation_table(
-        self,
-        relation_table: TypeRelationalTable,
-    ) -> Optional[str]:
-        data_source = self._resources.get(relation_table.DataSourceArn)
+    def _get_data_source_by_arn(
+        self, arn: str
+    ) -> Optional[Tuple[DataPlatform, Optional[str], Optional[str]]]:
+        data_source = self._resources.get(arn)
 
         if (
             data_source is None
             or not isinstance(data_source, DataSource)
             or data_source.Type is None
         ):
+            logger.warning(f"Cannot get data source {arn}")
             return None
 
         data_platform = DATA_SOURCE_PLATFORM_MAP.get(data_source.Type.upper(), None)
         if not data_platform:
+            logger.warning(
+                f"Cannot get data platform by type {data_source.Type} for {arn}"
+            )
             return None
 
         database = get_database(data_source)
         account = get_account(data_source)
+        return data_platform, database, account
+
+    def _get_source_from_custom_sql(
+        self,
+        table_id: str,
+        custom_sql: TypeCustomSql,
+    ) -> Tuple[List[str], Optional[VirtualViewQuery]]:
+        data_source_info = self._get_data_source_by_arn(custom_sql.DataSourceArn)
+        if not data_source_info:
+            return [], None
+
+        data_platform, database, account = data_source_info
+        query = custom_sql.SqlQuery
+
+        tll = extract_table_level_lineage(
+            query,
+            platform=data_platform,
+            account=account,
+            query_id=table_id,
+            default_database=database,
+        )
+
+        return unique_list(
+            [source.id for source in tll.sources if source.id]
+        ), VirtualViewQuery(
+            default_database=database,
+            query=custom_sql.SqlQuery,
+            source_dataset_account=account,
+            source_platform=data_platform,
+        )
+
+    def _get_source_from_relation_table(
+        self,
+        relation_table: TypeRelationalTable,
+    ) -> Optional[str]:
+        data_source_info = self._get_data_source_by_arn(relation_table.DataSourceArn)
+        if not data_source_info:
+            return None
+
+        data_platform, database, account = data_source_info
 
         source_entity_id = str(
             parts_to_dataset_entity_id(
@@ -178,12 +163,14 @@ class LineageProcessor:
         return source_entity_id
 
     def _init_virtual_view(self, table_id: str) -> VirtualView:
+        if table_id in self._virtual_views:
+            return self._virtual_views[table_id]
+
         view = VirtualView(
             logical_id=VirtualViewLogicalID(
                 name=table_id,
                 type=VirtualViewType.QUICK_SIGHT,
             ),
-            is_non_prod=True,
         )
 
         self._virtual_views[table_id] = view
@@ -196,61 +183,73 @@ class LineageProcessor:
     ) -> None:
         for table_id, physical_table in physical_table_map.items():
             column_lineage: TypeColumnMap = {}
+            source_entities: List[str] = []
+            query: Optional[VirtualViewQuery] = None
 
             if physical_table.CustomSql:
-                source_entities, query = _get_source_from_custom_sql(
-                    self._resources, table_id, physical_table.CustomSql
+                source_entities, query = self._get_source_from_custom_sql(
+                    table_id, physical_table.CustomSql
                 )
+                if not source_entities:
+                    logger.warning(
+                        f"Cannot parse sources from custom sql of table {table_id}"
+                    )
+                    continue
 
                 # CLL of custom sql is not supported
-                for column in physical_table.CustomSql.Columns:
-                    if column.Name is None:
-                        continue
-                    column_lineage[column.Name] = Column(output=column)
-
-                view = self._init_virtual_view(table_id)
-                view.entity_upstream = extract_virtual_view_upstream(
-                    column_lineage, source_entities or []
+                column_lineage = self._convert_column_lineage(
+                    physical_table.CustomSql.Columns
                 )
-                view.schema = extract_virtual_view_schema(column_lineage, query)
 
             elif physical_table.RelationalTable:
                 source_dataset_id = self._get_source_from_relation_table(
                     physical_table.RelationalTable
                 )
-
-                columns = physical_table.RelationalTable.InputColumns
-
-                for column in columns:
-                    if column.Name is None:
-                        continue
-                    column_lineage[column.Name] = Column(
-                        upstream=[
-                            ColumnReference(
-                                upstream_id=source_dataset_id, name=column.Name
-                            )
-                        ],
-                        output=column,
+                if not source_dataset_id:
+                    logger.warning(
+                        f"Cannot get source dataset id for relational table {table_id}"
                     )
+                    continue
 
-                view = self._init_virtual_view(table_id)
-                view.entity_upstream = extract_virtual_view_upstream(
-                    column_lineage, [source_dataset_id] if source_dataset_id else []
+                source_entities = [source_dataset_id]
+
+                column_lineage = self._convert_column_lineage(
+                    physical_table.RelationalTable.InputColumns, source_dataset_id
                 )
-                view.schema = extract_virtual_view_schema(column_lineage)
 
             elif physical_table.S3Source:
-                for column in physical_table.S3Source.InputColumns:
-                    if column.Name is None:
-                        continue
-                    column_lineage[column.Name] = Column(output=column)
+                column_lineage = self._convert_column_lineage(
+                    physical_table.S3Source.InputColumns
+                )
 
-                view = self._init_virtual_view(table_id)
-                view.schema = extract_virtual_view_schema(column_lineage)
-
+            view = self._init_virtual_view(table_id)
+            view.entity_upstream = self._extract_virtual_view_upstream(
+                column_lineage, source_entities
+            )
+            view.schema = self._extract_virtual_view_schema(column_lineage, query)
             tables[table_id] = column_lineage
 
         return None
+
+    @staticmethod
+    def _convert_column_lineage(
+        columns: List[DataSetColumn], source_dataset_id: Optional[str] = None
+    ) -> TypeColumnMap:
+        column_lineage: TypeColumnMap = {}
+        for column in columns:
+            if column.Name is None:
+                continue
+
+            upstream = (
+                [ColumnReference(upstream_id=source_dataset_id, name=column.Name)]
+                if source_dataset_id
+                else []
+            )
+            column_lineage[column.Name] = Column(
+                upstream=upstream,
+                output=column,
+            )
+        return column_lineage
 
     @staticmethod
     def _entity_id(arn_or_table_id: str) -> str:
@@ -356,18 +355,17 @@ class LineageProcessor:
                     unresolved.append((table_id, logical_table))
                     continue
 
-                _process_transformation(
+                self._process_transformation(
                     column_lineage, logical_table.DataTransforms or []
                 )
 
                 view = self._init_virtual_view(table_id)
-                view.entity_upstream = extract_virtual_view_upstream(
+                view.entity_upstream = self._extract_virtual_view_upstream(
                     column_lineage, source_entities
                 )
-                view.schema = extract_virtual_view_schema(column_lineage)
+                view.schema = self._extract_virtual_view_schema(column_lineage)
 
                 tables[table_id] = column_lineage
-
                 output_table_id = table_id
 
             logical_tables = unresolved
@@ -375,54 +373,80 @@ class LineageProcessor:
         # Return root table_id
         return output_table_id
 
+    @staticmethod
+    def _process_transformation(
+        columns: TypeColumnMap,
+        transformations: List[TransformOperation],
+    ) -> None:
+        for transformation in transformations:
+            if transformation.CreateColumnsOperation:
+                for column in transformation.CreateColumnsOperation.Columns:
+                    columns[column.ColumnName] = Column(
+                        upstream=[],
+                        expression=column.Expression,
+                        output=DataSetColumn(Name=column.ColumnName),
+                    )
+            elif transformation.ProjectOperation:
+                for key in list(columns.keys()):
+                    if key not in transformation.ProjectOperation.ProjectedColumns:
+                        columns.pop(key)
 
-def extract_virtual_view_schema(
-    column_lineage: TypeColumnMap,
-    query: Optional[VirtualViewQuery] = None,
-) -> Optional[VirtualViewSchema]:
-    if not column_lineage:
-        return None
+            elif transformation.RenameColumnOperation:
+                before = transformation.RenameColumnOperation.ColumnName
+                after = transformation.RenameColumnOperation.NewColumnName
+                columns[after] = columns[before]
+                columns.pop(before)
 
-    fields: List[VirtualViewSchemaField] = []
-    for column in column_lineage.values():
-        if column.output.Name is None:
-            continue
+    @staticmethod
+    def _extract_virtual_view_schema(
+        column_lineage: TypeColumnMap,
+        query: Optional[VirtualViewQuery] = None,
+    ) -> Optional[VirtualViewSchema]:
+        if not column_lineage:
+            return None
 
-        fields.append(
-            VirtualViewSchemaField(
-                field_name=column.output.Name,
-                field_path=column.output.Name.lower(),
-                description=column.output.Description,
-                type=column.output.Type,
-                formula=column.expression,
-                optional_type=("FORMULA" if column.expression else None),
+        fields: List[VirtualViewSchemaField] = []
+        for column in column_lineage.values():
+            if column.output.Name is None:
+                continue
+
+            fields.append(
+                VirtualViewSchemaField(
+                    field_name=column.output.Name,
+                    field_path=column.output.Name.lower(),
+                    description=column.output.Description,
+                    type=column.output.Type,
+                    formula=column.expression,
+                    optional_type=("FORMULA" if column.expression else None),
+                )
             )
-        )
-    return (
-        VirtualViewSchema(
-            fields=sorted(fields, key=lambda f: f.field_path), query=query
-        )
-        if fields
-        else None
-    )
-
-
-def extract_virtual_view_upstream(
-    column_lineage: Dict[str, Column], source_entities: List[str]
-) -> EntityUpstream:
-    field_mappings: List[FieldMapping] = []
-    for column_name, upstream_column in column_lineage.items():
-        field_mappings.append(
-            FieldMapping(
-                destination=column_name.lower(),
-                sources=[
-                    SourceField(source_entity_id=x.upstream_id, field=x.name.lower())
-                    for x in upstream_column.upstream
-                ],
+        return (
+            VirtualViewSchema(
+                fields=sorted(fields, key=lambda f: f.field_path), query=query
             )
+            if fields
+            else None
         )
 
-    return EntityUpstream(
-        source_entities=source_entities if source_entities else None,
-        field_mappings=field_mappings if field_mappings else None,
-    )
+    @staticmethod
+    def _extract_virtual_view_upstream(
+        column_lineage: Dict[str, Column], source_entities: List[str]
+    ) -> EntityUpstream:
+        field_mappings: List[FieldMapping] = []
+        for column_name, upstream_column in column_lineage.items():
+            field_mappings.append(
+                FieldMapping(
+                    destination=column_name.lower(),
+                    sources=[
+                        SourceField(
+                            source_entity_id=x.upstream_id, field=x.name.lower()
+                        )
+                        for x in upstream_column.upstream
+                    ],
+                )
+            )
+
+        return EntityUpstream(
+            source_entities=source_entities if source_entities else None,
+            field_mappings=field_mappings if field_mappings else None,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.177"
+version = "0.14.178"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/common/test_snowflake.py
+++ b/tests/common/test_snowflake.py
@@ -6,3 +6,13 @@ def test_normalize_snowflake_account():
     assert normalize_snowflake_account("org-acc") == "org-acc"
     assert normalize_snowflake_account("org.us-west-1") == "org.us-west-1"
     assert normalize_snowflake_account("foo.privatelink") == "foo"
+    assert (
+        normalize_snowflake_account("foo.us-west-2.privatelink.snowflakecomputing.com")
+        == "foo.us-west-2"
+    )
+    assert (
+        normalize_snowflake_account(
+            "foo.us-west-2.privatelink.snowflakecomputing.com", True
+        )
+        == "foo"
+    )

--- a/tests/quick_sight/data/data_sources.json
+++ b/tests/quick_sight/data/data_sources.json
@@ -23,7 +23,7 @@
       "LastUpdatedTime": "2024-09-18 16:13:10.685000+08:00",
       "DataSourceParameters": {
         "SnowflakeParameters": {
-          "Host": "account.snowflakecomputing.com",
+          "Host": "account.us-west-2.snowflakecomputing.com",
           "Database": "ACME",
           "Warehouse": "COMPUTE_WH"
         }

--- a/tests/quick_sight/expected.json
+++ b/tests/quick_sight/expected.json
@@ -85,7 +85,7 @@
       ]
     },
     "logicalId": {
-      "name": "arn:aws:quicksight:us-west-2:123456789012:dataset/6f516e19-84f8-4d17-9bd9-feecf1bdc346",
+      "name": "6f516e19-84f8-4d17-9bd9-feecf1bdc346",
       "type": "QUICK_SIGHT"
     },
     "schema": {
@@ -193,7 +193,6 @@
         "DATASET~D35648E120DEEA5750A87336C6AA2D25"
       ]
     },
-    "isNonProd": true,
     "logicalId": {
       "name": "f3b260dc-4638-4620-91fe-36f006936052",
       "type": "QUICK_SIGHT"
@@ -330,7 +329,6 @@
         "VIRTUAL_VIEW~543D1D7F1F0469635E8A454303BA2913"
       ]
     },
-    "isNonProd": true,
     "logicalId": {
       "name": "2c824bdb-87ae-43ff-bb28-b31b089be133",
       "type": "QUICK_SIGHT"
@@ -439,7 +437,6 @@
         "VIRTUAL_VIEW~3534AE0FAF6548F9160E55BD6863F608"
       ]
     },
-    "isNonProd": true,
     "logicalId": {
       "name": "ff3db8ef-966c-4631-b33f-867fdbe0c008",
       "type": "QUICK_SIGHT"
@@ -604,7 +601,7 @@
       ]
     },
     "logicalId": {
-      "name": "arn:aws:quicksight:us-west-2:123456789012:dataset/7bcddd7f-ed98-4e91-8064-9ae885f0376a",
+      "name": "7bcddd7f-ed98-4e91-8064-9ae885f0376a",
       "type": "QUICK_SIGHT"
     },
     "schema": {
@@ -826,7 +823,6 @@
         "DATASET~B639ACB48EEE0795206A61803BC37DDF"
       ]
     },
-    "isNonProd": true,
     "logicalId": {
       "name": "501bd127-d6a3-45ac-843c-6fee1ccb1aad",
       "type": "QUICK_SIGHT"
@@ -961,7 +957,7 @@
       ]
     },
     "logicalId": {
-      "name": "arn:aws:quicksight:us-west-2:123456789012:dataset/7c6a5c47-fbc7-4307-afd3-57f79864593e",
+      "name": "7c6a5c47-fbc7-4307-afd3-57f79864593e",
       "type": "QUICK_SIGHT"
     },
     "schema": {
@@ -1020,7 +1016,6 @@
         "DATASET~83E8304683CD6C30CA41557A39C4DF25"
       ]
     },
-    "isNonProd": true,
     "logicalId": {
       "name": "1b016641-23c2-4b17-ab94-c773333bc76d",
       "type": "QUICK_SIGHT"
@@ -1070,7 +1065,6 @@
         "DATASET~E2EB9491F5BDD97D1591D2454917F450"
       ]
     },
-    "isNonProd": true,
     "logicalId": {
       "name": "2a463fad-08c9-4a63-9aab-a786f1b41752",
       "type": "QUICK_SIGHT"
@@ -1132,7 +1126,6 @@
         "VIRTUAL_VIEW~F908650C2FC967EE56C1FFBBF061089A"
       ]
     },
-    "isNonProd": true,
     "logicalId": {
       "name": "12f0dcb4-ff96-4123-8568-00781596eb37",
       "type": "QUICK_SIGHT"
@@ -1196,7 +1189,6 @@
         "VIRTUAL_VIEW~3DC76D1D06345542B062CFB396C26AE4"
       ]
     },
-    "isNonProd": true,
     "logicalId": {
       "name": "82e644be-26ce-44a0-bbc9-95cc88e16a5c",
       "type": "QUICK_SIGHT"
@@ -1335,7 +1327,7 @@
       ]
     },
     "logicalId": {
-      "name": "arn:aws:quicksight:us-west-2:123456789012:dataset/fb1b23e7-ff1f-47b7-a04e-33b30847e9a7",
+      "name": "fb1b23e7-ff1f-47b7-a04e-33b30847e9a7",
       "type": "QUICK_SIGHT"
     },
     "schema": {
@@ -1488,7 +1480,6 @@
         "DATASET~F6D22C1B6C06D037407B74D2D708058E"
       ]
     },
-    "isNonProd": true,
     "logicalId": {
       "name": "48cf151b-0e89-4707-a901-871f69b22017",
       "type": "QUICK_SIGHT"
@@ -1627,7 +1618,6 @@
         "DATASET~1D56ACA83CDEEDC47163BA86B7ADF5C5"
       ]
     },
-    "isNonProd": true,
     "logicalId": {
       "name": "4e4695f3-6178-447b-947e-289363740a82",
       "type": "QUICK_SIGHT"
@@ -1771,7 +1761,6 @@
         "VIRTUAL_VIEW~0A83EA95986D9EE6A8BF88909EFE8975"
       ]
     },
-    "isNonProd": true,
     "logicalId": {
       "name": "a7b9ddbf-9fdf-48df-8952-b75b972fcc5d",
       "type": "QUICK_SIGHT"
@@ -1906,7 +1895,6 @@
         "VIRTUAL_VIEW~8C883993FF150DA6E24D4B31C751CAF4"
       ]
     },
-    "isNonProd": true,
     "logicalId": {
       "name": "fb24929a-5175-4485-b934-5210fbd09dae",
       "type": "QUICK_SIGHT"
@@ -1968,11 +1956,11 @@
     },
     "entityUpstream": {
       "sourceEntities": [
-        "VIRTUAL_VIEW~C791C9EC7B680B3BAF65B79D1765219B"
+        "VIRTUAL_VIEW~856DB99CD9EB660911DA12D6F14499CA"
       ]
     },
     "logicalId": {
-      "dashboardId": "arn:aws:quicksight:us-west-2:123456789012:dashboard/1c9b51b1-3204-4ee3-9491-e92ddded8518",
+      "dashboardId": "1c9b51b1-3204-4ee3-9491-e92ddded8518",
       "platform": "QUICK_SIGHT"
     },
     "sourceInfo": {
@@ -1998,11 +1986,11 @@
     },
     "entityUpstream": {
       "sourceEntities": [
-        "VIRTUAL_VIEW~042F9509D727CB7FE827A0FF0AD9DDEE"
+        "VIRTUAL_VIEW~D288BB7726CE69F66EB18C3AF1DD9FA7"
       ]
     },
     "logicalId": {
-      "dashboardId": "arn:aws:quicksight:us-west-2:123456789012:dashboard/eb39c0d9-d071-43e6-b75a-cc303752b702",
+      "dashboardId": "eb39c0d9-d071-43e6-b75a-cc303752b702",
       "platform": "QUICK_SIGHT"
     },
     "sourceInfo": {
@@ -2028,11 +2016,11 @@
     },
     "entityUpstream": {
       "sourceEntities": [
-        "VIRTUAL_VIEW~543D1D7F1F0469635E8A454303BA2913"
+        "VIRTUAL_VIEW~FA71319E309500C82F721FA821F6B24B"
       ]
     },
     "logicalId": {
-      "dashboardId": "arn:aws:quicksight:us-west-2:123456789012:dashboard/fea7f6ce-ac23-44f4-bf9b-fb03b535403e",
+      "dashboardId": "fea7f6ce-ac23-44f4-bf9b-fb03b535403e",
       "platform": "QUICK_SIGHT"
     },
     "sourceInfo": {


### PR DESCRIPTION
### 🤔 Why?

The upstream snowflake URL sometimes contains the default region `us-west-2` that needs to be stripped to match the account name from Snowflake crawler.

Also in some cases, when the lineage parser needs to find an existing dataset, it used quicksight dataset_id but the dictionary used arn as key, should all use id instead.

### 🤓 What?

- update snowflake account to remove default region
- update MCE dictionary to use id as key instead of arn
- refactor lineage parsing
- in the Virtual View and Dashboard logical ID, use the Quicksight ID instead of ARN as name.


### 🧪 Tested?

tested on Metaphor instance

### ☑️ Checks

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
