### PR TITLE
Quicksight crawler error physical table not [sc-30132]

### DIFF
--- a/metaphor/quick_sight/lineage.py
+++ b/metaphor/quick_sight/lineage.py
@@ -186,6 +186,9 @@ class LineageProcessor:
         physical_table_map: Dict[str, DataSetPhysicalTable],
     ) -> None:
         for table_id, physical_table in physical_table_map.items():
+            view = self._init_virtual_view(table_id)
+            tables[table_id] = {}
+
             column_lineage: TypeColumnMap = {}
             source_entities: List[str] = []
             query: Optional[VirtualViewQuery] = None
@@ -226,7 +229,6 @@ class LineageProcessor:
                     physical_table.S3Source.InputColumns
                 )
 
-            view = self._init_virtual_view(table_id)
             view.entity_upstream = self._extract_virtual_view_upstream(
                 column_lineage, source_entities
             )
@@ -327,7 +329,7 @@ class LineageProcessor:
                     upstream_id = self._entity_id(source.PhysicalTableId)
                     source_entities.append(upstream_id)
 
-                    if upstream_table:
+                    if upstream_table is not None:
                         column_lineage.update(
                             **self._replace_upstream_id(upstream_table, upstream_id)
                         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.179"
+version = "0.14.180"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION

### 🤔 Why?

For certain quicksight data sets with custom SQL, if the SQL can't be parsed, the dummy virtual view and table won't be created, so if a logical table referenced that table, it will throw error. 

### 🤓 What?

- When processing quicksight dataset physical table, init the table and virtual view first, so the entity skeleton is created and can be referenced.

### 🧪 Tested?

tested against the failure case

### ☑️ Checks

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
