### PR TITLE
Filter out non-active MC monitors

### DIFF
--- a/metaphor/monte_carlo/config.py
+++ b/metaphor/monte_carlo/config.py
@@ -1,4 +1,3 @@
-from dataclasses import field
 from typing import List, Optional
 
 from pydantic.dataclasses import dataclass
@@ -21,9 +20,5 @@ class MonteCarloRunConfig(BaseConfig):
     # Number of days to look back for anomalies
     anomalies_lookback_days = 30
 
-    # Errors to be ignored, e.g. timeouts
-    ignored_errors: List[str] = field(
-        default_factory=lambda: [
-            "Monitor timed out",
-        ]
-    )
+    # Deprecated. Not used anymore
+    ignored_errors: Optional[List[str]] = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.181"
+version = "0.14.182"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]

--- a/tests/monte_carlo/expected.json
+++ b/tests/monte_carlo/expected.json
@@ -93,9 +93,6 @@
       "monitors": [
         {
           "description": "Field Health for all fields in db:metaphor.test4",
-          "exceptions": [
-            "Oh no"
-          ],
           "lastRun": "2023-06-23T03:54:35.817000+00:00",
           "owner": "yi@metaphor.io",
           "severity": "UNKNOWN",

--- a/tests/monte_carlo/test_extractor.py
+++ b/tests/monte_carlo/test_extractor.py
@@ -67,11 +67,10 @@ async def test_extractor(mock_pycarlo_client: MagicMock, test_root_dir: str):
                         "MCON++6418a1e2-9718-4413-9d2b-6a354e01ddf8++a19e22b4-7659-4064-8fd4-8d6122fabe1c++table++db:metaphor.test1"
                     ],
                     "priority": "P1",
-                    "monitorStatus": "MISCONFIGURED",
+                    "breached": "BREACHED",
                     "monitorFields": None,
                     "creatorId": "yi@metaphor.io",
                     "prevExecutionTime": "2023-06-23T03:54:35.817000+00:00",
-                    "exceptions": None,
                 },
                 {
                     "uuid": "ce4c4568-35f4-4365-a6fe-95f233fcf6c3",
@@ -81,11 +80,10 @@ async def test_extractor(mock_pycarlo_client: MagicMock, test_root_dir: str):
                         "MCON++6418a1e2-9718-4413-9d2b-6a354e01ddf8++a19e22b4-7659-4064-8fd4-8d6122fabe1c++table++db:metaphor.test2"
                     ],
                     "priority": "P2",
-                    "monitorStatus": "SUCCESS",
+                    "breached": "NOT_BREACHED",
                     "monitorFields": ["foo", "bar"],
                     "creatorId": "yi@metaphor.io",
                     "prevExecutionTime": "2023-06-23T03:54:35.817000+00:00",
-                    "exceptions": None,
                 },
                 {
                     "uuid": "2c156c8d-ab4a-432f-b8bb-f9ea9f31ed3d",
@@ -95,11 +93,10 @@ async def test_extractor(mock_pycarlo_client: MagicMock, test_root_dir: str):
                         "MCON++6418a1e2-9718-4413-9d2b-6a354e01ddf8++a19e22b4-7659-4064-8fd4-8d6122fabe1c++table++db:metaphor.test3"
                     ],
                     "priority": "P3",
-                    "monitorStatus": "ERROR",
+                    "breached": "BREACHED",
                     "monitorFields": None,
                     "creatorId": "yi@metaphor.io",
                     "prevExecutionTime": "2023-06-23T03:54:35.817000+00:00",
-                    "exceptions": None,
                 },
                 {
                     "uuid": "d14af7d8-6342-420a-bb09-5805fad677f1",
@@ -109,8 +106,7 @@ async def test_extractor(mock_pycarlo_client: MagicMock, test_root_dir: str):
                         "MCON++6418a1e2-9718-4413-9d2b-6a354e01ddf8++a19e22b4-7659-4064-8fd4-8d6122fabe1c++table++db:metaphor.test4"
                     ],
                     "priority": None,
-                    "monitorStatus": "ERROR",
-                    "exceptions": "Oh no",
+                    "breached": "BREACHED",
                     "monitorFields": None,
                     "creatorId": "yi@metaphor.io",
                     "prevExecutionTime": "2023-06-23T03:54:35.817000+00:00",
@@ -122,8 +118,7 @@ async def test_extractor(mock_pycarlo_client: MagicMock, test_root_dir: str):
                     "entities": None,
                     "entityMcons": None,
                     "priority": None,
-                    "monitorStatus": "ERROR",
-                    "exceptions": "No entity, this exception is ignored",
+                    "breached": "BREACHED",
                     "monitorFields": None,
                     "creatorId": "yi@metaphor.io",
                     "prevExecutionTime": "2023-06-23T03:54:35.817000+00:00",


### PR DESCRIPTION
<!-- ☝️ give your PR a short, but descriptive title. -->

### 🤔 Why?

<!--
  Give reviewers the context necessary to understand this PR. For example,
  a link to the associated Shortcut story, or a few words describing the
  problem this PR solves.

  e.g. [SC000](https://app.shortcut.com/metaphor-data/story/000)
-->

Monte Carlo crawler has been incorrectly reporting non-active monitors as DQ errors, and not treating breached monitors as errors.

### 🤓 What?

<!--
  Summary of the changes committed. How does your PR fix the above issue?
-->

- Filter out non-active monitors (i.e.  `consolidatedStatusTypes = ENABLED`) when calling [get_monitors](https://apidocs.getmontecarlo.com/#query-getMonitors).
- Use the `breached` field instead of `monitorStatus` field to determine if there's a DQ issue.
- Drop exception process logic since it's only for monitors that failed to execute (i.e. `consolidatedStatusTypes = ERROR`).

### 🧪 Tested?

<!--
  Describe how the change was tested end-to-end.
-->

Verified against a production instance.

### ☑️ Checks

<!--
  Some sanity checks to make sure your PR is good to go. Make sure all checkboxes
  are ticked!
-->

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
