### PR TITLE
ThoughtSpot crawler HTTP 400 error [sc-30171]

### DIFF
--- a/metaphor/metabase/extractor.py
+++ b/metaphor/metabase/extractor.py
@@ -289,7 +289,7 @@ class MetabaseExtractor(BaseExtractor):
             else None
         )
 
-        dashboard = Dashboard(
+        self._dashboards[dashboard_id] = Dashboard(
             logical_id=DashboardLogicalID(
                 dashboard_id=str(dashboard_id), platform=DashboardPlatform.METABASE
             ),
@@ -301,8 +301,6 @@ class MetabaseExtractor(BaseExtractor):
             source_info=source_info,
             entity_upstream=entity_upstream,
         )
-
-        self._dashboards[dashboard_id] = dashboard
 
     def _parse_chart(self, card: Dict) -> Optional[ChartInfo]:
         if "id" not in card or "name" not in card:

--- a/metaphor/thought_spot/utils.py
+++ b/metaphor/thought_spot/utils.py
@@ -251,8 +251,12 @@ class ThoughtSpot:
     def fetch_answer_sql(cls, client: TSRestApiV2, answer_id: str) -> Optional[str]:
         logger.info(f"Fetching answer sql for id: {answer_id}")
 
-        response = client.metadata_answer_sql(answer_id)
-        json_dump_to_debug_file(response, f"answer_sql__{answer_id}.json")
+        try:
+            response = client.metadata_answer_sql(answer_id)
+            json_dump_to_debug_file(response, f"answer_sql__{answer_id}.json")
+        except Exception as e:
+            logger.error(f"Error fetching answer sql for id: {answer_id}, error: {e}")
+            return None
 
         if "sql_queries" in response:
             sql_queries = response["sql_queries"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metaphor-connectors"
-version = "0.14.183"
+version = "0.14.184"
 license = "Apache-2.0"
 description = "A collection of Python-based 'connectors' that extract metadata from various sources to ingest into the Metaphor app."
 authors = ["Metaphor <dev@metaphor.io>"]


### PR DESCRIPTION
### 🤔 Why?

For one particular customer asset, the API query throws `HTTPError: 400 Client Error: Bad Request for url: https://endpointclosing.thoughtspot.cloud/api/rest/2.0/metadata/answer/sql`

### 🤓 What?

- add try catch to no let the error terminate the crawler
- log the HTTP error

### 🧪 Tested?

tested on customer env

### ☑️ Checks

- [x] My PR contains actual code changes, and I have updated the version number in `pyproject.toml`.
